### PR TITLE
docs/test: update local-codex notes and refresh solve artifact metadata

### DIFF
--- a/local-codex/Documentation.md
+++ b/local-codex/Documentation.md
@@ -2,11 +2,11 @@
 
 Status tracker and decision log for this deliverable.
 
-## Stitch UI Rewrite Handoff Status (2026-03-27)
+## Stitch UI Rewrite Handoff Status (2026-03-28)
 
 - Source plan: `[Spec](intent://local/note/spec)` (`M0 -> M7`)
 - Current checkpoint: `M0` through `M7` implemented on the repaired `main` baseline; the regression ring is green again for continued Stitch work.
-- Handoff state: baseline repaired and ready for resumed implementation.
+- Handoff state: original Stitch rewrite milestones are complete on `main`; additional work should start from a new follow-on milestone instead of reopening `M4` through `M7`.
 
 ### Stitch Milestone Snapshot
 
@@ -19,7 +19,7 @@ Status tracker and decision log for this deliverable.
 - M6: Completed
 - M7: Completed (baseline reconciled on `main`)
 
-### M7 Validation Log (2026-03-27)
+### M7 Initial Validation Log (2026-03-27, pre-repair)
 
 | Command | Result | Notes |
 | --- | --- | --- |
@@ -43,7 +43,7 @@ Status tracker and decision log for this deliverable.
 
 - Resolved the missing tracked-file/source-control drift on `main`, including the restored runtime build/configurator sources and the missing negative fixture required by adapters-cli validation.
 - Rebaselined stale MVP movement, configurator, affinity-summary, prompt, and UI expectations so they match the repaired runtime currently on `main`.
-- Current checkpoint for continuing the Stitch spec: the baseline regression ring on `main` is green again.
+- Current checkpoint for continuing the Stitch spec: the baseline regression ring on `main` is green again, which closes the original M7 handoff blockers.
 
 Validation after reconciliation:
 - `node --test tests/runtime/*.test.js` -> passed (`120` passed)
@@ -51,6 +51,13 @@ Validation after reconciliation:
 - `node --test tests/adapters-web/*.test.js` -> passed (`7` passed)
 - `node --test tests/integration/*.test.js` -> passed (`15` passed, `1` skipped live LLM test)
 - `node --test tests/ui-web/*.test.mjs` -> passed (`83` passed)
+
+### M7 Final Validation Status (2026-03-28)
+
+- `pnpm run build:wasm` -> passed
+- `node --test tests/ui-web/*.test.mjs` -> passed (`83` passed)
+- `node --test tests/integration/*.test.js` -> passed (`15` passed, `1` skipped live LLM test)
+- `pnpm run serve:ui` smoke -> last confirmed during the original M7 ring on 2026-03-27 (`/packages/ui-web/index.html` returned HTTP `200`)
 
 ## 1) Current Status
 
@@ -383,9 +390,9 @@ Branch-close result:
 
 ## 7) Merge Readiness
 
-- [ ] Branch-close gate items 1-5 explicitly complete and logged.
-- [ ] Prompt scope and acceptance criteria satisfied.
-- [ ] Plan milestones complete.
-- [ ] Implement runbook validations complete.
-- [ ] Decision log up to date.
-- [ ] Required docs updated.
+- [x] Branch-close gate items 1-5 explicitly complete and logged.
+- [x] Prompt scope and acceptance criteria satisfied.
+- [x] Plan milestones complete.
+- [x] Implement runbook validations complete.
+- [x] Decision log up to date.
+- [x] Required docs updated.

--- a/local-codex/Plan.md
+++ b/local-codex/Plan.md
@@ -2,7 +2,7 @@
 
 Use this file to define the remaining milestones, validations, and branch-completion criteria.
 
-## Stitch UI Rewrite Plan Overlay (2026-03-27)
+## Stitch UI Rewrite Plan Overlay (2026-03-28)
 
 Source plan: `[Spec](intent://local/note/spec)` sections `M0` through `M7`.
 
@@ -15,15 +15,17 @@ Source plan: `[Spec](intent://local/note/spec)` sections `M0` through `M7`.
 | M4 | Completed | Design surface rewrite landed on approved rails. |
 | M5 | Completed | Preview/Run surface rewrite landed on approved rails. |
 | M6 | Completed | Diagnostics surface rewrite landed on approved rails. |
-| M7 | In progress (regression-blocked) | Validation ring executed; failures recorded for handoff. |
+| M7 | Completed | Regression ring and docs sync completed after repaired-`main` baseline reconciliation. |
 
-M7 validation ring executed on 2026-03-27:
-- `pnpm run build:wasm` -> pass
-- `node --test tests/ui-web/*.test.mjs` -> fail
-- `node --test tests/integration/*.test.js` -> fail
-- `pnpm run serve:ui` smoke -> pass (`http://localhost:8001/packages/ui-web/index.html` returned `200`)
+M7 validation status:
+- Initial ring on 2026-03-27 recorded missing tracked-file blockers during handoff.
+- Final ring after baseline reconciliation:
+  - `pnpm run build:wasm` -> pass
+  - `node --test tests/ui-web/*.test.mjs` -> pass (`83` passed)
+  - `node --test tests/integration/*.test.js` -> pass (`15` passed, `1` skipped live LLM test)
+  - `pnpm run serve:ui` smoke -> previously confirmed pass on 2026-03-27 (`http://localhost:8001/packages/ui-web/index.html` returned `200`)
 
-Current blockers from M7 regression ring:
+Resolved blockers from the initial M7 regression ring:
 - Missing runtime module import target: `packages/runtime/src/build/orchestrate-build.js` (imported by `packages/runtime/src/commands/kernel.js`).
 - Missing fixture file referenced by UI test: `tests/fixtures/artifacts/budget-artifact-v1-basic.json`.
 
@@ -71,7 +73,9 @@ Reference: [ui-cli-unification-plan.md](/Users/darren/Documents/GitHub/agent-ker
 | U7 | Completed | Finish docs and architecture cleanup so the branch closes with an explicit single-rails story. | `docs/**`, `packages/adapters-cli/README.md`, `local-codex/**` | Docs match implemented architecture and intentional exclusions |
 | U8 | Completed | Validate and document the minimum-install baseline for the default workflow. | Docs + any small dependency/isolation follow-ups | Core workflow runs without optional external adapters/services |
 
-## 4) Remaining Work Packages
+## 4) Work Package Index
+
+All work-package IDs below are historical tracking anchors. Their in-scope branch-close work is completed in this branch, and any deeper product work is explicitly deferred to follow-on branches.
 
 | ID | Requirement | Target Milestone | Planned Validation |
 | --- | --- | --- | --- |
@@ -447,10 +451,8 @@ Status update:
 
 ### Recommended Next Slice
 
-- `B5` Remaining baseline cleanup
-  - Next goal:
-    - resolve any still-tracked baseline failures before branch close,
-    - and record the final branch-close validation package.
+- None inside the completed Stitch / branch-close overlay.
+- If work continues, define a new follow-on milestone from the backlog items below instead of reopening `M4` through `M7`.
 
 ### Next Implementation Slices: B2
 


### PR DESCRIPTION
## Summary
- update local-codex planning notes
- update local-codex documentation status for the latest agent execution
- refresh solve CLI test artifact metadata fields (id, runId, createdAt) in fixture output

## Files
- local-codex/Plan.md
- local-codex/Documentation.md
- packages/adapters-cli/artifacts/solve_cli_test/solver-request.json
