### PR TITLE
Resolve merge conflicts and implement room affinity tile trap generation

### DIFF
--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -8,6 +8,7 @@ import { createLlmAdapter } from "../adapters/llm/index.js";
 import { createCommandKernel } from "../../../runtime/src/commands/kernel.js";
 import { instantiateCommandRuntimeCoreFromBuffer } from "../../../runtime/src/commands/wasm-core.js";
 import { orchestrateBuild } from "../../../runtime/src/build/orchestrate-build.js";
+import { summarizeMixedRoomAssemblies, formatMixedRoomAssembliesCliLines } from "../../../runtime/src/build/mixed-room-summary.js";
 import { buildBuildTelemetryRecord } from "../../../runtime/src/build/telemetry.js";
 import { createSchemaCatalog, filterSchemaCatalogEntries } from "../../../runtime/src/contracts/schema-catalog.js";
 import { buildBuildSpecFromSummary } from "../../../runtime/src/personas/director/buildspec-assembler.js";
@@ -912,7 +913,6 @@ function buildArtifactRefs(entries) {
   }));
 }
 
-<<<<<<< HEAD
 function attachMixedRoomAssembliesToBuildResult(buildResult) {
   const assemblies = summarizeMixedRoomAssemblies(buildResult?.simConfig?.layout?.data?.rooms);
   if (buildResult?.affinitySummary && typeof buildResult.affinitySummary === "object") {
@@ -931,8 +931,6 @@ function logMixedRoomAssembliesFromBuildResult(buildResult) {
   });
 }
 
-=======
->>>>>>> dc4cca0 (.)
 async function loadCoreFromWasm(wasmPath) {
   const buffer = await readFile(wasmPath);
   return instantiateCommandRuntimeCoreFromBuffer(buffer);

--- a/packages/runtime/src/build/orchestrate-build.js
+++ b/packages/runtime/src/build/orchestrate-build.js
@@ -625,6 +625,33 @@ function collectMixedRoomTemplateTraps({
   return generated;
 }
 
+function buildCardAffinityProfiles(cardSet) {
+  if (!Array.isArray(cardSet) || cardSet.length === 0) return [];
+  const profiles = [];
+  cardSet.forEach((card) => {
+    const type = typeof card?.type === "string" ? card.type.trim().toLowerCase() : "";
+    const source = typeof card?.source === "string" ? card.source.trim().toLowerCase() : "";
+    if (type !== "room" && source !== "room") return;
+    const affinities = Array.isArray(card?.affinities) ? card.affinities : [];
+    const emitAffinities = affinities
+      .map((a) => {
+        const kind = normalizeAffinityKind(a?.kind);
+        if (!kind) return null;
+        const expression = typeof a?.expression === "string" ? a.expression.trim().toLowerCase() : "";
+        if (expression !== "emit") return null;
+        return { kind, stacks: Math.max(1, normalizePositiveInt(a.stacks, 1)) };
+      })
+      .filter(Boolean);
+    if (emitAffinities.length === 0) return;
+    const count = Math.max(1, normalizePositiveInt(card?.count, 1));
+    const templateId = typeof card?.id === "string" && card.id.trim() ? card.id.trim() : `card_room_${profiles.length + 1}`;
+    for (let i = 0; i < count; i += 1) {
+      profiles.push({ templateId, templateInstanceId: `${templateId}-${i + 1}`, emitAffinities });
+    }
+  });
+  return profiles;
+}
+
 function augmentLayoutWithRoomAffinityEffects(
   layout,
   {
@@ -639,11 +666,11 @@ function augmentLayoutWithRoomAffinityEffects(
   }
 
   const templateMap = buildMixedRoomTemplateMap(affinityRules || resolveAffinityRules());
-  if (templateMap.size === 0) {
-    return { layout, generatedTrapCount: 0 };
+  let profiles = templateMap.size > 0 ? buildMixedRoomProfilesFromCardSet(cardSet, templateMap) : [];
+  const useCardAffinityFallback = profiles.length === 0;
+  if (useCardAffinityFallback) {
+    profiles = buildCardAffinityProfiles(cardSet);
   }
-
-  const profiles = buildMixedRoomProfilesFromCardSet(cardSet, templateMap);
   if (profiles.length === 0) {
     return { layout, generatedTrapCount: 0 };
   }
@@ -693,6 +720,48 @@ function augmentLayoutWithRoomAffinityEffects(
     const profile = profiles[orderIndex % profiles.length];
     if (!profile) return;
     const room = nextRooms[roomIndex];
+
+    if (useCardAffinityFallback) {
+      const emitAffinities = Array.isArray(profile.emitAffinities) ? profile.emitAffinities : [];
+      const primaryKind = emitAffinities[0]?.kind;
+      const nextRoom = {
+        ...room,
+        templateId: profile.templateId,
+        templateInstanceId: profile.templateInstanceId,
+        affinity: primaryKind || (fallbackAffinityKind || room.affinity),
+        affinities: emitAffinities.map(({ kind, stacks }) => ({ kind, expression: "emit", stacks })),
+      };
+      nextRooms[roomIndex] = nextRoom;
+      const roomId = resolveRoomId(room, roomIndex);
+      emitAffinities.forEach(({ kind, stacks }) => {
+        for (let dy = 0; dy < nextRoom.height; dy += 1) {
+          let placed = false;
+          for (let dx = 0; dx < nextRoom.width; dx += 1) {
+            const tx = nextRoom.x + dx;
+            const ty = nextRoom.y + dy;
+            const key = `${tx},${ty}`;
+            if (key === spawnKey || key === exitKey || occupied.has(key)) continue;
+            const manaReserve = ROOM_AFFINITY_EMIT_PERCENT_PER_STACK * stacks;
+            generatedTraps.push({
+              id: `${kind}_emit_${roomIndex}`,
+              x: tx,
+              y: ty,
+              blocking: false,
+              source: "room_affinity_tile",
+              roomId,
+              affinity: { kind, expression: "emit", stacks: 1, targetType: "floor" },
+              vitals: { mana: { current: manaReserve, max: manaReserve, regen: 0 } },
+            });
+            occupied.add(key);
+            placed = true;
+            break;
+          }
+          if (placed) break;
+        }
+      });
+      return;
+    }
+
     const composition = buildMixedRoomComposition({
       room,
       templateId: profile.templateId,

--- a/packages/runtime/src/commands/kernel.js
+++ b/packages/runtime/src/commands/kernel.js
@@ -1,4 +1,5 @@
 import { orchestrateBuild } from "../build/orchestrate-build.js";
+import { summarizeMixedRoomAssemblies, formatMixedRoomAssembliesCliLines } from "../build/mixed-room-summary.js";
 import { buildBuildTelemetryRecord } from "../build/telemetry.js";
 import { filterSchemaCatalogEntries } from "../contracts/schema-catalog.js";
 import { buildBuildSpecFromSummary } from "../personas/director/buildspec-assembler.js";
@@ -786,12 +787,9 @@ export function createCommandKernel(host = {}) {
       await writeJson(join(outDir, "telemetry.json"), telemetry);
 
       log(`build: wrote ${outDir}`);
-<<<<<<< HEAD
       formatMixedRoomAssembliesCliLines(mixedRoomAssemblies).forEach((line) => {
         log(line);
       });
-=======
->>>>>>> dc4cca0 (.)
       return { outDir };
     } catch (error) {
       const message = error?.message || String(error);


### PR DESCRIPTION
## Summary

- **Resolve merge conflicts** in `ak-impl.mjs` and `kernel.js` — both files had unresolved `<<<<<<<`/`=======`/`>>>>>>>` markers that caused JavaScript syntax errors and 113 test failures. Kept the HEAD versions in both cases, preserving mixed room assembly logging.
- **Add missing import** — `ak-impl.mjs` referenced `summarizeMixedRoomAssemblies` and `formatMixedRoomAssembliesCliLines` without importing them from `mixed-room-summary.js`.
- **Implement `room_affinity_tile` trap generation** — commit `b624ba7` updated tests to expect traps generated directly from card emit affinities (source `"room_affinity_tile"`) and removed the old template-based approach from affinity rules, but did not update `orchestrate-build.js` to match. Added `buildCardAffinityProfiles` and a fallback path in `augmentLayoutWithRoomAffinityEffects` that:
  - Activates when no affinity rule templates are configured
  - Assigns `room.affinities` from card emit affinities, enabling warden affinity-based room placement
  - Generates one `room_affinity_tile` trap per room per emit affinity with `stacks: 1` and mana = `ROOM_AFFINITY_EMIT_PERCENT_PER_STACK × card_stacks`
  - Ensures trap counts flow into budget receipt `trap_basic` line items

## Test plan

- [x] All 462 tests pass (0 failures) after these changes
- [x] `cli room-plan writes budget receipt with room layout and room-affinity spend`
- [x] `orchestrateBuild maps room affinities to warden placement and tile emit traps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)