### PR TITLE
Fix room affinity tile placement and add 8-direction spreading

### DIFF
--- a/packages/runtime/src/build/orchestrate-build.js
+++ b/packages/runtime/src/build/orchestrate-build.js
@@ -735,30 +735,30 @@ function augmentLayoutWithRoomAffinityEffects(
       nextRooms[roomIndex] = nextRoom;
       const roomId = resolveRoomId(room, roomIndex);
       emitAffinities.forEach(({ kind, stacks }) => {
+        const candidates = [];
         for (let dy = 0; dy < nextRoom.height; dy += 1) {
-          let placed = false;
           for (let dx = 0; dx < nextRoom.width; dx += 1) {
             const tx = nextRoom.x + dx;
             const ty = nextRoom.y + dy;
             const key = `${tx},${ty}`;
             if (key === spawnKey || key === exitKey || occupied.has(key)) continue;
-            const manaReserve = ROOM_AFFINITY_EMIT_PERCENT_PER_STACK * stacks;
-            generatedTraps.push({
-              id: `${kind}_emit_${roomIndex}`,
-              x: tx,
-              y: ty,
-              blocking: false,
-              source: "room_affinity_tile",
-              roomId,
-              affinity: { kind, expression: "emit", stacks: 1, targetType: "floor" },
-              vitals: { mana: { current: manaReserve, max: manaReserve, regen: 0 } },
-            });
-            occupied.add(key);
-            placed = true;
-            break;
+            candidates.push({ x: tx, y: ty });
           }
-          if (placed) break;
         }
+        if (candidates.length === 0) return;
+        const chosen = candidates[Math.floor(assignmentRng() * candidates.length)];
+        const manaReserve = ROOM_AFFINITY_EMIT_PERCENT_PER_STACK * stacks;
+        generatedTraps.push({
+          id: `${kind}_emit_${roomIndex}`,
+          x: chosen.x,
+          y: chosen.y,
+          blocking: false,
+          source: "room_affinity_tile",
+          roomId,
+          affinity: { kind, expression: "emit", stacks, targetType: "floor" },
+          vitals: { mana: { current: manaReserve, max: manaReserve, regen: 0 } },
+        });
+        occupied.add(`${chosen.x},${chosen.y}`);
       });
       return;
     }

--- a/packages/runtime/src/personas/configurator/guidance-level-builder.js
+++ b/packages/runtime/src/personas/configurator/guidance-level-builder.js
@@ -126,6 +126,36 @@ function upsertAffinityCell(index, x, y, affinity, { width, height }) {
   }
 }
 
+const CARDINAL_DELTAS = Object.freeze([
+  { dx: 0, dy: -1 },
+  { dx: 1, dy: 0 },
+  { dx: 0, dy: 1 },
+  { dx: -1, dy: 0 },
+]);
+
+function spreadAffinityToNeighbors(index, originX, originY, affinity, bounds) {
+  const queue = [{ x: originX, y: originY, remainingStacks: affinity.stacks - 1 }];
+  const visited = new Set([`${originX},${originY}`]);
+  let head = 0;
+  while (head < queue.length) {
+    const current = queue[head];
+    head += 1;
+    if (current.remainingStacks <= 0) continue;
+    for (const delta of CARDINAL_DELTAS) {
+      const nx = current.x + delta.dx;
+      const ny = current.y + delta.dy;
+      const key = `${nx},${ny}`;
+      if (visited.has(key)) continue;
+      visited.add(key);
+      if (nx < 0 || nx >= bounds.width || ny < 0 || ny >= bounds.height) continue;
+      upsertAffinityCell(index, nx, ny, { kind: affinity.kind, stacks: current.remainingStacks }, bounds);
+      if (current.remainingStacks > 1) {
+        queue.push({ x: nx, y: ny, remainingStacks: current.remainingStacks - 1 });
+      }
+    }
+  }
+}
+
 function buildFloorAffinityByCell({ width, height, floorAffinityCells = null, floorAffinityTraps = null } = {}) {
   const index = new Map();
   if (Array.isArray(floorAffinityCells)) {
@@ -144,6 +174,9 @@ function buildFloorAffinityByCell({ width, height, floorAffinityCells = null, fl
       const affinity = resolveTrapAffinityEntry(trap);
       if (!position || !affinity) return;
       upsertAffinityCell(index, position.x, position.y, affinity, { width, height });
+      if (affinity.stacks > 1) {
+        spreadAffinityToNeighbors(index, position.x, position.y, affinity, { width, height });
+      }
     });
   }
   return index;

--- a/packages/runtime/src/personas/configurator/guidance-level-builder.js
+++ b/packages/runtime/src/personas/configurator/guidance-level-builder.js
@@ -126,11 +126,15 @@ function upsertAffinityCell(index, x, y, affinity, { width, height }) {
   }
 }
 
-const CARDINAL_DELTAS = Object.freeze([
-  { dx: 0, dy: -1 },
-  { dx: 1, dy: 0 },
-  { dx: 0, dy: 1 },
-  { dx: -1, dy: 0 },
+const NEIGHBOR_DELTAS = Object.freeze([
+  { dx: 0, dy: -1 },   // N
+  { dx: 1, dy: -1 },   // NE
+  { dx: 1, dy: 0 },    // E
+  { dx: 1, dy: 1 },    // SE
+  { dx: 0, dy: 1 },    // S
+  { dx: -1, dy: 1 },   // SW
+  { dx: -1, dy: 0 },   // W
+  { dx: -1, dy: -1 },  // NW
 ]);
 
 function spreadAffinityToNeighbors(index, originX, originY, affinity, bounds) {
@@ -141,7 +145,7 @@ function spreadAffinityToNeighbors(index, originX, originY, affinity, bounds) {
     const current = queue[head];
     head += 1;
     if (current.remainingStacks <= 0) continue;
-    for (const delta of CARDINAL_DELTAS) {
+    for (const delta of NEIGHBOR_DELTAS) {
       const nx = current.x + delta.dx;
       const ny = current.y + delta.dy;
       const key = `${nx},${ny}`;

--- a/tests/personas/configurator-guidance-level-builder.test.js
+++ b/tests/personas/configurator-guidance-level-builder.test.js
@@ -62,8 +62,13 @@ const fromAffinityTiles = buildLevelRenderArtifactsFromTiles(["..."], {
   ],
 });
 assert.equal(fromAffinityTiles.ok, true);
-assert.equal(fromAffinityTiles.ascii.lines[0][0], "f");
+// With spreading: trap at [1,0] has roomStacks:3 which spreads to neighbors [0,0] and [2,0] with stacks:2
+// [0,0]: direct stacks 1 is overridden by spread stacks 2 → 'F'
+// [1,0]: direct stacks 3 (from roomStacks) → 'F'
+// [2,0]: spread stacks 2 → 'F'
+assert.equal(fromAffinityTiles.ascii.lines[0][0], "F");
 assert.equal(fromAffinityTiles.ascii.lines[0][1], "F");
+assert.equal(fromAffinityTiles.ascii.lines[0][2], "F");
 const lowStackPixel = Array.from(fromAffinityTiles.image.pixels.slice(0, 4));
 const highStackPixel = Array.from(fromAffinityTiles.image.pixels.slice(4, 8));
 assert.notDeepEqual(lowStackPixel, highStackPixel);


### PR DESCRIPTION
## Summary
- Fix room affinity tiles always being placed at top-left corner of rooms
- Implement multi-stack affinity spreading to neighboring tiles
- Expand spreading to all 8 directions (cardinal + diagonal)

## Changes

### Random Placement (`orchestrate-build.js`)
**Before:** Affinity trap tiles were always placed at position (0,0) relative to room origin (top-left corner)

**After:** Traps are now placed at random valid positions within rooms using `assignmentRng` for deterministic randomness

**Impact:** Creates more varied and natural room layouts with affinity tiles distributed throughout rooms

### Multi-Stack Spreading (`guidance-level-builder.js`)
**Before:** Only the source tile was affected, regardless of stack value (e.g., water+2+emit only colored one tile)

**After:** When `stacks > 1`, the affinity effect spreads to all 8 neighbors using breadth-first search with diminishing intensity:
- Stacks 3 → spreads to 8 neighbors with stacks 2 → their neighbors get stacks 1
- Cardinal directions (N, E, S, W)
- Diagonal directions (NE, NW, SE, SW)

**Impact:** Higher-power affinity tiles now create radial influence zones that affect surrounding tiles

### Technical Details
- Spreading uses existing `upsertAffinityCell` logic - higher stacks always win when multiple affinities compete
- Fixed stacks value propagation (was hardcoded to 1, now uses actual affinity stacks)
- Added `spreadAffinityToNeighbors` function with BFS algorithm for radial spreading

## Test plan
- [x] Updated test expectations in `configurator-guidance-level-builder.test.js` to reflect spreading behavior
- [x] All configurator persona tests passing (10/10)
- [x] Verified 8-direction spreading logic with cardinal + diagonal neighbors

🤖 Generated with [Claude Code](https://claude.com/claude-code)