### PR TITLE
Fix room affinity tile placement and multi-stack spreading

### DIFF
--- a/packages/runtime/src/build/orchestrate-build.js
+++ b/packages/runtime/src/build/orchestrate-build.js
@@ -735,30 +735,30 @@ function augmentLayoutWithRoomAffinityEffects(
       nextRooms[roomIndex] = nextRoom;
       const roomId = resolveRoomId(room, roomIndex);
       emitAffinities.forEach(({ kind, stacks }) => {
+        const candidates = [];
         for (let dy = 0; dy < nextRoom.height; dy += 1) {
-          let placed = false;
           for (let dx = 0; dx < nextRoom.width; dx += 1) {
             const tx = nextRoom.x + dx;
             const ty = nextRoom.y + dy;
             const key = `${tx},${ty}`;
             if (key === spawnKey || key === exitKey || occupied.has(key)) continue;
-            const manaReserve = ROOM_AFFINITY_EMIT_PERCENT_PER_STACK * stacks;
-            generatedTraps.push({
-              id: `${kind}_emit_${roomIndex}`,
-              x: tx,
-              y: ty,
-              blocking: false,
-              source: "room_affinity_tile",
-              roomId,
-              affinity: { kind, expression: "emit", stacks: 1, targetType: "floor" },
-              vitals: { mana: { current: manaReserve, max: manaReserve, regen: 0 } },
-            });
-            occupied.add(key);
-            placed = true;
-            break;
+            candidates.push({ x: tx, y: ty });
           }
-          if (placed) break;
         }
+        if (candidates.length === 0) return;
+        const chosen = candidates[Math.floor(assignmentRng() * candidates.length)];
+        const manaReserve = ROOM_AFFINITY_EMIT_PERCENT_PER_STACK * stacks;
+        generatedTraps.push({
+          id: `${kind}_emit_${roomIndex}`,
+          x: chosen.x,
+          y: chosen.y,
+          blocking: false,
+          source: "room_affinity_tile",
+          roomId,
+          affinity: { kind, expression: "emit", stacks, targetType: "floor" },
+          vitals: { mana: { current: manaReserve, max: manaReserve, regen: 0 } },
+        });
+        occupied.add(`${chosen.x},${chosen.y}`);
       });
       return;
     }

--- a/packages/runtime/src/personas/configurator/guidance-level-builder.js
+++ b/packages/runtime/src/personas/configurator/guidance-level-builder.js
@@ -126,6 +126,36 @@ function upsertAffinityCell(index, x, y, affinity, { width, height }) {
   }
 }
 
+const CARDINAL_DELTAS = Object.freeze([
+  { dx: 0, dy: -1 },
+  { dx: 1, dy: 0 },
+  { dx: 0, dy: 1 },
+  { dx: -1, dy: 0 },
+]);
+
+function spreadAffinityToNeighbors(index, originX, originY, affinity, bounds) {
+  const queue = [{ x: originX, y: originY, remainingStacks: affinity.stacks - 1 }];
+  const visited = new Set([`${originX},${originY}`]);
+  let head = 0;
+  while (head < queue.length) {
+    const current = queue[head];
+    head += 1;
+    if (current.remainingStacks <= 0) continue;
+    for (const delta of CARDINAL_DELTAS) {
+      const nx = current.x + delta.dx;
+      const ny = current.y + delta.dy;
+      const key = `${nx},${ny}`;
+      if (visited.has(key)) continue;
+      visited.add(key);
+      if (nx < 0 || nx >= bounds.width || ny < 0 || ny >= bounds.height) continue;
+      upsertAffinityCell(index, nx, ny, { kind: affinity.kind, stacks: current.remainingStacks }, bounds);
+      if (current.remainingStacks > 1) {
+        queue.push({ x: nx, y: ny, remainingStacks: current.remainingStacks - 1 });
+      }
+    }
+  }
+}
+
 function buildFloorAffinityByCell({ width, height, floorAffinityCells = null, floorAffinityTraps = null } = {}) {
   const index = new Map();
   if (Array.isArray(floorAffinityCells)) {
@@ -144,6 +174,9 @@ function buildFloorAffinityByCell({ width, height, floorAffinityCells = null, fl
       const affinity = resolveTrapAffinityEntry(trap);
       if (!position || !affinity) return;
       upsertAffinityCell(index, position.x, position.y, affinity, { width, height });
+      if (affinity.stacks > 1) {
+        spreadAffinityToNeighbors(index, position.x, position.y, affinity, { width, height });
+      }
     });
   }
   return index;


### PR DESCRIPTION
## Summary
- Fixed room affinity tile placement to use randomized candidate selection instead of sequential placement
- Implemented BFS-based affinity spreading for tiles with multiple stacks
- Corrected stacks field to use actual value instead of hardcoded 1

## Changes
- `orchestrate-build.js`: Refactored emit tile placement to collect all valid candidates and randomly select one using `assignmentRng()`
- `guidance-level-builder.js`: Added `spreadAffinityToNeighbors()` function to propagate affinity stacks to neighboring cells in a breadth-first manner

## Test plan
- [ ] Verify room affinity tiles are placed randomly across valid floor tiles
- [ ] Confirm multi-stack affinity tiles correctly spread to neighbors
- [ ] Validate that spawn, exit, and occupied tiles are excluded from placement
- [ ] Check that affinity stacks decrease correctly with distance from origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)