### PR TITLE
Finalize affinity visuals and resource bundle follow-ups

### DIFF
--- a/packages/runtime/src/contracts/artifacts.ts
+++ b/packages/runtime/src/contracts/artifacts.ts
@@ -1254,3 +1254,73 @@ export interface RunSummaryV1 {
 
 export type TelemetryRecord = TelemetryRecordV1;
 export type RunSummary = RunSummaryV1;
+
+// -------------------------
+// Resource Bundle (rendering)
+// -------------------------
+
+export const RESOURCE_BUNDLE_SCHEMA = "agent-kernel/ResourceBundleArtifact";
+
+/**
+ * Visual resource bundle for rendering simulation state.
+ * V1 uses IPFS references; V2 includes embedded data URIs and relative paths.
+ */
+export interface ResourceBundleAssetV1 {
+  id: string;
+  kind: "tile" | "actor" | "card" | "overlay" | "affinity" | "motivation" | "expression";
+  label: string;
+  ipfsUri: string;
+  mimeType: string;
+  width: number;
+  height: number;
+  /** V2+: Embedded data URI for offline rendering. */
+  dataUri?: string;
+  /** V2+: Relative path for file export. */
+  relativePath?: string;
+}
+
+export interface ResourceBundleMappingsV1 {
+  tiles: Record<string, string>;
+  actors: Record<string, string> & {
+    byRoleAndAffinity?: Record<string, Record<string, string>>;
+  };
+  cards: Record<string, string>;
+  affinities?: Record<string, string>;
+  motivations?: Record<string, string>;
+  expressions?: Record<string, string>;
+  overlays?: {
+    affinities?: Record<string, string>;
+    expressions?: Record<string, string>;
+    stackTiers?: Record<string, string>;
+    motivations?: Record<string, string>;
+    darknessMask?: string;
+  };
+}
+
+export interface ResourceBundleArtifactV1 {
+  schema: typeof RESOURCE_BUNDLE_SCHEMA;
+  schemaVersion: 1;
+  meta: ArtifactMeta;
+  bundleId: string;
+  bundleVersion: number;
+  tileWidth: number;
+  tileHeight: number;
+  gatewayBaseUrl: string;
+  assets: ResourceBundleAssetV1[];
+  mappings: ResourceBundleMappingsV1;
+}
+
+export interface ResourceBundleArtifactV2 {
+  schema: typeof RESOURCE_BUNDLE_SCHEMA;
+  schemaVersion: 2;
+  meta: ArtifactMeta;
+  bundleId: string;
+  bundleVersion: number;
+  tileWidth: number;
+  tileHeight: number;
+  gatewayBaseUrl: string;
+  assets: ResourceBundleAssetV1[];
+  mappings: ResourceBundleMappingsV1;
+}
+
+export type ResourceBundleArtifact = ResourceBundleArtifactV1 | ResourceBundleArtifactV2;

--- a/packages/runtime/src/contracts/schema-catalog.js
+++ b/packages/runtime/src/contracts/schema-catalog.js
@@ -157,6 +157,18 @@ const CATALOG = [
     description: "Run summary output.",
     fields: ["meta", "intentRef", "planRef", "simConfigRef", "budgetReceiptRef", "outcome"],
   },
+  {
+    schema: "agent-kernel/ResourceBundleArtifact",
+    schemaVersion: 1,
+    description: "Visual resource bundle for rendering.",
+    fields: ["meta", "bundleId", "bundleVersion", "tileWidth", "tileHeight", "gatewayBaseUrl", "assets", "mappings"],
+  },
+  {
+    schema: "agent-kernel/ResourceBundleArtifact",
+    schemaVersion: 2,
+    description: "Visual resource bundle with embedded data URIs.",
+    fields: ["meta", "bundleId", "bundleVersion", "tileWidth", "tileHeight", "gatewayBaseUrl", "assets", "mappings"],
+  },
 ];
 
 function sortSchemas(entries) {

--- a/packages/runtime/src/personas/configurator/guidance-level-builder.js
+++ b/packages/runtime/src/personas/configurator/guidance-level-builder.js
@@ -1,6 +1,7 @@
 import { buildBuildSpecFromSummary } from "../director/buildspec-assembler.js";
 import { generateGridLayoutFromInput } from "./level-layout.js";
 import { deriveLevelGenFromRoomCards } from "./card-model.js";
+import { AFFINITY_COLOR_HEX, resolveStackIntensity } from "../../render/affinity-palette.js";
 
 const WALKABLE_DENSITY_TARGET = 0.5;
 export const DEFAULT_LEVEL_RENDER_PALETTE = Object.freeze({
@@ -10,6 +11,19 @@ export const DEFAULT_LEVEL_RENDER_PALETTE = Object.freeze({
   E: "#f4a261",
   B: "#9ca3af",
 });
+const AFFINITY_ASCII_GLYPHS = Object.freeze({
+  fire: "f",
+  water: "w",
+  earth: "e",
+  wind: "n",
+  life: "l",
+  decay: "d",
+  corrode: "c",
+  fortify: "t",
+  light: "i",
+  dark: "k",
+});
+const AFFINITY_RENDER_ORDER = Object.freeze(Object.keys(AFFINITY_COLOR_HEX));
 
 function isPositiveInt(value) {
   return Number.isInteger(value) && value > 0;
@@ -45,6 +59,170 @@ function normalizeHexColor(value, fallback = "#000000") {
   return fallback;
 }
 
+function normalizeAffinityKind(value) {
+  const kind = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return kind && AFFINITY_COLOR_HEX[kind] ? kind : "";
+}
+
+function normalizeAffinityStacks(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 1;
+  return Math.max(1, Math.round(parsed));
+}
+
+function affinityOrder(kind) {
+  const index = AFFINITY_RENDER_ORDER.indexOf(kind);
+  return index >= 0 ? index : Number.MAX_SAFE_INTEGER;
+}
+
+function resolveTrapAffinityEntry(trap = null) {
+  if (!trap || typeof trap !== "object") return null;
+  const candidates = Array.isArray(trap.affinities)
+    ? trap.affinities
+    : trap.affinity && typeof trap.affinity === "object"
+      ? [trap.affinity]
+      : [];
+  const valid = candidates
+    .map((entry) => {
+      const kind = normalizeAffinityKind(entry?.kind);
+      if (!kind) return null;
+      const targetType = typeof entry?.targetType === "string" ? entry.targetType.trim().toLowerCase() : "";
+      const stacks = normalizeAffinityStacks(entry?.roomStacks ?? entry?.stacks);
+      return { kind, stacks, targetType };
+    })
+    .filter(Boolean);
+  if (valid.length === 0) return null;
+  const floorFirst = valid.filter((entry) => entry.targetType === "floor");
+  const pool = floorFirst.length > 0 ? floorFirst : valid;
+  pool.sort((left, right) => {
+    if (right.stacks !== left.stacks) return right.stacks - left.stacks;
+    return affinityOrder(left.kind) - affinityOrder(right.kind);
+  });
+  return pool[0];
+}
+
+function resolveTrapPosition(trap) {
+  if (!trap || typeof trap !== "object") return null;
+  const x = Number(trap?.position?.x ?? trap?.x);
+  const y = Number(trap?.position?.y ?? trap?.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return { x: Math.floor(x), y: Math.floor(y) };
+}
+
+function upsertAffinityCell(index, x, y, affinity, { width, height }) {
+  if (x < 0 || x >= width || y < 0 || y >= height) return;
+  const key = `${x},${y}`;
+  const prior = index.get(key);
+  if (!prior) {
+    index.set(key, { kind: affinity.kind, stacks: affinity.stacks });
+    return;
+  }
+  if (affinity.stacks > prior.stacks) {
+    index.set(key, { kind: affinity.kind, stacks: affinity.stacks });
+    return;
+  }
+  if (affinity.stacks === prior.stacks && affinityOrder(affinity.kind) < affinityOrder(prior.kind)) {
+    index.set(key, { kind: affinity.kind, stacks: affinity.stacks });
+  }
+}
+
+function buildFloorAffinityByCell({ width, height, floorAffinityCells = null, floorAffinityTraps = null } = {}) {
+  const index = new Map();
+  if (Array.isArray(floorAffinityCells)) {
+    floorAffinityCells.forEach((entry) => {
+      const x = Number(entry?.x);
+      const y = Number(entry?.y);
+      const kind = normalizeAffinityKind(entry?.kind);
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !kind) return;
+      const stacks = normalizeAffinityStacks(entry?.stacks);
+      upsertAffinityCell(index, Math.floor(x), Math.floor(y), { kind, stacks }, { width, height });
+    });
+  }
+  if (Array.isArray(floorAffinityTraps)) {
+    floorAffinityTraps.forEach((trap) => {
+      const position = resolveTrapPosition(trap);
+      const affinity = resolveTrapAffinityEntry(trap);
+      if (!position || !affinity) return;
+      upsertAffinityCell(index, position.x, position.y, affinity, { width, height });
+    });
+  }
+  return index;
+}
+
+function rgbToHsl(r, g, b) {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+  let h = 0;
+  if (delta > 0) {
+    if (max === rn) h = ((gn - bn) / delta) % 6;
+    else if (max === gn) h = ((bn - rn) / delta) + 2;
+    else h = ((rn - gn) / delta) + 4;
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs((2 * l) - 1));
+  return { h, s, l };
+}
+
+function hslToRgb(h, s, l) {
+  const c = (1 - Math.abs((2 * l) - 1)) * s;
+  const hPrime = (h % 360) / 60;
+  const x = c * (1 - Math.abs((hPrime % 2) - 1));
+  let r1 = 0;
+  let g1 = 0;
+  let b1 = 0;
+  if (hPrime >= 0 && hPrime < 1) {
+    r1 = c;
+    g1 = x;
+  } else if (hPrime < 2) {
+    r1 = x;
+    g1 = c;
+  } else if (hPrime < 3) {
+    g1 = c;
+    b1 = x;
+  } else if (hPrime < 4) {
+    g1 = x;
+    b1 = c;
+  } else if (hPrime < 5) {
+    r1 = x;
+    b1 = c;
+  } else {
+    r1 = c;
+    b1 = x;
+  }
+  const m = l - (c / 2);
+  return [
+    Math.round((r1 + m) * 255),
+    Math.round((g1 + m) * 255),
+    Math.round((b1 + m) * 255),
+  ];
+}
+
+function resolveAffinityFloorRgba(affinity) {
+  const baseHex = AFFINITY_COLOR_HEX[affinity?.kind];
+  if (!baseHex) return null;
+  const [baseR, baseG, baseB] = colorHexToRgba(baseHex);
+  const { h } = rgbToHsl(baseR, baseG, baseB);
+  const style = resolveStackIntensity(affinity?.stacks);
+  const sat = Math.max(0, Math.min(1, style.sat / 100));
+  const light = Math.max(0, Math.min(1, style.light / 100));
+  const [r, g, b] = hslToRgb(h, sat, light);
+  return [r, g, b, 255];
+}
+
+function resolveAffinityFloorGlyph(affinity) {
+  const kind = normalizeAffinityKind(affinity?.kind);
+  if (!kind) return ".";
+  const base = AFFINITY_ASCII_GLYPHS[kind] || ".";
+  const style = resolveStackIntensity(affinity?.stacks);
+  return style.stacks >= 2 ? base.toUpperCase() : base;
+}
+
 function resolveRenderPalette(palette = null) {
   const resolved = { ...DEFAULT_LEVEL_RENDER_PALETTE };
   if (palette && typeof palette === "object" && !Array.isArray(palette)) {
@@ -65,14 +243,31 @@ function colorHexToRgba(hex) {
   return [r, g, b, 255];
 }
 
-function buildAsciiArtifact(lines = []) {
+function buildAsciiArtifact(lines = [], { floorAffinityByCell = null } = {}) {
+  if (!(floorAffinityByCell instanceof Map) || floorAffinityByCell.size === 0) {
+    return {
+      lines: lines.slice(),
+      text: lines.join("\n"),
+    };
+  }
+  const styledLines = lines.map((rawRow, y) => {
+    const row = String(rawRow || "");
+    const chars = row.split("");
+    for (let x = 0; x < chars.length; x += 1) {
+      if (chars[x] !== ".") continue;
+      const affinity = floorAffinityByCell.get(`${x},${y}`);
+      if (!affinity) continue;
+      chars[x] = resolveAffinityFloorGlyph(affinity);
+    }
+    return chars.join("");
+  });
   return {
-    lines: lines.slice(),
-    text: lines.join("\n"),
+    lines: styledLines,
+    text: styledLines.join("\n"),
   };
 }
 
-function buildImageArtifact(lines = [], { palette = null } = {}) {
+function buildImageArtifact(lines = [], { palette = null, floorAffinityByCell = null } = {}) {
   const normalized = normalizeTiles(lines);
   if (!normalized) return null;
   const resolvedPalette = resolveRenderPalette(palette);
@@ -83,12 +278,22 @@ function buildImageArtifact(lines = [], { palette = null } = {}) {
     const row = normalized.lines[y];
     for (let x = 0; x < normalized.width; x += 1) {
       const char = row[x] || "#";
+      const floorAffinity = char === "." && floorAffinityByCell instanceof Map
+        ? floorAffinityByCell.get(`${x},${y}`)
+        : null;
       const colorHex = resolvedPalette[char]
         || (char === "#" ? resolvedPalette["#"] : resolvedPalette["."]);
-      const cacheKey = `${char}|${colorHex}`;
+      const cacheKey = floorAffinity
+        ? `affinity|${floorAffinity.kind}|${floorAffinity.stacks}`
+        : `${char}|${colorHex}`;
       let rgba = colorCache.get(cacheKey);
       if (!rgba) {
-        rgba = colorHexToRgba(colorHex);
+        rgba = floorAffinity
+          ? resolveAffinityFloorRgba(floorAffinity)
+          : colorHexToRgba(colorHex);
+        if (!rgba) {
+          rgba = colorHexToRgba(colorHex);
+        }
         colorCache.set(cacheKey, rgba);
       }
       pixels[idx] = rgba[0];
@@ -108,12 +313,24 @@ function buildImageArtifact(lines = [], { palette = null } = {}) {
 
 export function buildLevelRenderArtifactsFromTiles(
   tiles = [],
-  { includeAscii = true, includeImage = true, palette = null } = {},
+  {
+    includeAscii = true,
+    includeImage = true,
+    palette = null,
+    floorAffinityCells = null,
+    floorAffinityTraps = null,
+  } = {},
 ) {
   const normalized = normalizeTiles(tiles);
   if (!normalized) {
     return { ok: false, reason: "missing_tiles" };
   }
+  const floorAffinityByCell = buildFloorAffinityByCell({
+    width: normalized.width,
+    height: normalized.height,
+    floorAffinityCells,
+    floorAffinityTraps,
+  });
   const result = {
     ok: true,
     tiles: normalized.lines,
@@ -122,10 +339,10 @@ export function buildLevelRenderArtifactsFromTiles(
     walkableTiles: countWalkableTiles(normalized.lines),
   };
   if (includeAscii) {
-    result.ascii = buildAsciiArtifact(normalized.lines);
+    result.ascii = buildAsciiArtifact(normalized.lines, { floorAffinityByCell });
   }
   if (includeImage) {
-    result.image = buildImageArtifact(normalized.lines, { palette });
+    result.image = buildImageArtifact(normalized.lines, { palette, floorAffinityByCell });
   }
   return result;
 }
@@ -173,7 +390,13 @@ export function deriveLevelGenFromGuidanceSummary(summary) {
 
 export function buildLevelPreviewFromLevelGen(
   levelGen,
-  { includeAscii = true, includeImage = true, palette = null } = {},
+  {
+    includeAscii = true,
+    includeImage = true,
+    palette = null,
+    floorAffinityCells = null,
+    floorAffinityTraps = null,
+  } = {},
 ) {
   if (!levelGen || typeof levelGen !== "object") {
     return { ok: false, reason: "missing_level_gen" };
@@ -204,6 +427,8 @@ export function buildLevelPreviewFromLevelGen(
     includeAscii,
     includeImage,
     palette,
+    floorAffinityCells,
+    floorAffinityTraps: Array.isArray(floorAffinityTraps) ? floorAffinityTraps : generated.value?.traps,
   });
   if (!rendered.ok) {
     return rendered;
@@ -216,7 +441,13 @@ export function buildLevelPreviewFromLevelGen(
 
 export function buildLevelPreviewFromGuidanceSummary(
   summary,
-  { includeAscii = true, includeImage = true, palette = null } = {},
+  {
+    includeAscii = true,
+    includeImage = true,
+    palette = null,
+    floorAffinityCells = null,
+    floorAffinityTraps = null,
+  } = {},
 ) {
   if (!summary || typeof summary !== "object") {
     return { ok: false, reason: "missing_summary" };
@@ -225,5 +456,11 @@ export function buildLevelPreviewFromGuidanceSummary(
   if (!levelGen) {
     return { ok: false, reason: "missing_level_gen" };
   }
-  return buildLevelPreviewFromLevelGen(levelGen, { includeAscii, includeImage, palette });
+  return buildLevelPreviewFromLevelGen(levelGen, {
+    includeAscii,
+    includeImage,
+    palette,
+    floorAffinityCells,
+    floorAffinityTraps,
+  });
 }

--- a/packages/runtime/src/render/affinity-palette.js
+++ b/packages/runtime/src/render/affinity-palette.js
@@ -1,0 +1,118 @@
+/**
+ * Shared affinity visual palette and stack intensity rules.
+ *
+ * This module owns the canonical color palette for all affinity kinds
+ * and the intensity progression rules for affinity stack visualization.
+ *
+ * These rules drive:
+ * - Resource bundle sprite generation (resource-bundle.js)
+ * - ASCII-styled affinity rendering (movement-ui.js)
+ * - Future CLI-generated imagery with affinity-aware room/floor visuals
+ *
+ * @module affinity-palette
+ */
+
+import { AFFINITY_KINDS } from "../contracts/domain-constants.js";
+
+/**
+ * Canonical hex color for each affinity kind.
+ * Used for sprite generation and visual styling.
+ */
+export const AFFINITY_COLOR_HEX = Object.freeze({
+  fire: "#f05a28",
+  water: "#2b7fff",
+  earth: "#7a5c33",
+  wind: "#8fd3ff",
+  life: "#49b96b",
+  decay: "#6f7b46",
+  corrode: "#7fbf42",
+  fortify: "#8c6dd7",
+  light: "#f5d14d",
+  dark: "#3a2a57",
+});
+
+/**
+ * Stack intensity progression rules.
+ * Each tier increases saturation, reduces lightness, and adds glow.
+ *
+ * Used by ASCII styling and can drive CLI-generated image intensity overlays.
+ *
+ * Tiers:
+ * - tier1: stacks = 1 (baseline)
+ * - tier2: stacks = 2 (moderate boost)
+ * - tier3: stacks >= 3 (strong boost)
+ *
+ * @type {Array<{sat: number, light: number, glow: number}>}
+ */
+export const STACK_INTENSITY_TIERS = Object.freeze([
+  { sat: 55, light: 55, glow: 0 }, // tier1
+  { sat: 65, light: 50, glow: 4 }, // tier2
+  { sat: 75, light: 45, glow: 6 }, // tier3
+  { sat: 85, light: 40, glow: 8 }, // tier4+ (extended for future use)
+]);
+
+/**
+ * Convert hex color to RGBA array.
+ * @param {string} hex - 6-character hex color (e.g., "#f05a28")
+ * @param {number} alpha - Alpha channel (0-255), default 255
+ * @returns {[number, number, number, number]} RGBA array
+ */
+export function hexToRgba(hex, alpha = 255) {
+  const normalized = normalizeHex(hex, "#000000");
+  return [
+    Number.parseInt(normalized.slice(1, 3), 16),
+    Number.parseInt(normalized.slice(3, 5), 16),
+    Number.parseInt(normalized.slice(5, 7), 16),
+    alpha,
+  ];
+}
+
+/**
+ * Normalize and validate a hex color string.
+ * @param {string} value - Hex color to normalize
+ * @param {string} fallback - Fallback color if invalid
+ * @returns {string} Normalized hex color
+ */
+export function normalizeHex(value, fallback) {
+  const raw = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return /^#[0-9a-f]{6}$/i.test(raw) ? raw : fallback;
+}
+
+/**
+ * Resolve the intensity tier for a given stack count.
+ * @param {number} stacks - Affinity stack count (1+)
+ * @returns {{sat: number, light: number, glow: number, stacks: number}}
+ */
+export function resolveStackIntensity(stacks) {
+  const normalized = Math.max(1, Math.round(Number(stacks) || 1));
+  const index = Math.min(STACK_INTENSITY_TIERS.length - 1, normalized - 1);
+  return { ...STACK_INTENSITY_TIERS[index], stacks: normalized };
+}
+
+/**
+ * Get the RGBA color for an affinity kind.
+ * @param {string} kind - Affinity kind
+ * @param {number} alpha - Alpha channel (0-255), default 255
+ * @returns {[number, number, number, number]} RGBA array
+ */
+export function getAffinityRgba(kind, alpha = 255) {
+  const hex = AFFINITY_COLOR_HEX[kind];
+  if (!hex) {
+    return [255, 255, 255, alpha]; // fallback white
+  }
+  return hexToRgba(hex, alpha);
+}
+
+/**
+ * Validate that all canonical affinity kinds have palette entries.
+ * @returns {{ok: boolean, missing: string[]}}
+ */
+export function validateAffinityPalette() {
+  const missing = [];
+  AFFINITY_KINDS.forEach((kind) => {
+    if (!AFFINITY_COLOR_HEX[kind]) {
+      missing.push(kind);
+    }
+  });
+  return { ok: missing.length === 0, missing };
+}

--- a/packages/runtime/src/render/resource-bundle.js
+++ b/packages/runtime/src/render/resource-bundle.js
@@ -3,6 +3,7 @@ import {
   ALLOWED_AFFINITY_EXPRESSIONS,
   ALLOWED_MOTIVATIONS,
 } from "../personas/orchestrator/prompt-contract.js";
+import { AFFINITY_COLOR_HEX, hexToRgba as sharedHexToRgba, normalizeHex as sharedNormalizeHex } from "./affinity-palette.js";
 
 export const RESOURCE_BUNDLE_SCHEMA = "agent-kernel/ResourceBundleArtifact";
 export const RESOURCE_BUNDLE_VERSION = 2;
@@ -93,20 +94,9 @@ function createVisualMappings() {
   };
 }
 
-function normalizeHex(value, fallback) {
-  const raw = typeof value === "string" ? value.trim().toLowerCase() : "";
-  return /^#[0-9a-f]{6}$/i.test(raw) ? raw : fallback;
-}
-
-function hexToRgba(hex, alpha = 255) {
-  const normalized = normalizeHex(hex, "#000000");
-  return [
-    Number.parseInt(normalized.slice(1, 3), 16),
-    Number.parseInt(normalized.slice(3, 5), 16),
-    Number.parseInt(normalized.slice(5, 7), 16),
-    alpha,
-  ];
-}
+// Use shared palette functions for consistency
+const normalizeHex = sharedNormalizeHex;
+const hexToRgba = sharedHexToRgba;
 
 function createAssetEntry(
   id,
@@ -405,18 +395,12 @@ const PALETTE = Object.freeze({
   border: hexToRgba("#0d1110"),
   white: hexToRgba("#ffffff"),
   black: hexToRgba("#000000"),
-  affinity: {
-    fire: hexToRgba("#f05a28"),
-    water: hexToRgba("#2b7fff"),
-    earth: hexToRgba("#7a5c33"),
-    wind: hexToRgba("#8fd3ff"),
-    life: hexToRgba("#49b96b"),
-    decay: hexToRgba("#6f7b46"),
-    corrode: hexToRgba("#7fbf42"),
-    fortify: hexToRgba("#8c6dd7"),
-    light: hexToRgba("#f5d14d"),
-    dark: hexToRgba("#3a2a57"),
-  },
+  // Affinity colors now sourced from shared palette
+  affinity: Object.freeze(
+    Object.fromEntries(
+      Object.entries(AFFINITY_COLOR_HEX).map(([kind, hex]) => [kind, hexToRgba(hex)]),
+    ),
+  ),
 });
 
 function inferTileSemantic(char) {

--- a/packages/ui-web/src/movement-ui.js
+++ b/packages/ui-web/src/movement-ui.js
@@ -8,7 +8,7 @@ import {
   TRAP_VITAL_KEYS,
   VITAL_KEYS,
 } from "../../runtime/src/contracts/domain-constants.js";
-import { STACK_INTENSITY_TIERS, resolveStackIntensity } from "../../runtime/src/render/affinity-palette.js";
+import { AFFINITY_COLOR_HEX, STACK_INTENSITY_TIERS, resolveStackIntensity } from "../../runtime/src/render/affinity-palette.js";
 
 const EVENT_STREAM_LIMIT = 6;
 const DEFAULT_VIEWPORT_SIZE = 50;
@@ -107,6 +107,8 @@ const REALTIME_MOVE_BY_ACTION = Object.freeze({
 });
 // Stack intensity rules now sourced from shared affinity-palette module
 const STACK_STYLES = STACK_INTENSITY_TIERS;
+// Affinity render order for deterministic tie-breaks (matches guidance-level-builder.js)
+const AFFINITY_RENDER_ORDER = Object.freeze(Object.keys(AFFINITY_COLOR_HEX));
 
 function escapeHtmlChar(char) {
   if (char === "&") return "&amp;";
@@ -125,6 +127,11 @@ function normalizeStacks(value) {
   const num = Number(value);
   if (!Number.isFinite(num) || num <= 0) return 1;
   return Math.max(1, Math.round(num));
+}
+
+function affinityOrder(kind) {
+  const index = AFFINITY_RENDER_ORDER.indexOf(kind);
+  return index >= 0 ? index : Number.MAX_SAFE_INTEGER;
 }
 
 function resolveAffinityFromTraits(traits) {
@@ -207,7 +214,10 @@ function resolveTrapAffinityEntry(trap = null) {
   if (valid.length === 0) return null;
   const floorFirst = valid.filter((entry) => entry.targetType === "floor");
   const pool = floorFirst.length > 0 ? floorFirst : valid;
-  pool.sort((a, b) => b.stacks - a.stacks);
+  pool.sort((left, right) => {
+    if (right.stacks !== left.stacks) return right.stacks - left.stacks;
+    return affinityOrder(left.kind) - affinityOrder(right.kind);
+  });
   return pool[0];
 }
 
@@ -228,7 +238,15 @@ function buildFloorAffinityIndex(traps = [], { viewport = null } = {}) {
     const localY = viewport ? y - viewport.startY : y;
     const key = keyForCell(localX, localY);
     const prior = index.get(key);
-    if (!prior || affinity.stacks > prior.stacks) {
+    if (!prior) {
+      index.set(key, affinity);
+      return;
+    }
+    if (affinity.stacks > prior.stacks) {
+      index.set(key, affinity);
+      return;
+    }
+    if (affinity.stacks === prior.stacks && affinityOrder(affinity.kind) < affinityOrder(prior.kind)) {
       index.set(key, affinity);
     }
   });

--- a/packages/ui-web/src/movement-ui.js
+++ b/packages/ui-web/src/movement-ui.js
@@ -8,6 +8,7 @@ import {
   TRAP_VITAL_KEYS,
   VITAL_KEYS,
 } from "../../runtime/src/contracts/domain-constants.js";
+import { STACK_INTENSITY_TIERS, resolveStackIntensity } from "../../runtime/src/render/affinity-palette.js";
 
 const EVENT_STREAM_LIMIT = 6;
 const DEFAULT_VIEWPORT_SIZE = 50;
@@ -104,12 +105,8 @@ const REALTIME_MOVE_BY_ACTION = Object.freeze({
   left: { direction: "west", dx: -1, dy: 0 },
   right: { direction: "east", dx: 1, dy: 0 },
 });
-const STACK_STYLES = [
-  { sat: 55, light: 55, glow: 0 },
-  { sat: 65, light: 50, glow: 4 },
-  { sat: 75, light: 45, glow: 6 },
-  { sat: 85, light: 40, glow: 8 },
-];
+// Stack intensity rules now sourced from shared affinity-palette module
+const STACK_STYLES = STACK_INTENSITY_TIERS;
 
 function escapeHtmlChar(char) {
   if (char === "&") return "&amp;";
@@ -175,10 +172,9 @@ function resolveAffinityInfo(actor) {
   return null;
 }
 
+// Use shared stack intensity resolver
 function resolveStackStyle(stacks) {
-  const normalized = normalizeStacks(stacks);
-  const index = Math.min(STACK_STYLES.length - 1, normalized - 1);
-  return { ...STACK_STYLES[index], stacks: normalized };
+  return resolveStackIntensity(stacks);
 }
 
 function buildActorSymbolMap(actors = [], symbols, fallbackSymbols) {

--- a/packages/ui-web/src/movement-ui.js
+++ b/packages/ui-web/src/movement-ui.js
@@ -198,7 +198,7 @@ function resolveTrapAffinityEntry(trap = null) {
   const valid = candidates
     .map((entry) => {
       const kind = normalizeAffinityKind(entry?.kind);
-      const stacks = normalizeStacks(entry?.stacks);
+      const stacks = normalizeStacks(entry?.roomStacks ?? entry?.stacks);
       const targetType = typeof entry?.targetType === "string" ? entry.targetType.trim().toLowerCase() : "";
       if (!kind || !AFFINITY_HUES[kind]) return null;
       return { kind, stacks, targetType };
@@ -215,8 +215,8 @@ function buildFloorAffinityIndex(traps = [], { viewport = null } = {}) {
   if (!Array.isArray(traps) || traps.length === 0) return new Map();
   const index = new Map();
   traps.forEach((trap) => {
-    const x = Number(trap?.position?.x);
-    const y = Number(trap?.position?.y);
+    const x = Number(trap?.position?.x ?? trap?.x);
+    const y = Number(trap?.position?.y ?? trap?.y);
     if (!Number.isFinite(x) || !Number.isFinite(y)) return;
     if (viewport) {
       if (x < viewport.startX || x >= viewport.endX) return;

--- a/packages/ui-web/src/views/simulation-view.js
+++ b/packages/ui-web/src/views/simulation-view.js
@@ -469,7 +469,12 @@ export function wireSimulationView({
     const nextHash = hashTiles(baseTiles);
     if (nextHash === lastBaseTilesHash) return;
     lastBaseTilesHash = nextHash;
-    void regenerateLevelArtifacts({ tiles: baseTiles });
+    void regenerateLevelArtifacts({
+      tiles: baseTiles,
+      renderOptions: {
+        floorAffinityTraps: Array.isArray(observation?.traps) ? observation.traps : [],
+      },
+    });
   }
 
   function mountPlayback(config, { initCore } = {}) {

--- a/tests/adapters-web/adapter-modules.test.js
+++ b/tests/adapters-web/adapter-modules.test.js
@@ -124,6 +124,25 @@ assert.equal(fromTiles.width, 3);
 assert.equal(fromTiles.height, 2);
 assert.equal(fromTiles.walkableTiles, 5);
 
+const affinityFromTiles = await inProcess.buildFromTiles({
+  tiles: ["..."],
+  renderOptions: {
+    includeAscii: true,
+    includeImage: true,
+    floorAffinityTraps: [
+      { x: 0, y: 0, affinity: { kind: "water", targetType: "floor", stacks: 1 } },
+      { x: 1, y: 0, affinity: { kind: "water", targetType: "floor", stacks: 1, roomStacks: 3 } },
+    ],
+  },
+});
+assert.equal(affinityFromTiles.ok, true);
+assert.equal(affinityFromTiles.ascii.lines[0][0], "w");
+assert.equal(affinityFromTiles.ascii.lines[0][1], "W");
+assert.notDeepEqual(
+  Array.from(affinityFromTiles.image.pixels.slice(0, 4)),
+  Array.from(affinityFromTiles.image.pixels.slice(4, 8)),
+);
+
 const fromLevelGen = await inProcess.buildFromLevelGen({ levelGen: inProcessResult.levelGen });
 assert.equal(fromLevelGen.ok, true);
 assert.equal(fromLevelGen.walkableTiles, 120);

--- a/tests/personas/configurator-guidance-level-builder.test.js
+++ b/tests/personas/configurator-guidance-level-builder.test.js
@@ -98,6 +98,104 @@ highBudgetShapes.forEach((shape, index) => {
   runEsm(script);
 });
 
+test("mixed-affinity floor resolution is invariant to trap ordering (permutation test)", () => {
+  const script = `
+import assert from "node:assert/strict";
+import {
+  buildLevelRenderArtifactsFromTiles,
+} from ${JSON.stringify(builderModule)};
+
+// Three traps at the same cell (1,0) with equal stacks but different affinities.
+// The tie-break rule uses AFFINITY_RENDER_ORDER index, so "fire" (index 0) should
+// always win over "water" (index 1) and "earth" (index 2) when stacks are equal.
+const baseTrap = (kind) => ({
+  x: 1, y: 0,
+  affinity: { kind, expression: "emit", targetType: "floor", stacks: 2 },
+});
+
+const trapSets = [
+  [baseTrap("fire"), baseTrap("water"), baseTrap("earth")],
+  [baseTrap("water"), baseTrap("fire"), baseTrap("earth")],
+  [baseTrap("earth"), baseTrap("water"), baseTrap("fire")],
+  [baseTrap("earth"), baseTrap("fire"), baseTrap("water")],
+  [baseTrap("water"), baseTrap("earth"), baseTrap("fire")],
+  [baseTrap("fire"), baseTrap("earth"), baseTrap("water")],
+];
+
+const tiles = ["..."];
+let referenceAscii = null;
+let referencePixels = null;
+
+trapSets.forEach((traps, permIndex) => {
+  const result = buildLevelRenderArtifactsFromTiles(tiles, {
+    includeAscii: true,
+    includeImage: true,
+    floorAffinityTraps: traps,
+  });
+  assert.equal(result.ok, true, "permutation " + permIndex + " should succeed");
+
+  // Cell (1,0) should resolve to "fire" (lowest AFFINITY_RENDER_ORDER index at equal stacks)
+  // ASCII glyph for fire at stacks>=2 is uppercase "F"
+  assert.equal(result.ascii.lines[0][1], "F",
+    "permutation " + permIndex + ": cell (1,0) should be fire uppercase glyph");
+
+  const cellPixelOffset = 1 * 4; // cell (1,0) -> pixel index 1
+  const pixel = Array.from(result.image.pixels.slice(cellPixelOffset, cellPixelOffset + 4));
+
+  if (permIndex === 0) {
+    referenceAscii = result.ascii.lines[0];
+    referencePixels = pixel;
+  } else {
+    assert.equal(result.ascii.lines[0], referenceAscii,
+      "permutation " + permIndex + ": ASCII row must match reference");
+    assert.deepStrictEqual(pixel, referencePixels,
+      "permutation " + permIndex + ": pixel RGBA must match reference");
+  }
+});
+
+// Also verify a second cell with different stacks to ensure higher-stacks still wins
+// regardless of ordering. Place a stacks=3 water trap and a stacks=2 fire trap at (0,0).
+const mixedStackTraps = [
+  [
+    { x: 0, y: 0, affinity: { kind: "fire", expression: "emit", targetType: "floor", stacks: 2 } },
+    { x: 0, y: 0, affinity: { kind: "water", expression: "emit", targetType: "floor", stacks: 3 } },
+  ],
+  [
+    { x: 0, y: 0, affinity: { kind: "water", expression: "emit", targetType: "floor", stacks: 3 } },
+    { x: 0, y: 0, affinity: { kind: "fire", expression: "emit", targetType: "floor", stacks: 2 } },
+  ],
+];
+
+let refStackAscii = null;
+let refStackPixel = null;
+
+mixedStackTraps.forEach((traps, permIndex) => {
+  const result = buildLevelRenderArtifactsFromTiles(tiles, {
+    includeAscii: true,
+    includeImage: true,
+    floorAffinityTraps: traps,
+  });
+  assert.equal(result.ok, true);
+  // Water at stacks=3 should win (higher stacks). Uppercase "W"
+  assert.equal(result.ascii.lines[0][0], "W",
+    "mixed-stacks perm " + permIndex + ": higher-stacks water should win");
+
+  const pixel = Array.from(result.image.pixels.slice(0, 4));
+  if (permIndex === 0) {
+    refStackAscii = result.ascii.lines[0][0];
+    refStackPixel = pixel;
+  } else {
+    assert.equal(result.ascii.lines[0][0], refStackAscii,
+      "mixed-stacks perm " + permIndex + ": ASCII must match");
+    assert.deepStrictEqual(pixel, refStackPixel,
+      "mixed-stacks perm " + permIndex + ": pixel must match");
+  }
+});
+`;
+
+  runEsm(script);
+});
+
 test("guidance level builder maps room cards into level generation inputs", () => {
   const script = `
 import assert from "node:assert/strict";

--- a/tests/personas/configurator-guidance-level-builder.test.js
+++ b/tests/personas/configurator-guidance-level-builder.test.js
@@ -53,6 +53,21 @@ assert.equal(fromTiles.height, 2);
 assert.equal(fromTiles.walkableTiles, 5);
 assert.ok(fromTiles.image && fromTiles.image.pixels instanceof Uint8ClampedArray);
 
+const fromAffinityTiles = buildLevelRenderArtifactsFromTiles(["..."], {
+  includeAscii: true,
+  includeImage: true,
+  floorAffinityTraps: [
+    { x: 0, y: 0, affinity: { kind: "fire", expression: "emit", targetType: "floor", stacks: 1 } },
+    { x: 1, y: 0, affinity: { kind: "fire", expression: "emit", targetType: "floor", stacks: 1, roomStacks: 3 } },
+  ],
+});
+assert.equal(fromAffinityTiles.ok, true);
+assert.equal(fromAffinityTiles.ascii.lines[0][0], "f");
+assert.equal(fromAffinityTiles.ascii.lines[0][1], "F");
+const lowStackPixel = Array.from(fromAffinityTiles.image.pixels.slice(0, 4));
+const highStackPixel = Array.from(fromAffinityTiles.image.pixels.slice(4, 8));
+assert.notDeepEqual(lowStackPixel, highStackPixel);
+
 const invalidPreview = buildLevelPreviewFromGuidanceSummary(null);
 assert.equal(invalidPreview.ok, false);
 assert.equal(invalidPreview.reason, "missing_summary");

--- a/tests/runtime/affinity-palette.test.js
+++ b/tests/runtime/affinity-palette.test.js
@@ -1,0 +1,170 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AFFINITY_COLOR_HEX,
+  STACK_INTENSITY_TIERS,
+  hexToRgba,
+  normalizeHex,
+  resolveStackIntensity,
+  getAffinityRgba,
+  validateAffinityPalette,
+} from "../../packages/runtime/src/render/affinity-palette.js";
+import { AFFINITY_KINDS } from "../../packages/runtime/src/contracts/domain-constants.js";
+
+describe("affinity-palette", () => {
+  describe("AFFINITY_COLOR_HEX", () => {
+    it("should define a hex color for every canonical affinity kind", () => {
+      AFFINITY_KINDS.forEach((kind) => {
+        assert.ok(
+          AFFINITY_COLOR_HEX[kind],
+          `Missing palette entry for affinity kind: ${kind}`,
+        );
+        assert.match(
+          AFFINITY_COLOR_HEX[kind],
+          /^#[0-9a-f]{6}$/i,
+          `Invalid hex color for ${kind}: ${AFFINITY_COLOR_HEX[kind]}`,
+        );
+      });
+    });
+
+    it("should have exactly 10 affinity entries", () => {
+      assert.equal(Object.keys(AFFINITY_COLOR_HEX).length, 10);
+    });
+
+    it("should provide the expected colors for key affinities", () => {
+      assert.equal(AFFINITY_COLOR_HEX.fire, "#f05a28");
+      assert.equal(AFFINITY_COLOR_HEX.water, "#2b7fff");
+      assert.equal(AFFINITY_COLOR_HEX.light, "#f5d14d");
+      assert.equal(AFFINITY_COLOR_HEX.dark, "#3a2a57");
+    });
+  });
+
+  describe("STACK_INTENSITY_TIERS", () => {
+    it("should define at least 3 intensity tiers", () => {
+      assert.ok(STACK_INTENSITY_TIERS.length >= 3);
+    });
+
+    it("should have increasing saturation and decreasing lightness", () => {
+      for (let i = 1; i < STACK_INTENSITY_TIERS.length; i += 1) {
+        const prev = STACK_INTENSITY_TIERS[i - 1];
+        const curr = STACK_INTENSITY_TIERS[i];
+        assert.ok(
+          curr.sat >= prev.sat,
+          `Stack tier ${i} saturation should be >= tier ${i - 1}`,
+        );
+        assert.ok(
+          curr.light <= prev.light,
+          `Stack tier ${i} lightness should be <= tier ${i - 1}`,
+        );
+      }
+    });
+
+    it("should have glow values that increase or stay constant", () => {
+      for (let i = 1; i < STACK_INTENSITY_TIERS.length; i += 1) {
+        const prev = STACK_INTENSITY_TIERS[i - 1];
+        const curr = STACK_INTENSITY_TIERS[i];
+        assert.ok(
+          curr.glow >= prev.glow,
+          `Stack tier ${i} glow should be >= tier ${i - 1}`,
+        );
+      }
+    });
+  });
+
+  describe("hexToRgba", () => {
+    it("should convert valid hex to RGBA", () => {
+      const rgba = hexToRgba("#f05a28");
+      assert.deepEqual(rgba, [240, 90, 40, 255]);
+    });
+
+    it("should apply custom alpha", () => {
+      const rgba = hexToRgba("#f05a28", 128);
+      assert.deepEqual(rgba, [240, 90, 40, 128]);
+    });
+
+    it("should fallback to black for invalid hex", () => {
+      const rgba = hexToRgba("invalid");
+      assert.deepEqual(rgba, [0, 0, 0, 255]);
+    });
+  });
+
+  describe("normalizeHex", () => {
+    it("should return valid hex unchanged", () => {
+      assert.equal(normalizeHex("#f05a28", "#000000"), "#f05a28");
+    });
+
+    it("should normalize uppercase to lowercase", () => {
+      assert.equal(normalizeHex("#F05A28", "#000000"), "#f05a28");
+    });
+
+    it("should return fallback for invalid hex", () => {
+      assert.equal(normalizeHex("not-a-color", "#ffffff"), "#ffffff");
+      assert.equal(normalizeHex("#fff", "#ffffff"), "#ffffff");
+    });
+  });
+
+  describe("resolveStackIntensity", () => {
+    it("should return tier1 for stack count 1", () => {
+      const result = resolveStackIntensity(1);
+      assert.equal(result.sat, 55);
+      assert.equal(result.light, 55);
+      assert.equal(result.glow, 0);
+      assert.equal(result.stacks, 1);
+    });
+
+    it("should return tier2 for stack count 2", () => {
+      const result = resolveStackIntensity(2);
+      assert.equal(result.sat, 65);
+      assert.equal(result.light, 50);
+      assert.equal(result.glow, 4);
+      assert.equal(result.stacks, 2);
+    });
+
+    it("should return tier3 for stack count 3", () => {
+      const result = resolveStackIntensity(3);
+      assert.equal(result.sat, 75);
+      assert.equal(result.light, 45);
+      assert.equal(result.glow, 6);
+      assert.equal(result.stacks, 3);
+    });
+
+    it("should cap at highest tier for stack count >= 4", () => {
+      const result = resolveStackIntensity(10);
+      assert.equal(result.sat, 85);
+      assert.equal(result.light, 40);
+      assert.equal(result.glow, 8);
+      assert.equal(result.stacks, 10);
+    });
+
+    it("should normalize non-integer stacks to nearest positive integer", () => {
+      assert.equal(resolveStackIntensity(2.7).stacks, 3);
+      assert.equal(resolveStackIntensity(0).stacks, 1);
+      assert.equal(resolveStackIntensity(-5).stacks, 1);
+    });
+  });
+
+  describe("getAffinityRgba", () => {
+    it("should return RGBA for valid affinity kind", () => {
+      const rgba = getAffinityRgba("fire");
+      assert.deepEqual(rgba, [240, 90, 40, 255]);
+    });
+
+    it("should apply custom alpha", () => {
+      const rgba = getAffinityRgba("water", 128);
+      assert.equal(rgba[3], 128);
+    });
+
+    it("should fallback to white for unknown affinity kind", () => {
+      const rgba = getAffinityRgba("unknown");
+      assert.deepEqual(rgba, [255, 255, 255, 255]);
+    });
+  });
+
+  describe("validateAffinityPalette", () => {
+    it("should pass validation for complete palette", () => {
+      const result = validateAffinityPalette();
+      assert.equal(result.ok, true);
+      assert.equal(result.missing.length, 0);
+    });
+  });
+});

--- a/tests/ui-web/simulation-view.test.mjs
+++ b/tests/ui-web/simulation-view.test.mjs
@@ -76,3 +76,12 @@ test("simulation canvas hit-testing translates viewport-local tile positions bac
   assert.deepEqual(resolveCanvasBoardPosition({ x: 1, y: 1 }, null), { x: 1, y: 1 });
   assert.equal(resolveCanvasBoardPosition(null, { viewport: { startX: 4, startY: 7 } }), null);
 });
+
+test("simulation view forwards observation traps into level regeneration render options", () => {
+  const viewPath = path.resolve(root, "packages", "ui-web", "src", "views", "simulation-view.js");
+  const source = fs.readFileSync(viewPath, "utf8");
+  assert.match(
+    source,
+    /regenerateLevelArtifacts\(\{\s*tiles:\s*baseTiles,\s*renderOptions:\s*\{\s*floorAffinityTraps:/s,
+  );
+});


### PR DESCRIPTION
## Summary
- add shared affinity palette and stack-intensity-driven room visuals to generated ASCII and image outputs
- restore ResourceBundleArtifact contract and manifest parity for build-to-run resource bundle flow
- align mixed-affinity tie-break behavior across preview and runtime and add permutation-invariance test coverage

## Verification
- node --test tests/personas/configurator-guidance-level-builder.test.js
- node --test tests/adapters-web/adapter-modules.test.js
- node --test tests/ui-web/simulation-view.test.mjs
- node --test tests/adapters-cli/ak-build.test.js
- node --test tests/runtime/build-orchestrator.test.js
- node --test tests/runtime/resource-bundle.test.js