### PR TITLE
Restore current UI with delver-warden terminology and resource bundles

### DIFF
--- a/packages/runtime/src/build/orchestrate-build.js
+++ b/packages/runtime/src/build/orchestrate-build.js
@@ -7,6 +7,7 @@ import { normalizeAffinityRulesArtifact, resolveAffinityRules } from "../persona
 import { buildSimConfigArtifact, buildInitialStateArtifact } from "../personas/configurator/artifact-builders.js";
 import { evaluateConfiguratorSpend } from "../personas/configurator/spend-proposal.js";
 import { normalizeMotivationRulesArtifact, resolveMotivationRules } from "../personas/configurator/motivation-rules.js";
+import { createDefaultResourceBundleArtifact } from "../render/resource-bundle.js";
 import {
   DEFAULT_ROOM_CARD_AFFINITY,
   ROOM_AFFINITY_EMIT_PERCENT_PER_STACK,
@@ -970,6 +971,7 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
   let affinitySummary = null;
   let affinityRules = null;
   let motivationRules = null;
+  let resourceBundle = null;
 
   if (hasLevelGen) {
     if (!hasActors) {
@@ -1103,6 +1105,13 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
         ambientPressure,
       };
     }
+
+    resourceBundle = createDefaultResourceBundleArtifact({
+      createMeta: (metaOverrides) => createBuildMeta(spec, metaOverrides.producedBy, "resource_bundle"),
+      runId: spec.meta.runId,
+      producedBy: "cli-build",
+      emitVisualAssets: true,
+    });
   }
 
   return {
@@ -1119,6 +1128,7 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
     affinitySummary,
     simConfig,
     initialState,
+    resourceBundle,
     capturedInputs: Array.isArray(capturedInputs) ? capturedInputs : undefined,
   };
 }

--- a/packages/runtime/src/commands/kernel.js
+++ b/packages/runtime/src/commands/kernel.js
@@ -495,6 +495,7 @@ function buildBuildArtifacts(buildResult, { includeBudgetAllocation = null, capt
   if (buildResult.solverResult) artifacts.push(buildResult.solverResult);
   if (buildResult.simConfig) artifacts.push(buildResult.simConfig);
   if (buildResult.initialState) artifacts.push(buildResult.initialState);
+  if (buildResult.resourceBundle) artifacts.push(buildResult.resourceBundle);
   capturedInputs.forEach((entry) => {
     artifacts.push(entry.artifact || entry);
   });
@@ -521,6 +522,7 @@ function buildBuildManifestEntries(buildResult, { includeBudgetAllocation = null
   addManifestEntry(entries, buildResult.solverResult, "solver-result.json");
   addManifestEntry(entries, buildResult.simConfig, "sim-config.json");
   addManifestEntry(entries, buildResult.initialState, "initial-state.json");
+  addManifestEntry(entries, buildResult.resourceBundle, "resource-bundle.json");
   capturedInputs.forEach((entry, index) => {
     const artifact = entry.artifact || entry;
     const capturePath = entry.path || buildCapturedInputPath("llm", index, artifact?.meta?.id);
@@ -708,6 +710,9 @@ export function createCommandKernel(host = {}) {
       }
       if (result.initialState) {
         await writeJson(join(outDir, "initial-state.json"), result.initialState);
+      }
+      if (result.resourceBundle) {
+        await writeJson(join(outDir, "resource-bundle.json"), result.resourceBundle);
       }
 
       const captures = Array.isArray(spec.adapters?.capture) ? spec.adapters.capture : [];
@@ -1940,6 +1945,9 @@ export function createCommandKernel(host = {}) {
     }
     if (buildResult.initialState) {
       await writeJson(join(outDir, "initial-state.json"), buildResult.initialState);
+    }
+    if (buildResult.resourceBundle) {
+      await writeJson(join(outDir, "resource-bundle.json"), buildResult.resourceBundle);
     }
 
     const capturedInputs = Array.isArray(buildResult.capturedInputs) ? buildResult.capturedInputs : [];

--- a/tests/adapters-web/cli-worker.test.js
+++ b/tests/adapters-web/cli-worker.test.js
@@ -57,7 +57,7 @@ const fetchFn = async (resource) => {
   return fixtureResponse(readFileSync(filePath, "utf8"));
 };
 
-const specPath = "/tests/fixtures/artifacts/build-spec-v1-basic.json";
+const specPath = "/tests/fixtures/artifacts/build-spec-v1-configurator.json";
 const adapter = createCliWorkerAdapter({ forceInProcess: true, fetchFn, env: { AK_LLM_LIVE: "1" } });
 const buildResult = await adapter.build({ specPath });
 
@@ -67,6 +67,9 @@ assert.equal(buildResult.bundle.spec.schema, "agent-kernel/BuildSpec");
 assert.equal(buildResult.telemetry.data.status, "success");
 assert.ok(Array.isArray(buildResult.logs));
 assert.ok(buildResult.artifacts["manifest.json"]);
+assert.ok(buildResult.artifacts["resource-bundle.json"]);
+assert.ok(buildResult.bundle.artifacts.some((artifact) => artifact.schema === "agent-kernel/ResourceBundleArtifact"));
+assert.ok(buildResult.manifest.artifacts.some((entry) => entry.path === "resource-bundle.json"));
 
 const configuratorResult = await adapter.configurator({
   levelGenPath: "/tests/fixtures/configurator/level-gen-input-v1-trap.json",

--- a/tests/integration/ui-cli-equivalence.test.js
+++ b/tests/integration/ui-cli-equivalence.test.js
@@ -199,7 +199,7 @@ test("browser host build artifacts are equivalent to Node CLI output", async () 
   runCli([
     "build",
     "--spec",
-    "tests/fixtures/artifacts/build-spec-v1-basic.json",
+    "tests/fixtures/artifacts/build-spec-v1-configurator.json",
     "--out-dir",
     outDir,
   ]);
@@ -207,7 +207,7 @@ test("browser host build artifacts are equivalent to Node CLI output", async () 
   const cliArtifacts = collectJsonArtifacts(outDir);
   const adapter = await createBrowserAdapter();
   const browserResult = await adapter.build({
-    specPath: "/tests/fixtures/artifacts/build-spec-v1-basic.json",
+    specPath: "/tests/fixtures/artifacts/build-spec-v1-configurator.json",
     outDir: "/artifacts/equivalence/build",
   });
 

--- a/tests/runtime/build-orchestrator.test.js
+++ b/tests/runtime/build-orchestrator.test.js
@@ -41,6 +41,11 @@ const resultConfigurator = await orchestrateBuild({
 
 assert.equal(resultConfigurator.simConfig.schema, "agent-kernel/SimConfigArtifact");
 assert.equal(resultConfigurator.initialState.schema, "agent-kernel/InitialStateArtifact");
+assert.equal(resultConfigurator.resourceBundle.schema, "agent-kernel/ResourceBundleArtifact");
+assert.equal(resultConfigurator.resourceBundle.schemaVersion, 2);
+assert.ok(Array.isArray(resultConfigurator.resourceBundle.assets));
+assert.ok(resultConfigurator.resourceBundle.assets.length > 0);
+assert.match(resultConfigurator.resourceBundle.assets[0].dataUri, /^data:image\\/png;base64,/);
 `;
 
 const actorPlacementScript = `

--- a/tests/runtime/e2e-build-artifacts.test.js
+++ b/tests/runtime/e2e-build-artifacts.test.js
@@ -179,6 +179,7 @@ test("orchestrated build produces deterministic bundle/manifest/telemetry output
   addManifestEntry(manifestEntries, buildResult.solverResult, "solver-result.json");
   addManifestEntry(manifestEntries, buildResult.simConfig, "sim-config.json");
   addManifestEntry(manifestEntries, buildResult.initialState, "initial-state.json");
+  addManifestEntry(manifestEntries, buildResult.resourceBundle, "resource-bundle.json");
   addManifestEntry(manifestEntries, captureArtifact, "captured-input-llm-1.json");
 
   manifestEntries.sort((a, b) => {
@@ -217,6 +218,7 @@ test("orchestrated build produces deterministic bundle/manifest/telemetry output
     buildResult.solverResult,
     buildResult.simConfig,
     buildResult.initialState,
+    buildResult.resourceBundle,
     captureArtifact,
   ].filter(Boolean);
 
@@ -253,6 +255,7 @@ test("orchestrated build produces deterministic bundle/manifest/telemetry output
   const manifestSchemas = new Set(manifest.artifacts.map((entry) => entry.schema));
   requiredSchemas.forEach((schema) => assert.ok(manifestSchemas.has(schema)));
   assert.ok(manifestSchemas.has("agent-kernel/CapturedInputArtifact"));
+  assert.ok(manifestSchemas.has("agent-kernel/ResourceBundleArtifact"));
 
   const sortedManifest = [...manifest.artifacts].sort((a, b) => {
     if (a.schema === b.schema) {

--- a/tests/ui-web/bundle-integration.test.mjs
+++ b/tests/ui-web/bundle-integration.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import { wireBuildOrchestrator } from "../../packages/ui-web/src/build-orchestrator.js";
 import { wireBundleReview } from "../../packages/ui-web/src/bundle-review.js";
+import { createDefaultResourceBundleArtifact } from "../../packages/runtime/src/render/resource-bundle.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -80,6 +81,29 @@ function createStorage() {
 test("build response snapshot loads into bundle review panel", async () => {
   const bundle = JSON.parse(readFileSync(path.join(root, "tests/fixtures/ui/build-spec-bundle/bundle.json"), "utf8"));
   const manifest = JSON.parse(readFileSync(path.join(root, "tests/fixtures/ui/build-spec-bundle/manifest.json"), "utf8"));
+  const resourceBundle = createDefaultResourceBundleArtifact({
+    createMeta: ({ producedBy, runId }) => ({
+      id: "resource_bundle_basic",
+      runId,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      producedBy,
+    }),
+    runId: bundle.spec.meta.runId,
+    producedBy: "fixture",
+    emitVisualAssets: true,
+  });
+  bundle.artifacts.push(resourceBundle);
+  manifest.artifacts.push({
+    id: resourceBundle.meta.id,
+    schema: resourceBundle.schema,
+    schemaVersion: resourceBundle.schemaVersion,
+    path: "resource-bundle.json",
+  });
+  manifest.schemas.push({
+    schema: resourceBundle.schema,
+    schemaVersion: resourceBundle.schemaVersion,
+    description: "Visual resource bundle with generated imagery data.",
+  });
   const specText = JSON.stringify(bundle.spec, null, 2);
 
   const originalDocument = globalThis.document;
@@ -158,11 +182,13 @@ test("build response snapshot loads into bundle review panel", async () => {
     assert.equal(schemaList.children.length > 0, true);
     assert.equal(schemaList.children.some((entry) => entry.textContent.includes("agent-kernel/BuildSpec")), true);
     assert.match(manifestOutput.textContent, /specPath/);
+    assert.match(manifestOutput.textContent, /resource-bundle\.json/);
     assert.match(specTextarea.value, /agent-kernel\/BuildSpec/);
 
     const intent = JSON.parse(intentOutput.textContent);
     assert.equal(intent.goal, bundle.spec.intent.goal);
     assert.equal(artifactsContainer.children.length, bundle.artifacts.length);
+    assert.equal(bundle.artifacts.some((artifact) => artifact.schema === "agent-kernel/ResourceBundleArtifact"), true);
   } finally {
     globalThis.document = originalDocument;
     globalThis.localStorage = originalLocalStorage;


### PR DESCRIPTION
## Summary
- Restore UI delver and warden surfaces, replacing attacker/defender terminology throughout
- Add resource bundle system for managing visual assets in build and render pipeline
- Wire resource bundle into orchestrate-build output for design-to-run handoff
- Update all tests, fixtures, and CLI commands to align with delver-warden contract

## Changes
- **Terminology**: attacker → delver, defender → warden across runtime, CLI, UI, and tests
- **Resource bundles**: New `resource-bundle.js` module (952 lines) plus integration with build orchestrator
- **UI updates**: Design view, preview view, simulation view updated for new terminology and bundle rendering
- **Tests**: Updated 57 files with comprehensive fixture and assertion alignment

## Test plan
- [ ] All existing tests pass with updated terminology
- [ ] Resource bundle tests validate artifact schema conformance
- [ ] UI integration tests verify bundle rendering in simulation view
- [ ] CLI worker tests confirm delver-warden fixture references

🤖 Generated with [Claude Code](https://claude.com/claude-code)