### PR TITLE
Add agent-friendly CLI for game object authoring

### DIFF
--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -828,6 +828,28 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function sanitizeFileSegment(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "capture";
+}
+
+function sanitizeFileName(value) {
+  return String(value || "")
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "_")
+    .replace(/^_+|_+$/g, "") || "capture";
+}
+
+function buildCapturedInputPath(adapter, index, outputRefId) {
+  if (isNonEmptyString(outputRefId)) {
+    return `${sanitizeFileName(outputRefId)}.json`;
+  }
+  return `captured-input-${sanitizeFileSegment(adapter)}-${index + 1}.json`;
+}
+
 function makeId(prefix) {
   const rand = Math.random().toString(36).slice(2, 8);
   return `${prefix}_${Date.now().toString(36)}_${rand}`;
@@ -1272,6 +1294,9 @@ async function writeBuildOutputs({
   if (buildResult.budgetReceipt) {
     await writeJson(join(outDir, "budget-receipt.json"), buildResult.budgetReceipt);
   }
+  if (buildResult.spendProposal) {
+    await writeJson(join(outDir, "spend-proposal.json"), buildResult.spendProposal);
+  }
   if (buildResult.solverRequest) {
     await writeJson(join(outDir, "solver-request.json"), buildResult.solverRequest);
   }
@@ -1284,6 +1309,24 @@ async function writeBuildOutputs({
   if (buildResult.initialState) {
     await writeJson(join(outDir, "initial-state.json"), buildResult.initialState);
   }
+  if (buildResult.affinitySummary) {
+    await writeJson(join(outDir, "affinity-summary.json"), buildResult.affinitySummary);
+  }
+  if (buildResult.resourceBundle) {
+    await writeJson(join(outDir, "resource-bundle.json"), buildResult.resourceBundle);
+  }
+
+  const capturedInputs = Array.isArray(buildResult.capturedInputs) ? buildResult.capturedInputs : [];
+  const capturedArtifacts = capturedInputs.map((entry, index) => {
+    const artifact = entry?.artifact || entry;
+    return {
+      artifact,
+      path: entry?.path || buildCapturedInputPath(artifact?.source?.adapter || "llm", index, artifact?.meta?.id),
+    };
+  });
+  for (const capture of capturedArtifacts) {
+    await writeJson(join(outDir, capture.path), capture.artifact);
+  }
 
   const bundleArtifacts = [requestArtifact];
   if (buildResult.intent) bundleArtifacts.push(buildResult.intent);
@@ -1291,10 +1334,14 @@ async function writeBuildOutputs({
   if (buildResult.budget?.budget) bundleArtifacts.push(buildResult.budget.budget);
   if (buildResult.budget?.priceList) bundleArtifacts.push(buildResult.budget.priceList);
   if (buildResult.budgetReceipt) bundleArtifacts.push(buildResult.budgetReceipt);
+  if (buildResult.spendProposal) bundleArtifacts.push(buildResult.spendProposal);
   if (buildResult.solverRequest) bundleArtifacts.push(buildResult.solverRequest);
   if (buildResult.solverResult) bundleArtifacts.push(buildResult.solverResult);
   if (buildResult.simConfig) bundleArtifacts.push(buildResult.simConfig);
   if (buildResult.initialState) bundleArtifacts.push(buildResult.initialState);
+  if (buildResult.affinitySummary) bundleArtifacts.push(buildResult.affinitySummary);
+  if (buildResult.resourceBundle) bundleArtifacts.push(buildResult.resourceBundle);
+  capturedArtifacts.forEach((capture) => bundleArtifacts.push(capture.artifact));
 
   bundleArtifacts.sort((a, b) => {
     if (a.schema === b.schema) {
@@ -1310,10 +1357,14 @@ async function writeBuildOutputs({
   addManifestEntry(manifestEntries, buildResult.budget?.budget, "budget.json");
   addManifestEntry(manifestEntries, buildResult.budget?.priceList, "price-list.json");
   addManifestEntry(manifestEntries, buildResult.budgetReceipt, "budget-receipt.json");
+  addManifestEntry(manifestEntries, buildResult.spendProposal, "spend-proposal.json");
   addManifestEntry(manifestEntries, buildResult.solverRequest, "solver-request.json");
   addManifestEntry(manifestEntries, buildResult.solverResult, "solver-result.json");
   addManifestEntry(manifestEntries, buildResult.simConfig, "sim-config.json");
   addManifestEntry(manifestEntries, buildResult.initialState, "initial-state.json");
+  addManifestEntry(manifestEntries, buildResult.affinitySummary, "affinity-summary.json");
+  addManifestEntry(manifestEntries, buildResult.resourceBundle, "resource-bundle.json");
+  capturedArtifacts.forEach((capture) => addManifestEntry(manifestEntries, capture.artifact, capture.path));
 
   manifestEntries.sort((a, b) => {
     if (a.schema === b.schema) {

--- a/packages/runtime/src/commands/ui-flow.js
+++ b/packages/runtime/src/commands/ui-flow.js
@@ -20,6 +20,14 @@ function normalizeArrayField(container, key) {
   return { changed: false };
 }
 
+function normalizeRepeatableField(container, key) {
+  if (!container || typeof container !== "object") return { changed: false };
+  const value = container[key];
+  if (value === undefined || Array.isArray(value)) return { changed: false };
+  container[key] = [value];
+  return { changed: true };
+}
+
 function normalizeAgentHints(hints) {
   if (!hints || typeof hints !== "object" || Array.isArray(hints)) return { changed: false };
   let changed = false;
@@ -62,6 +70,20 @@ export function normalizeBuildSpecForUi(specInput) {
   }
   if (spec.configurator?.inputs) {
     if (normalizeAgentHints(spec.configurator.inputs).changed) changed = true;
+  }
+  if (spec.authoring && typeof spec.authoring === "object" && !Array.isArray(spec.authoring)) {
+    if (normalizeRepeatableField(spec.authoring, "objectKinds").changed) changed = true;
+    const request = spec.authoring.request;
+    if (request && typeof request === "object" && !Array.isArray(request)) {
+      if (normalizeArrayField(request, "objects").changed) changed = true;
+      if (request.compilation && typeof request.compilation === "object" && !Array.isArray(request.compilation)) {
+        if (normalizeArrayField(request.compilation, "rules").changed) changed = true;
+        const rules = Array.isArray(request.compilation.rules) ? request.compilation.rules : [];
+        rules.forEach((rule) => {
+          if (normalizeArrayField(rule, "compileTo").changed) changed = true;
+        });
+      }
+    }
   }
 
   if (spec.budget && typeof spec.budget === "object" && !Array.isArray(spec.budget)) {

--- a/packages/runtime/src/contracts/artifacts.ts
+++ b/packages/runtime/src/contracts/artifacts.ts
@@ -92,6 +92,105 @@ export interface CapturedInputArtifactV1 {
 export type CapturedInputArtifact = CapturedInputArtifactV1;
 
 // -------------------------
+// Agent authoring contract
+// -------------------------
+
+export const AGENT_COMMAND_REQUEST_SCHEMA = "agent-kernel/AgentCommandRequestArtifact";
+
+export type AgentCommandAction = "author" | "configure";
+export type AgentCommandObjectKind =
+  | "room"
+  | "floor_tile"
+  | "trap"
+  | "delver"
+  | "warden"
+  | "shared_config";
+export type AgentCommandCompileTarget =
+  | "build_spec_intent"
+  | "build_spec_plan"
+  | "build_spec_configurator"
+  | "artifact_extension";
+
+export interface AgentCommandObjectRequestV1 {
+  /** Canonical authored object kind. */
+  kind: AgentCommandObjectKind;
+  /** Original text span or normalized object prompt for this authored object. */
+  prompt: string;
+  /** Optional stable id for updates/reconfiguration flows. */
+  id?: string;
+  /** Optional object multiplicity for additive authoring. */
+  count?: number;
+  /** Optional object-specific structured attributes. */
+  attributes?: Record<string, unknown>;
+}
+
+export interface AgentCommandCompilationRouteV1 {
+  /** Downstream compilation target for this object kind. */
+  target: AgentCommandCompileTarget;
+  /** Dot path in BuildSpec/configurator payloads when target is build_spec_* . */
+  path?: string;
+  /** Schema name for additive artifacts when target is artifact_extension. */
+  artifactSchema?: string;
+  /** Existing additive flow that already satisfies this route. */
+  legacyFlow?: string;
+}
+
+export interface AgentCommandCompilationRuleV1 {
+  /** Authored object kind governed by this rule. */
+  kind: AgentCommandObjectKind;
+  /** Ordered compilation routes for this kind. */
+  compileTo: AgentCommandCompilationRouteV1[];
+  /** Optional implementor notes for later parser/mapper work. */
+  notes?: string[];
+}
+
+export interface AgentCommandSharedConfigV1 extends Record<string, unknown> {
+  dungeonAffinity?: string;
+  budgetTokens?: number;
+  levelSize?: string;
+  roomCount?: number;
+}
+
+export interface AgentCommandCompatibilityV1 {
+  /** Contract is additive and must preserve existing direct commands. */
+  preserveExistingCommands?: boolean;
+  /** Existing commands/flows that remain supported during rollout. */
+  supportedLegacyFlows?: string[];
+  /** Optional notes for migration/backward compatibility. */
+  notes?: string[];
+}
+
+export interface AgentCommandRequestArtifactV1 {
+  schema: typeof AGENT_COMMAND_REQUEST_SCHEMA;
+  schemaVersion: 1;
+  meta: ArtifactMeta;
+
+  /** Canonical agent-originated authoring command. */
+  command: {
+    action: AgentCommandAction;
+    text: string;
+    source: string;
+    taxonomyVersion: 1;
+  };
+
+  /** Normalized authored objects extracted from the command text. */
+  objects: AgentCommandObjectRequestV1[];
+
+  /** Optional shared configuration that applies across authored objects. */
+  sharedConfig?: AgentCommandSharedConfigV1;
+
+  /** Explicit compilation mapping for each authored object kind. */
+  compilation: {
+    rules: AgentCommandCompilationRuleV1[];
+  };
+
+  /** Explicit backward compatibility expectations for current flows. */
+  compatibility?: AgentCommandCompatibilityV1;
+}
+
+export type AgentCommandRequestArtifact = AgentCommandRequestArtifactV1;
+
+// -------------------------
 // Build spec intake (CLI/UI)
 // -------------------------
 
@@ -155,6 +254,15 @@ export interface BuildSpecAgentHintsV1 extends Record<string, unknown> {
   actorGroups?: BuildSpecActorGroupHintV1[];
 }
 
+export interface BuildSpecAuthoringV1 {
+  /** Optional reference to the canonical agent command request. */
+  requestRef?: ArtifactRef;
+  /** Optional inline request for self-contained build specs. */
+  request?: AgentCommandRequestArtifact;
+  /** Canonical object kinds represented by this spec. */
+  objectKinds?: AgentCommandObjectKind[];
+}
+
 /**
  * Agent-facing build spec that feeds the CLI/UI.
  * The agent translates informal prompts into this structured format.
@@ -180,6 +288,9 @@ export interface BuildSpecV1 {
   configurator?: {
     inputs?: BuildSpecAgentHintsV1;
   };
+
+  /** Optional normalized authoring provenance for agent-authored requests. */
+  authoring?: BuildSpecAuthoringV1;
 
   /** Optional budget inputs (refs or inline artifacts). */
   budget?: {

--- a/packages/runtime/src/contracts/build-spec.js
+++ b/packages/runtime/src/contracts/build-spec.js
@@ -1,9 +1,25 @@
 export const BUILD_SPEC_SCHEMA = "agent-kernel/BuildSpec";
 export const BUILD_SPEC_SCHEMA_VERSION = 1;
+export const AGENT_COMMAND_REQUEST_SCHEMA = "agent-kernel/AgentCommandRequestArtifact";
 
 const BUDGET_SCHEMA = "agent-kernel/BudgetArtifact";
 const PRICE_LIST_SCHEMA = "agent-kernel/PriceList";
 const BUDGET_RECEIPT_SCHEMA = "agent-kernel/BudgetReceiptArtifact";
+const AGENT_COMMAND_ACTIONS = new Set(["author", "configure"]);
+const AGENT_COMMAND_OBJECT_KINDS = new Set([
+  "room",
+  "floor_tile",
+  "trap",
+  "delver",
+  "warden",
+  "shared_config",
+]);
+const AGENT_COMMAND_COMPILE_TARGETS = new Set([
+  "build_spec_intent",
+  "build_spec_plan",
+  "build_spec_configurator",
+  "artifact_extension",
+]);
 
 function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -61,6 +77,15 @@ function validateOptionalNumber(value, path, errors) {
   }
   if (!Number.isFinite(value)) {
     addError(errors, path, "expected number");
+  }
+}
+
+function validateOptionalBoolean(value, path, errors) {
+  if (value === undefined) {
+    return;
+  }
+  if (typeof value !== "boolean") {
+    addError(errors, path, "expected boolean");
   }
 }
 
@@ -152,6 +177,218 @@ function validateAgentHints(value, path, errors) {
   validateActorGroupHints(value.actorGroups, `${path}.actorGroups`, errors);
 }
 
+function validateArtifactMeta(value, path, errors) {
+  if (!isObject(value)) {
+    addError(errors, path, "expected object");
+    return;
+  }
+  if (!isNonEmptyString(value.id)) {
+    addError(errors, `${path}.id`, "expected non-empty string");
+  }
+  if (!isNonEmptyString(value.runId)) {
+    addError(errors, `${path}.runId`, "expected non-empty string");
+  }
+  if (!isNonEmptyString(value.createdAt)) {
+    addError(errors, `${path}.createdAt`, "expected non-empty string");
+  }
+  if (!isNonEmptyString(value.producedBy)) {
+    addError(errors, `${path}.producedBy`, "expected non-empty string");
+  }
+}
+
+function validateAgentCommandObjectKind(value, path, errors) {
+  if (!isNonEmptyString(value) || !AGENT_COMMAND_OBJECT_KINDS.has(value)) {
+    addError(
+      errors,
+      path,
+      `expected one of ${Array.from(AGENT_COMMAND_OBJECT_KINDS).join(", ")}`,
+    );
+  }
+}
+
+function validateAgentCommandObject(value, path, errors) {
+  if (!isObject(value)) {
+    addError(errors, path, "expected object");
+    return;
+  }
+  validateAgentCommandObjectKind(value.kind, `${path}.kind`, errors);
+  if (!isNonEmptyString(value.prompt)) {
+    addError(errors, `${path}.prompt`, "expected non-empty string");
+  }
+  validateOptionalString(value.id, `${path}.id`, errors);
+  validateOptionalNumber(value.count, `${path}.count`, errors);
+  if (value.attributes !== undefined && !isObject(value.attributes)) {
+    addError(errors, `${path}.attributes`, "expected object");
+  }
+}
+
+function validateAgentCommandRoute(value, path, errors) {
+  if (!isObject(value)) {
+    addError(errors, path, "expected object");
+    return;
+  }
+  if (!isNonEmptyString(value.target) || !AGENT_COMMAND_COMPILE_TARGETS.has(value.target)) {
+    addError(
+      errors,
+      `${path}.target`,
+      `expected one of ${Array.from(AGENT_COMMAND_COMPILE_TARGETS).join(", ")}`,
+    );
+  }
+  validateOptionalString(value.path, `${path}.path`, errors);
+  validateOptionalString(value.artifactSchema, `${path}.artifactSchema`, errors);
+  validateOptionalString(value.legacyFlow, `${path}.legacyFlow`, errors);
+  if (value.target === "artifact_extension" && !isNonEmptyString(value.artifactSchema)) {
+    addError(errors, `${path}.artifactSchema`, "expected non-empty string for artifact_extension");
+  }
+  if (value.target !== "artifact_extension" && value.path !== undefined && !isNonEmptyString(value.path)) {
+    addError(errors, `${path}.path`, "expected non-empty string");
+  }
+}
+
+function validateAgentCommandCompilation(value, path, errors, expectedKinds = []) {
+  if (!isObject(value)) {
+    addError(errors, path, "expected object");
+    return;
+  }
+  if (!Array.isArray(value.rules) || value.rules.length === 0) {
+    addError(errors, `${path}.rules`, "expected non-empty array");
+    return;
+  }
+  const seenKinds = new Set();
+  value.rules.forEach((rule, index) => {
+    const basePath = `${path}.rules[${index}]`;
+    if (!isObject(rule)) {
+      addError(errors, basePath, "expected object");
+      return;
+    }
+    validateAgentCommandObjectKind(rule.kind, `${basePath}.kind`, errors);
+    if (!Array.isArray(rule.compileTo) || rule.compileTo.length === 0) {
+      addError(errors, `${basePath}.compileTo`, "expected non-empty array");
+    } else {
+      rule.compileTo.forEach((route, routeIndex) => {
+        validateAgentCommandRoute(route, `${basePath}.compileTo[${routeIndex}]`, errors);
+      });
+    }
+    validateStringArray(rule.notes, `${basePath}.notes`, errors);
+    if (isNonEmptyString(rule.kind)) {
+      seenKinds.add(rule.kind);
+    }
+  });
+  expectedKinds.forEach((kind) => {
+    if (!seenKinds.has(kind)) {
+      addError(errors, `${path}.rules`, `missing compilation rule for ${kind}`);
+    }
+  });
+}
+
+function validateAgentCommandSharedConfig(value, path, errors) {
+  if (value === undefined) {
+    return;
+  }
+  if (!isObject(value)) {
+    addError(errors, path, "expected object");
+    return;
+  }
+  validateOptionalString(value.dungeonAffinity, `${path}.dungeonAffinity`, errors);
+  validateOptionalNumber(value.budgetTokens, `${path}.budgetTokens`, errors);
+  validateOptionalString(value.levelSize, `${path}.levelSize`, errors);
+  validateOptionalNumber(value.roomCount, `${path}.roomCount`, errors);
+}
+
+function validateAgentCommandCompatibility(value, path, errors) {
+  if (value === undefined) {
+    return;
+  }
+  if (!isObject(value)) {
+    addError(errors, path, "expected object");
+    return;
+  }
+  validateOptionalBoolean(value.preserveExistingCommands, `${path}.preserveExistingCommands`, errors);
+  validateStringArray(value.supportedLegacyFlows, `${path}.supportedLegacyFlows`, errors);
+  validateStringArray(value.notes, `${path}.notes`, errors);
+}
+
+export function validateAgentCommandRequest(request, path = "agentCommandRequest") {
+  const errors = [];
+  if (!isObject(request)) {
+    return { ok: false, errors: [`${path}: expected object`] };
+  }
+  if (request.schema !== AGENT_COMMAND_REQUEST_SCHEMA) {
+    addError(errors, `${path}.schema`, `expected ${AGENT_COMMAND_REQUEST_SCHEMA}`);
+  }
+  if (request.schemaVersion !== 1) {
+    addError(errors, `${path}.schemaVersion`, "expected 1");
+  }
+  validateArtifactMeta(request.meta, `${path}.meta`, errors);
+
+  if (!isObject(request.command)) {
+    addError(errors, `${path}.command`, "expected object");
+  } else {
+    if (!isNonEmptyString(request.command.action) || !AGENT_COMMAND_ACTIONS.has(request.command.action)) {
+      addError(errors, `${path}.command.action`, `expected one of ${Array.from(AGENT_COMMAND_ACTIONS).join(", ")}`);
+    }
+    if (!isNonEmptyString(request.command.text)) {
+      addError(errors, `${path}.command.text`, "expected non-empty string");
+    }
+    if (!isNonEmptyString(request.command.source)) {
+      addError(errors, `${path}.command.source`, "expected non-empty string");
+    }
+    if (request.command.taxonomyVersion !== 1) {
+      addError(errors, `${path}.command.taxonomyVersion`, "expected 1");
+    }
+  }
+
+  if (!Array.isArray(request.objects) || request.objects.length === 0) {
+    addError(errors, `${path}.objects`, "expected non-empty array");
+  } else {
+    request.objects.forEach((entry, index) => {
+      validateAgentCommandObject(entry, `${path}.objects[${index}]`, errors);
+    });
+  }
+
+  validateAgentCommandSharedConfig(request.sharedConfig, `${path}.sharedConfig`, errors);
+  validateAgentCommandCompatibility(request.compatibility, `${path}.compatibility`, errors);
+
+  const expectedKinds = Array.isArray(request.objects)
+    ? Array.from(
+      new Set(
+        request.objects
+          .map((entry) => entry?.kind)
+          .filter((kind) => isNonEmptyString(kind)),
+      ),
+    )
+    : [];
+  validateAgentCommandCompilation(request.compilation, `${path}.compilation`, errors, expectedKinds);
+
+  return { ok: errors.length === 0, errors };
+}
+
+function validateBuildSpecAuthoring(value, path, errors) {
+  if (value === undefined) {
+    return;
+  }
+  if (!isObject(value)) {
+    addError(errors, path, "expected object");
+    return;
+  }
+  if (value.requestRef !== undefined) {
+    validateArtifactRef(value.requestRef, `${path}.requestRef`, errors);
+  }
+  if (value.request !== undefined) {
+    const result = validateAgentCommandRequest(value.request, `${path}.request`);
+    errors.push(...result.errors);
+  }
+  if (value.objectKinds !== undefined) {
+    if (!Array.isArray(value.objectKinds) || value.objectKinds.length === 0) {
+      addError(errors, `${path}.objectKinds`, "expected non-empty array");
+    } else {
+      value.objectKinds.forEach((kind, index) => {
+        validateAgentCommandObjectKind(kind, `${path}.objectKinds[${index}]`, errors);
+      });
+    }
+  }
+}
+
 export function validateBuildSpec(spec) {
   const errors = [];
 
@@ -215,6 +452,8 @@ export function validateBuildSpec(spec) {
       validateAgentHints(spec.configurator.inputs, "configurator.inputs", errors);
     }
   }
+
+  validateBuildSpecAuthoring(spec.authoring, "authoring", errors);
 
   if (spec.budget !== undefined) {
     if (!isObject(spec.budget)) {

--- a/test-results.txt
+++ b/test-results.txt
@@ -1,0 +1,981 @@
+
+> agent-kernel@1.0.0 test /Users/darren/intent/workspaces/plan-create/agent-kernel
+> node --test "tests/**/*.test.js"
+
+✔ cli adapters use deterministic fixtures (362.628792ms)
+✔ cli ipfs adapter handles URL build and errors (360.272125ms)
+✔ cli blockchain adapter handles errors (166.866209ms)
+✔ cli llm adapter handles errors (234.116125ms)
+✔ cli solver adapter errors without solver (254.855375ms)
+✔ cli run emits deterministic actor configs and action logs (249.745458ms)
+✔ cli run normalizes action logs without fixture input (224.14625ms)
+✔ cli run applies actor/vital/tile overrides and emits resolved artifacts (133.436958ms)
+✔ cli ipfs command writes fetched JSON (117.511875ms)
+✔ cli ipfs-load command writes canonical artifact files from fixture map (98.007125ms)
+✔ cli ipfs-publish command writes publish summary from canonical artifact map (90.01275ms)
+✔ cli blockchain command writes chainId and balance (71.789541ms)
+✔ cli blockchain-mint command writes minted token metadata (90.591917ms)
+✔ cli blockchain-load command writes minted card payload (71.886834ms)
+✔ cli llm command writes response JSON (121.45125ms)
+✔ cli llm command defaults model to phi4 when omitted (89.807209ms)
+✔ cli run writes affinity summary (131.595584ms)
+✔ cli run rejects affinity summary without presets or loadouts (92.29975ms)
+✔ cli help documents generic create and configure authoring commands (115.029875ms)
+✔ cli create emits a complete playable artifact bundle for agent requests (142.395875ms)
+✔ cli configure preserves generic parsing but records configure action (159.236625ms)
+✔ cli create rejects invalid trap expressions deterministically (96.41875ms)
+✔ cli budget prints and writes budget artifacts (120.60725ms)
+✔ cli build outputs deterministic manifest/bundle/telemetry (205.306583ms)
+✔ cli build accepts --spec and writes mapped artifacts (134.159125ms)
+✔ cli build rejects unknown flags (93.312333ms)
+✔ cli build runs configurator inputs without executing core (166.065334ms)
+✔ cli build writes a sorted manifest for emitted artifacts (143.716458ms)
+✔ cli build writes bundle.json with inlined artifacts (153.9635ms)
+✔ cli build writes telemetry on success (125.63ms)
+✔ cli build writes telemetry on failure (194.197333ms)
+✔ cli build runs solver with fixture hints (131.679167ms)
+✔ cli build writes inline budget artifacts when refs are absent (110.304709ms)
+✔ cli build captures adapter outputs as captured input artifacts (124.188375ms)
+✔ cli build allows local llm baseUrl without AK_ALLOW_NETWORK (128.767208ms)
+✔ cli build blocks non-local llm baseUrl without AK_ALLOW_NETWORK (149.401ms)
+✔ cli build defaults to artifacts/runs/<runId>/build under cwd (121.601416ms)
+✔ cli configurator builds sim config and initial state artifacts (133.464333ms)
+✔ cli configurator emits a budget receipt from budget inputs (117.032333ms)
+✔ cli configurator rejects invalid level-gen input (78.434ms)
+✔ cli delver-plan authors delver cards directly from delver flags (191.218167ms)
+✔ cli delver-plan applies default delver motivation and affinity fallback (144.884958ms)
+✔ cli delver-plan supports multiple delver configurations in one command (156.411959ms)
+✔ cli delver-plan supports advanced affinities, vitals, setup mode, and receipt accounting (129.919416ms)
+✔ cli delver-plan rejects invalid motivation (194.341208ms)
+✔ cli delver-plan rejects duplicate motivation declarations (93.888666ms)
+✔ cli delver-plan rejects invalid setup mode (84.37725ms)
+✔ cli delver-plan rejects invalid vital tuple (97.143ms)
+✔ cli delver-plan requires --budget and --price-list together (80.688208ms)
+✔ cli solve rejects missing scenario (82.332209ms)
+✔ cli run rejects missing args (73.9725ms)
+✔ cli replay rejects missing tick frames (94.906792ms)
+✔ cli ipfs rejects missing cid (81.414708ms)
+✔ cli blockchain rejects missing rpc-url (108.867416ms)
+✔ cli blockchain-mint rejects missing rpc-url (86.738208ms)
+✔ cli blockchain-mint rejects missing card (81.156542ms)
+✔ cli blockchain-load rejects missing token-id (206.206042ms)
+✔ cli llm rejects missing args (103.316834ms)
+✔ cli run rejects schema mismatch (77.874583ms)
+✔ cli run rejects initial state schema mismatch (90.130084ms)
+✔ cli run rejects sim config missing schemaVersion (93.265709ms)
+✔ cli run rejects initial state schema kind mismatch (104.876792ms)
+✔ cli run rejects out-of-bounds tile overrides (108.038583ms)
+✔ cli run rejects malformed vital specs (88.401959ms)
+✔ cli run rejects invalid actor kind (92.620209ms)
+✔ cli solve rejects plan schema mismatch (98.522792ms)
+✔ cli solve produces stable solver request fields (91.645125ms)
+✔ cli run outputs deterministic frames for fixed inputs (200.73325ms)
+✔ cli replay and inspect produce stable schemas (465.908792ms)
+✔ cli llm-plan writes build outputs with captured input artifact (158.261292ms)
+✔ cli llm-plan budget loop writes multiple captures (151.453292ms)
+✔ cli llm-plan budget loop writes feasibility warnings into telemetry (170.48775ms)
+✔ cli llm-plan budget loop honors custom budget pools (101.141583ms)
+✔ cli llm-plan budget loop requires budget tokens (148.469541ms)
+✔ cli llm-plan requires budget tokens in single-pass mode (98.754958ms)
+✔ cli llm-plan strict mode fails but writes capture with errors (89.18075ms)
+✔ cli llm-plan resilient mode sanitizes invalid affinities (158.66225ms)
+✔ cli llm-plan supports prompt-only mode with catalog (157.957791ms)
+✔ cli llm-plan falls back to scenario summary when AK_LLM_LIVE is off (180.777ms)
+✔ cli llm-plan rejects summaries that do not match catalog entries (114.158708ms)
+✔ cli room-plan authors room cards directly from room flags (139.798917ms)
+✔ cli room-plan applies default room affinity and stacks when omitted (153.254125ms)
+✔ cli room-plan supports multiple room configurations in one command (118.531666ms)
+✔ cli room-plan writes budget receipt with room layout and room-affinity spend (250.278833ms)
+✔ cli room-plan rejects invalid room size (78.369208ms)
+✔ cli room-plan rejects invalid affinity expression (95.204042ms)
+✔ cli room-plan requires --budget and --price-list together (95.581333ms)
+✔ cli schemas prints catalog to stdout (96.616375ms)
+✔ cli schemas writes schemas.json when --out-dir is provided (131.125666ms)
+✔ cli warden-plan authors warden cards directly from warden flags (155.404542ms)
+✔ cli warden-plan applies default warden motivation and affinity fallback (121.424792ms)
+✔ cli warden-plan supports multiple warden configurations in one command (239.637542ms)
+✔ cli warden-plan supports advanced affinities, vitals, and receipt accounting (180.262792ms)
+✔ cli warden-plan rejects invalid motivation (94.547625ms)
+✔ cli warden-plan rejects duplicate motivation declarations (102.230583ms)
+✔ cli warden-plan rejects invalid vital tuple (94.634958ms)
+✔ cli warden-plan requires --budget and --price-list together (90.503959ms)
+✔ cli solve writes solver artifacts (98.95ms)
+✔ cli run writes tick frames and logs (99.153083ms)
+✔ cli replay writes replay summary (356.469041ms)
+✔ cli inspect writes summary (199.780125ms)
+✔ map build spec to intent + plan artifacts (3.6105ms)
+✔ map build spec budget keeps refs and inline artifacts (0.734792ms)
+✔ demo script produces fixture-backed artifacts (910.034416ms)
+✔ adapters-cli entrypoints exist (0.405083ms)
+✔ cli solve supports solver fixture (295.411667ms)
+✔ dispatchEffect consumes adapter fixtures for log/telemetry/solver_request (181.096209ms)
+✔ ipfs test adapter fixtures (195.023875ms)
+✔ blockchain test adapter fixtures (196.13825ms)
+✔ llm test adapter fixtures (213.68325ms)
+✔ adapters-test entrypoints exist (0.853917ms)
+✔ test solver adapter looks up fixtures and defers missing (178.35475ms)
+✔ ipfs adapter builds URLs and handles fetch errors (217.033084ms)
+✔ blockchain adapter validates inputs and handles RPC errors (164.674459ms)
+✔ llm adapter validates inputs and handles HTTP errors (240.379208ms)
+✖ level builder adapter supports in-process and worker-backed requests (252.862917ms)
+✔ cli worker adapter supports in-process build execution and worker lifecycle controls (621.581958ms)
+✔ adapters-web entrypoints exist (0.411791ms)
+✔ web solver adapter supports fixture and stub paths (194.676791ms)
+✔ allocator layout spend applies tile costs and budget bounds (190.925875ms)
+✔ allocator selection spend trims over-budget selections deterministically (230.353083ms)
+✔ allocator selection spend approves selections when budget allows (212.535375ms)
+✔ allocator selection spend includes actor configuration costs (217.561791ms)
+✔ allocator validates spend proposals deterministically (191.154459ms)
+✔ allocator ledger updates deterministically (186.0615ms)
+✔ loadCore rejects missing wasm (205.62575ms)
+✔ loadCore rejects invalid wasm (212.371583ms)
+✔ bindings expose MVP movement helpers and stable shapes (208.142875ms)
+✔ bindings observation includes affinity metadata when provided (189.857125ms)
+✔ readObservation includes static traps exposed directly by core (185.1845ms)
+✔ bindings entrypoints exist (0.375584ms)
+✔ budget artifacts accept valid shapes (0.700958ms)
+✔ budget artifacts reject missing costs or status (5.412208ms)
+✔ budget receipts reject negative remaining when approved (1.043ms)
+✔ build spec validation accepts basic fixture (2.039375ms)
+✔ build spec validation rejects missing intent goal (1.213833ms)
+✔ build spec validation rejects invalid adapter capture (0.741084ms)
+✔ build spec validation rejects non-object intent hints (0.697833ms)
+✔ build spec validation rejects non-object configurator inputs (0.603041ms)
+✔ build spec validation accepts agent authoring contract metadata (1.039125ms)
+✔ build spec validation rejects invalid agent authoring object kind (0.299083ms)
+✔ build spec validation rejects incomplete agent authoring compilation rules (0.176833ms)
+✔ captured input artifacts accept valid shapes (1.415ms)
+✔ captured input artifacts reject missing source or payload (6.065583ms)
+✔ core-as rejects invalid actor placement: actor-placement-v1-out-of-bounds.json (8.321375ms)
+✔ core-as rejects invalid actor placement: actor-placement-v1-spawn-mismatch.json (2.555708ms)
+✔ core-as rejects invalid actor placement: actor-placement-v1-spawn-barrier.json (2.1785ms)
+✔ core-as rejects invalid actor placement: actor-placement-v1-overlap.json (2.085958ms)
+✔ core-as rejects placements over the max actor slots (1.614417ms)
+✔ core-as exposes canonical actor state with vitals (6.439334ms)
+✔ core-as rejects actor states missing a vital (1.299375ms)
+✔ core-as rejects actor states missing stamina (1.646792ms)
+✔ core-as rejects actor states missing vital regen values (2.870208ms)
+✔ core-as raises/destroys barriers and arms/disarms static traps (6.418333ms)
+✔ core-as defaults capability costs to deterministic values (5.845417ms)
+✔ core-as accepts capability fixtures with non-negative values (1.7745ms)
+✔ core-as rejects negative capability costs (1.264375ms)
+✔ core-as applies tick regen and clamps vitals (1.910542ms)
+✔ core init rejects invalid seed (3.875583ms)
+✔ core applyAction rejects invalid kind/value (2.130708ms)
+✔ core budget caps emit limit reached/violated (1.179459ms)
+✔ core emits external fact requests and fulfillment/defer effects deterministically (1.338542ms)
+✔ core guards missing pending requests and emits telemetry/solver requests (0.848291ms)
+✔ core-as has no external imports (2.514459ms)
+✔ core-as applies move actions and renders MVP frames (6.899667ms)
+✔ core-as rejects blocked or mistimed moves without advancing state (1.262458ms)
+✔ core-as rejects moves when stamina is insufficient (1.048583ms)
+✔ core-as moves across large coordinates with new encoding (1.598041ms)
+✔ core-as applies emit trap damage when moving onto an affinity tile (0.850458ms)
+✔ core-as snapshot data is deterministic for barrier scenario (8.755959ms)
+✔ core-as exposes tile actor occupancy for the MVP grid (8.092083ms)
+✔ core-as blocks movement into barrier tile actors and renders barriers (2.7995ms)
+✔ shared runtime vital constants match core-as VitalKind enum order (1.895709ms)
+✔ core-as configures tiered grid sizes (5.450041ms)
+✔ core-as rejects grids over the max cell limit (1.693ms)
+✔ default pool weights: 55% rooms, 20% delvers, 25% wardens (design §2.2) (210.088333ms)
+✔ reference budget constant is 1000 (design §2.1) (195.628833ms)
+✔ custom pool weights override defaults (243.6225ms)
+✔ UI budgetSplitPercent handoff: poolWeights pass through summary → BuildSpec → allocation (258.557875ms)
+✔ default allocation when poolWeights not provided (264.755209ms)
+✔ affinity stack cost formula: 10 + 8·(n-1)² (design §6.2) (217.87725ms)
+✔ vital max costs: 2H + 2M + S + 2D (design §7) (214.343667ms)
+✔ regen costs are quadratic: 12·R² + 5·R² + 4·R² + 10·R² (design §8) (246.514208ms)
+✔ durability regen is supported (design §8.4) (233.017542ms)
+✔ affinity base cost is 30 (design §6.1) (185.263834ms)
+✔ expression costs: external=35, internal=25 (design §6.4) (187.897208ms)
+✔ motivation costs: simple=25, advanced=50 (design §6.6) (175.45525ms)
+✔ minimum external affinity package cost: 30 + 10 + 35 = 75 (design §6.5) (184.359667ms)
+✔ minimum internal affinity package cost: 30 + 10 + 25 = 65 (design §6.5) (252.491792ms)
+✔ runtime external mana use: 5 + 4·(s-1)² (design §9.1) (188.296792ms)
+✔ runtime internal mana upkeep: 2 + s (design §9.2) (196.581083ms)
+✔ external range: 1 + s (design §10.1) (234.544584ms)
+✔ internal radius: 1 + s (design §10.2) (273.721209ms)
+✔ draw net formula: 3·min(s,e) - (2+s) (design §11.3) (204.273708ms)
+✔ emit strength: s (design §12.2) (195.60725ms)
+✔ affinity package validation: requires kind + stacks + expression (design §5.1) (196.018417ms)
+✔ incentive multiplier: max(0, 1 - 1.25×|D/W - 0.8|) (design §3.3) (198.360958ms)
+✔ target delver/warden ratio is 0.8 (design §3.2) (176.099834ms)
+✔ reference budget is 1000 (design §2.1) (280.705084ms)
+✔ reference targets: rooms=550, delvers=200, wardens=250 (design §2.2) (194.770791ms)
+✔ scenario spend report includes all required fields (design §14) (164.433167ms)
+✔ simple motivations cost 25, advanced cost 50 (design §6.6) (172.717292ms)
+✔ calculateMotivationStackCost uses updated pricing (181.44875ms)
+✔ actor placement fixtures declare schema and expected errors (0.543167ms)
+✔ actor-state fixtures include full vitals defaults (0.539709ms)
+✔ actor-state invalid fixtures omit required vital fields (0.1285ms)
+✔ mvp sim config defines a deterministic 9x9 grid with spawn/exit and palette (1.2825ms)
+✔ initial actor defaults live on the spawn tile with vitals stub (0.075ms)
+✔ action sequence walks the MVP maze to the exit in deterministic ticks (0.089917ms)
+✔ frame buffers mirror the action path and keep map metadata in sync (0.131709ms)
+✔ build spec bundle fixture preserves spec serialization order (0.517666ms)
+✔ build spec bundle manifest and bundle are consistent (8.200625ms)
+✔ artifact fixtures round-trip serialize (6.432209ms)
+✔ invalid fixtures omit required fields (0.757042ms)
+✔ preview load reflects the real ui-web core-as.wasm prerequisite (169.954625ms)
+✔ mixed-object create bundle survives the CLI -> Diagnostics -> injected Preview -> run-gating flow (205.382917ms)
+✔ room-only create bundle still previews the generated room image and remains run-blocked with injected Preview helpers (167.046667ms)
+﹣ live llm prompt flows into build + runtime (0.48175ms) # Set AK_LLM_LIVE=1 to run live LLM integration test.
+✔ e2e trace wires prompt -> summary -> build -> runtime (56.066416ms)
+✔ e2e trace exercises room layouts for tiered scenario (16.47075ms)
+(node:94875) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/integration/ui-aura-display.test.js is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /Users/darren/intent/workspaces/plan-create/agent-kernel/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+▶ UI aura display integration
+  ✔ simulation view stores auras from observation (0.30575ms)
+  ✔ tooltip format includes expected aura fields (0.103417ms)
+✔ UI aura display integration (0.810791ms)
+✔ browser host build artifacts are equivalent to Node CLI output (271.239917ms)
+✔ browser host normalizes agent-authored build specs for UI parity (1.843708ms)
+✔ browser host solve artifacts are equivalent to Node CLI output (121.923833ms)
+✔ browser host configurator artifacts are equivalent to Node CLI output (138.329792ms)
+✔ browser host budget artifacts are equivalent to Node CLI output (87.410167ms)
+✔ browser host ipfs-publish artifacts are equivalent to Node CLI output (97.794541ms)
+✔ browser host ipfs-load artifacts are equivalent to Node CLI output (95.324625ms)
+✔ browser host blockchain-mint artifacts are equivalent to Node CLI output (94.49725ms)
+✔ browser host blockchain-load artifacts are equivalent to Node CLI output (87.141458ms)
+✔ browser host llm-plan artifacts are equivalent to Node CLI output (200.941583ms)
+✔ browser host llm artifacts are equivalent to Node CLI output (80.876375ms)
+✔ browser host run artifacts are equivalent to Node CLI output (130.771ms)
+✔ browser host replay artifacts are equivalent to Node CLI output (214.897833ms)
+✔ browser host inspect artifacts are equivalent to Node CLI output (200.759167ms)
+﹣ perf harness probes grid sizes and reports headless metrics (0.303792ms) # Set AK_PERF=1 to run perf harness
+✔ actor persona gates motivation and affinity proposals by budget (345.787792ms)
+✔ actor persona filters proposals to motivated actors (408.450291ms)
+✔ actor persona proposes deterministic movement toward exit (420.243666ms)
+✔ actor persona handles phase-driven cases (368.428792ms)
+✔ actor persona enforces guard/invalid events (532.97275ms)
+✔ actor persona emits runtime-decision solver requests from live observation context (377.579ms)
+✔ actor persona keeps manual live LLM runtime requests on the same solver_request rail (400.047167ms)
+✔ actor state machine follows happy path transitions (295.987791ms)
+✔ actor state machine enforces guard and invalid transitions (263.863167ms)
+✔ allocator and actor personas emit budget-aware actions and close request loops (573.588375ms)
+✔ motivation price policy: canonical costs, families, and stack pricing (171.588791ms)
+✔ motivation costs flow through calculateActorConfigurationUnitCost (227.9935ms)
+✔ allocator persona handles phase-driven cases (312.964584ms)
+✔ allocator persona enforces guard/invalid events (267.511084ms)
+✔ allocator persona emits solver_request when provided (307.585833ms)
+✔ allocator persona has no solver_request when missing payload (371.190708ms)
+✔ allocator state machine follows happy path transitions (251.374334ms)
+✔ allocator state machine enforces guard and invalid transitions (264.906541ms)
+✔ annotator llm trace helper summarizes orchestrator captures (181.244916ms)
+✔ annotator persona handles phase-driven cases (343.311959ms)
+✔ annotator persona enforces guard/invalid events (270.339958ms)
+✔ annotator state machine follows happy path transitions (238.209625ms)
+✔ annotator state machine enforces guard and invalid transitions (238.532541ms)
+✔ annotator persona emits telemetry records and summaries from observations (327.593292ms)
+✖ actor config generation cost calculation and validation (181.212042ms)
+✔ actor generator emits stable, diverse, bounded actors (187.101208ms)
+✔ affinity effects resolve vitals and abilities deterministically (201.384125ms)
+✔ affinity presets and loadouts normalize with defaults (236.927875ms)
+✔ affinity presets reject invalid kinds (203.165459ms)
+✔ affinity presets reject invalid expressions (192.67875ms)
+✔ loadouts reject unknown preset references (243.17175ms)
+✔ loadouts reject invalid expressions and non-affinity equipment (195.204292ms)
+✔ loadouts reject invalid target types (195.605625ms)
+✔ loadouts reject missing actor ids (189.659458ms)
+✔ loadouts reject stacks exceeding preset max (186.954958ms)
+✔ loadouts enforce required expressions per actor (211.077583ms)
+✔ configurator artifact builders produce deterministic artifacts (198.3225ms)
+✔ configurator artifact fixtures include traps and affinity traits (0.682625ms)
+✔ configurator feasibility validation checks layout and actor placement (202.722959ms)
+✔ guidance level builder derives deterministic level previews from guidance summaries (290.765458ms)
+✔ mixed-affinity floor resolution is invariant to trap ordering (permutation test) (227.792833ms)
+✔ guidance level builder maps room cards into level generation inputs (298.368917ms)
+✔ normalizeLevelGenInput applies room/hallway defaults for optional fields (197.902375ms)
+✔ normalizeLevelGenInput clamps out-of-range room and distance values (194.743542ms)
+✔ normalizeLevelGenInput rejects invalid sizes (202.173417ms)
+✔ normalizeLevelGenInput rejects missing required fields (202.445375ms)
+✔ normalizeLevelGenInput rejects walkable target above grid capacity (206.914542ms)
+✔ normalizeLevelGenInput does not enforce fixed max side or walkable limits (224.965542ms)
+✔ normalizeLevelGenInput preserves optional shape corridor settings (189.582167ms)
+✔ normalizeLevelGenInput accepts explicit grid pattern shape settings (227.329833ms)
+✔ normalizeLevelGenInput accepts diagonal and concentric hallway patterns (195.408625ms)
+✔ normalizeLevelGenInput validates optional trap target types (180.885584ms)
+✔ room layouts are deterministic and connected for tiered sizes (241.370042ms)
+✔ level layout generator is deterministic for rooms-and-hallways inputs (408.367583ms)
+✔ default layout uses room-first flow with explicit room chambers (243.434416ms)
+✔ level layout honors walkable tile targets for connected rooms (229.284292ms)
+✔ requirePath guarantees a spawn-to-exit path in room layouts (294.433333ms)
+✔ wider hallways increase carved walkable area for the same room seed (210.178083ms)
+✔ high-scale walkable room layouts complete in practical time (1642.786125ms)
+✔ grid overlay carves internal room barriers while preserving movement gaps (196.323542ms)
+✔ diagonal and concentric hallway overlays carve patterned internal barriers (513.338416ms)
+✔ higher hallway infill produces denser in-room overlay carving (149.677583ms)
+✔ pattern overlays do not block walkable room perimeter tiles (416.180917ms)
+✔ level strategy mapping applies deterministic overrides (191.893125ms)
+✔ configurator persona handles phase-driven cases (286.904708ms)
+✔ configurator persona enforces guard/invalid events (266.264417ms)
+✔ configurator persona emits solver_request when provided (265.3975ms)
+✔ configurator persona has no solver_request when missing payload (295.924667ms)
+✔ configurator builds spend proposals and validates receipts (239.123125ms)
+✔ configurator state machine follows happy path transitions (211.608917ms)
+✔ configurator state machine enforces guard and invalid transitions (230.938667ms)
+✔ director budget allocation splits pools deterministically (206.694208ms)
+✔ director/configurator personas emit deterministic solver_request effects (351.558042ms)
+✔ director persona handles subscribed phases via table (297.890375ms)
+✔ director persona ignores non-subscribed phases and surfaces guard errors (354.155041ms)
+✔ director persona emits solver_request effect when provided (352.895375ms)
+✔ director state machine advances through table-driven happy path (243.882042ms)
+✔ director state machine enforces table-driven guard and missing transition errors (327.249667ms)
+✔ moderator affinity target resolver emits vital and environment effects (205.008209ms)
+✔ moderator planner derives deterministic barrier and trap actions (236.667875ms)
+✔ moderator persona handles phase-driven cases (266.28325ms)
+✔ moderator persona ignores non-advancing cases (288.001125ms)
+✔ moderator state machine follows happy path transitions (220.982917ms)
+✔ moderator state machine enforces guard and invalid transitions (209.05825ms)
+✔ orchestrator ingests budget + price list inputs deterministically (205.489917ms)
+✔ budget loop repairs feasibility failures via repair prompt (298.165167ms)
+✔ budget loop benchmarks walkability budget scaling up to 550000 at 1M total budget (4052.003541ms)
+✔ budget loop supports one billion token budgets without imposed ceiling (125.564791ms)
+✔ budget loop avoids full-grid feasibility slowdown for very large walkability counts (120.677958ms)
+✖ orchestrator budget loop sequences layout then actors (273.31175ms)
+✔ orchestrator budget loop applies tile price list costs (395.084084ms)
+✔ orchestrator budget loop uses phi4 option budgets by phase (259.726541ms)
+✔ orchestrator budget loop auto-fits over-budget layout responses in non-strict mode (283.020083ms)
+✔ orchestrator budget loop recovers actor picks without exact catalog pair in non-strict mode (268.520709ms)
+✔ orchestrator budget loop keeps oversized walkable layout when budget allows (301.760417ms)
+✔ orchestrator captures llm prompt/response as artifact (276.007875ms)
+✔ orchestrator llm session captures prompt/response (183.409792ms)
+✔ orchestrator llm session honors strict vs resilient parsing (257.410083ms)
+✔ orchestrator llm session enforces non-empty summary when configured (179.034334ms)
+✔ orchestrator llm session captures phase metadata (189.460167ms)
+✔ orchestrator llm session expands repair output budget when actor response is truncated (209.372375ms)
+✔ orchestrator llm session sanitizes invalid defender token hints and stamina regen (229.798125ms)
+✔ orchestrator llm session recovers defender JSON with trailing commas (187.387166ms)
+✔ orchestrator llm session supports AI summary to card model to build spec round-trip (210.379625ms)
+✔ orchestrator persona handles phase-driven cases (259.920833ms)
+✔ orchestrator persona enforces guard/invalid events (269.711667ms)
+✔ orchestrator state machine follows happy path transitions (233.81375ms)
+✔ orchestrator state machine enforces guard and invalid transitions (250.790625ms)
+✔ summarizeTickHistory produces expected summary (178.687375ms)
+✔ tick orchestrator drives phases and personas and collects actions (464.442458ms)
+✔ tick orchestrator surfaces invalid transitions (274.306875ms)
+✔ tick orchestrator converts solver runtime decisions into actions on the existing rail (343.76ms)
+✔ tick orchestrator fulfills manual-mode live LLM runtime decisions on the same rail and captures the exchange (363.197583ms)
+✔ tick orchestrator does not perform automatic solver-to-LLM fallback when solver is unfulfilled (339.662375ms)
+✔ tick state machine follows happy path transitions (249.983375ms)
+✔ tick state machine enforces guard cases (259.316042ms)
+✔ tick state machine emits debug logs when enabled (225.566209ms)
+✔ runtime maps actor proposals to core actions and replays deterministically (429.562042ms)
+✔ runtime filters non-motivated proposals before packing actions (510.34775ms)
+(node:95065) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-aura-lifecycle.test.js is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /Users/darren/intent/workspaces/plan-create/agent-kernel/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+▶ affinity aura lifecycle integration
+  ✔ attaches aura data to observation after readObservation call (5.111958ms)
+✔ affinity aura lifecycle integration (5.832375ms)
+(node:95068) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-palette.test.js is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /Users/darren/intent/workspaces/plan-create/agent-kernel/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+▶ affinity-palette
+  ▶ AFFINITY_COLOR_HEX
+    ✔ should define a hex color for every canonical affinity kind (0.495583ms)
+    ✔ should have exactly 10 affinity entries (0.077ms)
+    ✔ should provide the expected colors for key affinities (0.058542ms)
+  ✔ AFFINITY_COLOR_HEX (0.983459ms)
+  ▶ STACK_INTENSITY_TIERS
+    ✔ should define at least 3 intensity tiers (0.072792ms)
+    ✔ should have increasing saturation and decreasing lightness (0.065083ms)
+    ✔ should have glow values that increase or stay constant (0.048167ms)
+  ✔ STACK_INTENSITY_TIERS (0.26425ms)
+  ▶ hexToRgba
+    ✔ should convert valid hex to RGBA (0.800375ms)
+    ✔ should apply custom alpha (0.175666ms)
+    ✔ should fallback to black for invalid hex (0.1605ms)
+  ✔ hexToRgba (1.376167ms)
+  ▶ normalizeHex
+    ✔ should return valid hex unchanged (0.269542ms)
+    ✔ should normalize uppercase to lowercase (0.096958ms)
+    ✔ should return fallback for invalid hex (0.142166ms)
+  ✔ normalizeHex (1.62625ms)
+  ▶ resolveStackIntensity
+    ✔ should return tier1 for stack count 1 (0.180708ms)
+    ✔ should return tier2 for stack count 2 (0.078334ms)
+    ✔ should return tier3 for stack count 3 (0.055833ms)
+    ✔ should cap at highest tier for stack count >= 5 (0.054041ms)
+    ✔ should normalize non-integer stacks to nearest positive integer (0.057958ms)
+  ✔ resolveStackIntensity (0.580166ms)
+  ▶ getAffinityRgba
+    ✔ should return RGBA for valid affinity kind (0.139333ms)
+    ✔ should apply custom alpha (0.057667ms)
+    ✔ should fallback to white for unknown affinity kind (0.059334ms)
+  ✔ getAffinityRgba (0.3305ms)
+  ▶ validateAffinityPalette
+    ✔ should pass validation for complete palette (0.1435ms)
+  ✔ validateAffinityPalette (0.191208ms)
+✔ affinity-palette (5.868708ms)
+(node:95069) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-spatial-formulas.test.js is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /Users/darren/intent/workspaces/plan-create/agent-kernel/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+▶ computeRadius
+  ▶ push
+    ✔ stacks 1-2 → radius 1 (0.325042ms)
+    ✔ stacks 3-4 → radius 2 (0.06ms)
+    ✔ stacks 5 → radius 3 (0.043542ms)
+  ✔ push (0.738916ms)
+  ▶ pull mirrors push
+    ✔ produces same radius as push at all stack levels (0.064459ms)
+  ✔ pull mirrors push (0.111166ms)
+  ▶ emit
+    ✔ stacks 1 → radius 2 (buffer + 1 tile) (0.064458ms)
+    ✔ stacks 2 → radius 3 (0.054459ms)
+    ✔ stacks 5 → radius 6 (0.0445ms)
+  ✔ emit (0.244458ms)
+  ▶ draw
+    ✔ always radius 1 regardless of stacks (0.043416ms)
+  ✔ draw (0.084541ms)
+  ▶ edge cases
+    ✔ returns 1 for unknown expression (0.054583ms)
+    ✔ clamps stacks < 1 to 1 (0.063167ms)
+  ✔ edge cases (0.175041ms)
+✔ computeRadius (1.6425ms)
+▶ computeIntensity
+  ▶ emit buffer zone
+    ✔ d=1 is always 0 (buffer) (0.101666ms)
+    ✔ d=2 is non-zero for stacks >= 1 (0.0725ms)
+  ✔ emit buffer zone (0.214042ms)
+  ▶ emit falloff at d=2 is full peak at each stack level
+    ✔ d=2 is highest intensity for emit (0.061791ms)
+  ✔ emit falloff at d=2 is full peak at each stack level (0.109916ms)
+  ▶ emit out-of-range is zero
+    ✔ stacks=1 radius=2: d=3 → 0 (0.074375ms)
+    ✔ stacks=2 radius=3: d=4 → 0 (0.038625ms)
+  ✔ emit out-of-range is zero (0.166833ms)
+  ▶ push — no buffer, starts at d=1
+    ✖ d=1 is non-zero for push (3.479375ms)
+    ✔ d=1 > d=2 for push (quadratic falloff) (0.133417ms)
+    ✔ d=0 → 0 (no effect at source tile) (0.392166ms)
+  ✖ push — no buffer, starts at d=1 (4.246625ms)
+  ▶ pull mirrors push intensity
+    ✔ pull and push have identical intensity at same d and stacks (0.117875ms)
+  ✔ pull mirrors push intensity (0.161209ms)
+  ▶ draw — flat at d=1, zero everywhere else
+    ✔ d=1 is non-zero (0.0775ms)
+    ✔ d=2 is zero (out of range) (0.053875ms)
+    ✔ d=1 intensity same regardless of stacks (flat) (0.040916ms)
+  ✔ draw — flat at d=1, zero everywhere else (0.212459ms)
+  ▶ returns 0 for unknown expression
+    ✔ unknown expression → 0 (0.041208ms)
+  ✔ returns 0 for unknown expression (0.071917ms)
+✖ computeIntensity (5.387542ms)
+▶ computePotency
+  ▶ push uses quadratic scaling
+    ✔ stacks 1 → 1 (0.073541ms)
+    ✔ stacks 2 → 4 (0.239875ms)
+    ✔ stacks 3 → 9 (0.051291ms)
+    ✔ stacks 4 → 16 (0.030792ms)
+    ✔ stacks 5 → 25 (0.029458ms)
+  ✔ push uses quadratic scaling (3.670833ms)
+  ▶ pull uses linear scaling
+    ✔ stacks 1 → 1 (0.051083ms)
+    ✔ stacks 2 → 2 (0.035958ms)
+    ✔ stacks 3 → 3 (0.019709ms)
+    ✔ stacks 4 → 4 (0.020583ms)
+    ✔ stacks 5 → 5 (0.021333ms)
+  ✔ pull uses linear scaling (0.21125ms)
+  ▶ emit uses linear scaling
+    ✔ stacks 1 → 1 (0.044417ms)
+    ✔ stacks 2 → 2 (0.01575ms)
+    ✔ stacks 3 → 3 (0.019709ms)
+    ✔ stacks 4 → 4 (0.018125ms)
+    ✔ stacks 5 → 5 (0.015792ms)
+  ✔ emit uses linear scaling (0.156625ms)
+  ▶ draw uses linear scaling
+    ✔ stacks 1 → 1 (0.046792ms)
+    ✔ stacks 2 → 2 (0.015833ms)
+    ✔ stacks 3 → 3 (0.0165ms)
+    ✔ stacks 4 → 4 (0.015542ms)
+    ✔ stacks 5 → 5 (0.017792ms)
+  ✔ draw uses linear scaling (0.156292ms)
+  ✔ returns 0 for unknown expression (0.028583ms)
+  ✔ clamps stacks < 1 to 1 (0.0335ms)
+✔ computePotency (4.352625ms)
+▶ resolveStackCancellation
+  ✔ fire+5 vs water+2: netFire=3, netWater=0, canceled=2 (0.074458ms)
+  ✔ equal stacks: mutual cancellation, both net=0 (0.025917ms)
+  ✔ source weaker: netSource=0, netTarget has remainder (0.023ms)
+  ✔ stacks=1 vs stacks=1: both net=0 (0.02225ms)
+  ✔ clamps invalid stacks to 1 (0.022834ms)
+✔ resolveStackCancellation (0.219042ms)
+▶ resolveMergedStacks
+  ✔ sums stacks when under cap (0.058417ms)
+  ✔ caps at W.maxMergedStacks (8) (0.022334ms)
+  ✔ single stack from each: 1+1=2 (0.018125ms)
+✔ resolveMergedStacks (0.131375ms)
+▶ computeEffectivePotency
+  ▶ opposite affinity
+    ✔ fire+5+emit vs water+2+emit: winner gets potency(3) (0.046709ms)
+    ✖ equal stacks: potency(0) = 0 (2.335333ms)
+    ✔ decay+4+pull vs life+2+pull: net decay=2 (0.513625ms)
+  ✖ opposite affinity (3.043625ms)
+  ▶ same affinity
+    ✔ uses source stacks directly (0.125167ms)
+  ✔ same affinity (0.190166ms)
+  ▶ unrelated affinity
+    ✔ uses source stacks directly (0.090084ms)
+  ✔ unrelated affinity (0.138333ms)
+✖ computeEffectivePotency (3.500208ms)
+▶ computeManaCost
+  ▶ push/pull have no per-tick cost
+    ✔ push stacks 1-5 all → 0 (0.174041ms)
+    ✔ pull stacks 1-5 all → 0 (0.093125ms)
+  ✔ push/pull have no per-tick cost (0.332584ms)
+  ▶ emit has quadratic per-tick cost
+    ✖ stacks 1 → 1 (0.34475ms)
+    ✔ stacks 2 → 3 (1 + 0.5*4 = 3) (0.054625ms)
+    ✔ stacks 3 → 6 (1 + 0.5*9 = 5.5 → ceil = 6) (0.033166ms)
+    ✔ increases with stacks (0.047292ms)
+  ✖ emit has quadratic per-tick cost (0.557417ms)
+  ▶ draw has lower quadratic cost
+    ✖ stacks 1 → 0 (0.122666ms)
+    ✔ stacks 2 → 1 (0.25*4 = 1) (0.110125ms)
+    ✔ draw always cheaper than emit at same stacks (0.031125ms)
+  ✖ draw has lower quadratic cost (0.300209ms)
+✖ computeManaCost (1.357084ms)
+▶ computeStackAlphaMultiplier
+  ✔ stacks=1 returns W.alphaBase (0.20) (0.063792ms)
+  ✔ increases with stacks (0.03525ms)
+  ✔ stacks=5 stays below 1.0 (0.057167ms)
+✔ computeStackAlphaMultiplier (0.186958ms)
+▶ computeTileAlpha
+  ✔ emit buffer zone (d=1) → alpha 0 (0.047625ms)
+  ✔ emit d=2 stacks=2 → non-zero alpha (0.022583ms)
+  ✖ push d=1 stacks=1 → non-zero alpha (0.264375ms)
+  ✔ push out of range → 0 (0.025334ms)
+  ✔ result always in [0, 1] (0.116834ms)
+✖ computeTileAlpha (1.20175ms)
+▶ INTERACTION_MATRIX
+  ✔ has entries for all 4 source expressions (0.045834ms)
+  ✔ each source expression has entries for all 4 target expressions (0.038958ms)
+  ✔ each cell has all 3 affinity relationships (0.050208ms)
+  ✔ each cell has required fields (0.07625ms)
+  ✔ all 48 cells are defined (4 src × 4 tgt × 3 rel) (0.044167ms)
+✔ INTERACTION_MATRIX (0.295916ms)
+(node:95070) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-tile-mask.test.js is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /Users/darren/intent/workspaces/plan-create/agent-kernel/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+▶ stackAlphaMultiplier
+  ✔ returns base alpha for stacks=1 (0.413209ms)
+  ✔ increases with stacks (0.06125ms)
+  ✔ handles stacks=0 gracefully (clamps to 1) (0.046083ms)
+✔ stackAlphaMultiplier (1.369666ms)
+▶ emitMask
+  ✔ returns values in [0, 1] (0.115542ms)
+  ✔ center > edge (0.04425ms)
+✔ emitMask (0.228167ms)
+▶ pushMask
+  ✔ returns values in [0, 1] (0.106958ms)
+  ✔ shows directional concentration (forward > backward) (0.058083ms)
+✔ pushMask (0.2385ms)
+▶ pullMask
+  ✔ returns values in [0, 1] (0.095375ms)
+  ✔ edge differs from center (gradient exists) (0.056791ms)
+✔ pullMask (0.212625ms)
+▶ drawMask
+  ✔ returns values in [0, 1] (0.109042ms)
+  ✔ ring shape: mid-radius > center and > far corner (0.037333ms)
+✔ drawMask (0.183458ms)
+▶ conflictMask
+  ✔ returns deterministic results (0.390417ms)
+  ✔ returns valid RGBA values (0.037209ms)
+  ✔ produces dithered blend (not all same color) (0.1125ms)
+✔ conflictMask (0.587209ms)
+▶ reinforceMask
+  ✔ returns 1.0 for single stack (0.043625ms)
+  ✔ increases with combined stacks (0.0275ms)
+✔ reinforceMask (0.104791ms)
+▶ layeredMask
+  ✔ returns valid RGBA (0.050166ms)
+  ✔ uses both colors across tile (0.053833ms)
+✔ layeredMask (0.129959ms)
+▶ applyAuraMask
+  ✔ writes to pixel buffer correctly (0.151875ms)
+  ✔ does not write outside tile bounds (0.046417ms)
+  ✔ respects maskAlpha=0 (no writes) (0.044959ms)
+  ✔ handles tileSize=1 (0.032125ms)
+✔ applyAuraMask (0.328167ms)
+▶ resolveAuraRgba
+  ✔ returns RGBA array for valid kind (0.145791ms)
+  ✔ alpha increases with stacks via glow (0.063709ms)
+  ✔ respects baseAlpha parameter (0.030333ms)
+✔ resolveAuraRgba (0.283708ms)
+▶ STACK_INTENSITY_TIERS 5th tier
+  ✔ has 5 tiers (0.029084ms)
+  ✔ 5th tier has highest saturation (0.022333ms)
+✔ STACK_INTENSITY_TIERS 5th tier (0.07825ms)
+▶ edge cases
+  ✔ emitMask handles exact boundaries (0.0465ms)
+  ✔ negative distance values clamped in masks (0.024041ms)
+  ✔ resolveAuraRgba handles missing kind gracefully (0.02575ms)
+  ✔ resolveAuraRgba handles stacks=0 (0.024416ms)
+✔ edge cases (0.164583ms)
+✔ runtime applies budget caps from SimConfig (308.709167ms)
+✔ orchestrateBuild uses runtime modules for solver and configurator (345.20925ms)
+✔ orchestrateBuild aligns actors to walkable layout positions (258.709084ms)
+✔ orchestrateBuild places delvers at entry and wardens inside rooms (319.379083ms)
+✔ orchestrateBuild translates cardSet delvers/wardens and applies strategic placement (326.897291ms)
+✔ orchestrateBuild keeps the inferred delver on spawn (264.210334ms)
+✔ orchestrateBuild maps room affinities to warden placement and tile emit traps (253.439625ms)
+✔ runtime bulk layout loading matches per-cell results (207.20725ms)
+✔ command kernel budget reads, writes, and logs artifacts via injected host IO (38.111958ms)
+✔ command kernel inspect surfaces runtime decisions and decision-driven actions (39.144208ms)
+✔ command kernel solve writes solver artifacts via injected host services (37.877042ms)
+✔ runtime applies configurator sim config and initial state artifacts (323.092125ms)
+✔ applySimConfigToCore arms non-blocking static traps with mana reserve (209.796334ms)
+✔ buildDesignSpendLedger computes level, actor base, and actor config categories (7.77675ms)
+✔ buildDesignSpendLedger flags over-budget totals (0.204125ms)
+✔ buildDesignSpendLedger prices actor configuration from price list items (0.702875ms)
+✔ buildDesignSpendLedger treats tokenHint as per-unit and multiplies by count (0.213667ms)
+✔ buildDesignSpendLedger uses shared room-card layout budget when cardSet is provided (0.877458ms)
+✔ buildDesignSpendLedger discounts room affinity configuration to 10% of base cost (0.268667ms)
+✔ affinity and expression type unions stay aligned with shared runtime constants (3.434667ms)
+✔ domain constraints expose canonical llm defaults (1.217667ms)
+✔ e2e actor fixtures include deterministic, varied actor sets (7.263709ms)
+✔ allocator receipts and ledger link to buildspec budget refs (55.8845ms)
+✔ annotator affinity summary artifacts are deterministic and schema-valid (43.474375ms)
+✔ buildspec includes budget and price list refs from fixtures (18.400959ms)
+✔ orchestrated build produces deterministic bundle/manifest/telemetry outputs (52.636ms)
+✔ tier generators produce deterministic actors and layouts (10.346709ms)
+✔ e2e scenario fixtures load and summary matches prompt contract (5.845209ms)
+✔ summary -> pool -> budget -> buildspec chain uses fixtures deterministically (24.453709ms)
+✔ budget enforcement trims selections when budget is tight (1.851833ms)
+✔ need_external_fact effects enforce sourceRef policy (286.513792ms)
+✔ normalizeMotivations accepts allowed kinds and applies defaults (4.173042ms)
+✔ normalizeMotivations surfaces invalid kinds/patterns and clamps intensity (0.29125ms)
+✔ normalizeMotivations rejects contradictory motivations from the same exclusive group (0.498166ms)
+✔ MOTIVATION_FAMILIES defines three canonical families (0.115125ms)
+✔ stealthy and friendly are valid motivation kinds (0.1035ms)
+✔ exclusive groups use family names: mobility, posture, cognition (0.107958ms)
+✔ posture family rejects stealthy + friendly conflict (0.101166ms)
+✔ posture family rejects attacking + stealthy conflict (0.102709ms)
+✔ cognition family rejects reflexive + goal_oriented conflict (0.116833ms)
+✔ cross-family motivations compose freely (0.209917ms)
+✔ shorthand string inputs continue to work for new kinds (0.109333ms)
+✔ MOTIVATION_GOAL_TYPES defines supported goal types per kind (1.266458ms)
+✔ normalizeMotivation includes goal for defending with defend_point (0.842417ms)
+✔ normalizeMotivation includes goal for goal_oriented + reach_point (0.7275ms)
+✔ normalizeMotivation omits goal when not provided (0.451958ms)
+✔ normalizeMotivation errors on goal for unsupported kind (0.305291ms)
+✔ normalizeMotivation errors on unknown goal type for kind (0.182375ms)
+✔ normalizeMotivation errors on missing goal type (0.176334ms)
+✔ normalizeMotivation errors on unknown goal param keys (0.304917ms)
+✔ normalizeMotivations passes goals through for composed motivations (0.323792ms)
+✔ string shorthand motivations do not produce goals (0.518458ms)
+✔ goal payload is serializable (frozen params) (0.574833ms)
+✔ runtime loads multi-actor initial state into core (342.583292ms)
+✔ runtime default movement generates golden actions and frames (361.686834ms)
+✔ enforceBudget trims to cap deterministically (2.866792ms)
+✔ enforceBudget passes through when no cap (0.163834ms)
+✔ summary + catalog produces a valid BuildSpec (18.471292ms)
+✔ summary without catalog still produces actor configuration via shared selection mapper (0.825917ms)
+✔ summary roomDesign drives connected-room level shape in BuildSpec (0.876417ms)
+✔ summary roomDesign numeric hints drive level shape in BuildSpec (0.238ms)
+✔ summary roomDesign rooms with counts map to level roomCount (0.216792ms)
+✔ summary hallway overlay hints propagate to level shape in BuildSpec (0.1905ms)
+✔ room bounds and total fields drive level shape without explicit layout (0.185208ms)
+✔ normalizePoolCatalog loads and sorts entries deterministically (12.329833ms)
+✔ normalizePoolCatalog rejects invalid entries (0.275833ms)
+✔ mapSummaryToPool snaps to nearest entry and generates stable IDs (11.647167ms)
+✔ mapSummaryToPool reports missing when no match and propagates catalog errors (0.217167ms)
+✔ mapSummaryToPool snaps arbitrary token hints down deterministically (0.19525ms)
+✔ applyBudgetCaps applies known caps (158.552375ms)
+✔ dispatchEffect handles log path (209.480625ms)
+✔ solver port populates meta (165.337167ms)
+✔ prompt/response fixture parses and matches summary contract (6.272708ms)
+✔ buildLlmActorConfigPromptTemplate includes allowed lists and warden phase shape (5.328667ms)
+✔ buildLlmLevelPromptTemplate injects layout phase metadata (0.267042ms)
+✔ buildLlmLevelPromptTemplate encodes room-first response shape (0.154375ms)
+✔ buildLlmPhasePromptTemplate routes to layout and warden templates (0.170042ms)
+✔ buildLlmActorConfigPromptTemplate scopes warden affinities when provided (0.105083ms)
+✔ normalizeSummary accepts valid summary and rejects invalid fields (0.790584ms)
+✔ normalizeSummary preserves actor vitals when provided (0.12625ms)
+✔ normalizeSummary requires stamina regen for non-stationary actors (0.494625ms)
+✔ normalizeSummary defaults delver config mode when omitted (0.335166ms)
+✔ normalizeSummary accepts delverConfigs and derives delverCount (0.227834ms)
+✔ normalizeSummary preserves delver affinity configuration (0.517167ms)
+✔ normalizeSummary validates delver affinity configuration (0.11725ms)
+✔ normalizeSummary validates delverCount against delverConfigs length (0.102666ms)
+✔ normalizeSummary preserves room design details when provided (0.271875ms)
+✔ capturePromptResponse parses JSON and surfaces errors (0.119667ms)
+✔ normalizeSummaryWithOptions accepts phase metadata and stop reasons (0.120416ms)
+✔ deriveAllowedOptionsFromCatalog unions catalog entries (0.348084ms)
+✔ buildLlmRepairPromptTemplate omits allowed lists when not provided (0.415958ms)
+✔ canonical prompt template markers are centralized in domain-constants (29.602334ms)
+✔ replay produces golden frames for MVP action log (7.405958ms)
+✔ replay mismatch is detected when actions diverge (1.597167ms)
+(node:95128) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/resource-bundle-aura-rendering.test.js is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /Users/darren/intent/workspaces/plan-create/agent-kernel/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+▶ renderBoardWithResourceBundle - aura rendering
+  ✔ renders floor tiles without auras when observation.auras is absent (3.65075ms)
+  ✔ renders floor tiles without auras when observation.auras is empty (1.137167ms)
+  ✔ applies aura tinting to floor tiles when observation.auras is present (1.869375ms)
+  ✔ does not override trap tiles with aura rendering (2.532792ms)
+  ✔ renders different aura visual states correctly (4.612458ms)
+  ✔ handles multiple auras on different tiles (1.64325ms)
+  ✔ skips auras with missing affinity color (0.571792ms)
+  ✔ renders auras only on floor tiles, not walls or barriers (1.469416ms)
+✔ renderBoardWithResourceBundle - aura rendering (18.459875ms)
+✔ resource bundle default artifact validates and renders deterministically (232.378209ms)
+✔ resource bundle visual-assets mode emits v2 mappings and inline asset payloads (253.686708ms)
+✔ renderBoardWithResourceBundle tints floor tiles when affinities are present (164.293042ms)
+✔ renderBoardWithResourceBundle tints floor tiles for observation-style traps (188.365291ms)
+✔ run helpers summarize and compare runtime decisions from tick frames (217.44875ms)
+✔ runtime uses injected runId and clock for deterministic frames (264.751417ms)
+✔ runtime routes rich effect records and preserves ids/requestIds from fixtures (272.3505ms)
+✔ runtime runner produces tick frames (263.796166ms)
+✔ allocator rebalance transitions are driven by runtime signals (318.079291ms)
+✔ buildRuntimeDecisionEnvelope normalizes actor context and candidate actions (333.996833ms)
+✔ runtime decision provider policy only allows live Ollama in explicit manual mode (221.643417ms)
+✔ captured LLM runtime decision resolves to an action without a live provider (157.000708ms)
+✔ fsm runtime advances tick phases and applies persona actions (270.840916ms)
+✔ runtime validates personaEvents/personaPayloads shapes (226.033083ms)
+✔ runtime applies moderator affinity environment actions to core (267.510167ms)
+✔ runtime routes control events to moderator (261.807583ms)
+✔ runtime drives all personas via the FSM schedule (222.916ms)
+✔ runtime emits plan artifacts and orchestrator starts from director output (224.197334ms)
+✔ schema catalog includes core runtime schemas (8.060917ms)
+✔ runtime entrypoints exist (0.88875ms)
+✔ buildSelectionsFromSummary creates deterministic actor and room selections (4.061291ms)
+✔ normalizeSummaryPick maps actor-set role/source fields (0.346833ms)
+✔ normalizeCardEntry removes contradictory motivations from shared exclusive groups (0.715625ms)
+✔ buildSelectionsFromSummary supports delverConfigs array (0.538791ms)
+✔ extractSummaryFromCardSet keeps delver and warden cards as distinct actor picks (1.154416ms)
+✔ buildCardSetFromSummary maps attacking actors to delver cards (0.686666ms)
+✔ buildSelectionsFromSummary derives instance ids from card template ids (0.35225ms)
+✔ runtime records tick frames and fulfillment (163.158167ms)
+✔ normalizeBuildSpecForUi normalizes singleton authoring request fields (7.521041ms)
+✔ level generation benchmark script reports walkability budgets (110.145ms)
+✔ llm prompt benchmark script ranks cleaner runs above repaired runs (44.998834ms)
+✔ index.html includes server readiness check before loading main.js (1.119333ms)
+✔ core-as.wasm exists for CLI and UI surfaces (0.356125ms)
+ℹ tests 624
+ℹ suites 55
+ℹ pass 614
+ℹ fail 8
+ℹ cancelled 0
+ℹ skipped 2
+ℹ todo 0
+ℹ duration_ms 9484.794583
+
+✖ failing tests:
+
+test at tests/adapters-web/adapter-modules.test.js:216:1
+✖ level builder adapter supports in-process and worker-backed requests (252.862917ms)
+  Error: ESM script failed (1): node:internal/modules/run_main:107
+      triggerUncaughtException(
+      ^
+  
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  
+  'W' !== 'w'
+  
+      at file:///Users/darren/intent/workspaces/plan-create/agent-kernel/[eval1]:40:8 {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 'W',
+    expected: 'w',
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+  
+  Node.js v25.9.0
+  
+      at runEsm (/Users/darren/intent/workspaces/plan-create/agent-kernel/tests/helpers/esm-runner.js:30:11)
+      at TestContext.<anonymous> (/Users/darren/intent/workspaces/plan-create/agent-kernel/tests/adapters-web/adapter-modules.test.js:217:3)
+      at Test.runInAsyncScope (node:async_hooks:226:14)
+      at Test.run (node:internal/test_runner/test:1201:25)
+      at Test.processPendingSubtests (node:internal/test_runner/test:831:18)
+      at Test.postRun (node:internal/test_runner/test:1330:19)
+      at Test.run (node:internal/test_runner/test:1258:12)
+      at async Test.processPendingSubtests (node:internal/test_runner/test:831:7)
+
+test at tests/personas/configurator-actor-config-generation.test.js:66:1
+✖ actor config generation cost calculation and validation (181.212042ms)
+  Error: ESM script failed (1): node:internal/modules/run_main:107
+      triggerUncaughtException(
+      ^
+  
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  
+  false !== true
+  
+      at file:///Users/darren/intent/workspaces/plan-create/agent-kernel/[eval1]:32:10
+      at ModuleJob.run (node:internal/modules/esm/module_job:437:25)
+      at async node:internal/modules/esm/loader:246:26
+      at async ModuleLoader.executeModuleJob (node:internal/modules/esm/loader:243:20)
+      at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+  
+  Node.js v25.9.0
+  
+      at runEsm (/Users/darren/intent/workspaces/plan-create/agent-kernel/tests/helpers/esm-runner.js:30:11)
+      at TestContext.<anonymous> (/Users/darren/intent/workspaces/plan-create/agent-kernel/tests/personas/configurator-actor-config-generation.test.js:67:3)
+      at Test.runInAsyncScope (node:async_hooks:226:14)
+      at Test.run (node:internal/test_runner/test:1201:25)
+      at Test.start (node:internal/test_runner/test:1096:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:385:17)
+
+test at tests/personas/orchestrator-llm-budget-loop.test.js:91:1
+✖ orchestrator budget loop sequences layout then actors (273.31175ms)
+  Error: ESM script failed (1): node:internal/modules/run_main:107
+      triggerUncaughtException(
+      ^
+  
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  
+  99 !== 118
+  
+      at file:///Users/darren/intent/workspaces/plan-create/agent-kernel/[eval1]:72:8 {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 99,
+    expected: 118,
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+  
+  Node.js v25.9.0
+  
+      at runEsm (/Users/darren/intent/workspaces/plan-create/agent-kernel/tests/helpers/esm-runner.js:30:11)
+      at TestContext.<anonymous> (/Users/darren/intent/workspaces/plan-create/agent-kernel/tests/personas/orchestrator-llm-budget-loop.test.js:92:3)
+      at Test.runInAsyncScope (node:async_hooks:226:14)
+      at Test.run (node:internal/test_runner/test:1201:25)
+      at Test.start (node:internal/test_runner/test:1096:17)
+      at startSubtestAfterBootstrap (node:internal/test_runner/harness:385:17)
+
+test at tests/runtime/affinity-spatial-formulas.test.js:116:5
+✖ d=1 is non-zero for push (3.479375ms)
+  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
+  
+    assert.ok(computeIntensity(1, 1, "push", W) > 0)
+  
+      at TestContext.<anonymous> (file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-spatial-formulas.test.js:117:14)
+      at Test.runInAsyncScope (node:async_hooks:226:14)
+      at Test.run (node:internal/test_runner/test:1201:25)
+      at Test.start (node:internal/test_runner/test:1096:17)
+      at node:internal/test_runner/test:1617:71
+      at node:internal/per_context/primordials:466:82
+      at new Promise (<anonymous>)
+      at new SafePromise (node:internal/per_context/primordials:435:3)
+      at node:internal/per_context/primordials:466:9
+      at Array.map (<anonymous>) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '==',
+    diff: 'simple'
+  }
+
+test at tests/runtime/affinity-spatial-formulas.test.js:271:5
+✖ equal stacks: potency(0) = 0 (2.335333ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  
+  1 !== 0
+  
+      at TestContext.<anonymous> (file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-spatial-formulas.test.js:273:14)
+      at Test.runInAsyncScope (node:async_hooks:226:14)
+      at Test.run (node:internal/test_runner/test:1201:25)
+      at Suite.processPendingSubtests (node:internal/test_runner/test:831:18)
+      at Test.postRun (node:internal/test_runner/test:1330:19)
+      at Test.run (node:internal/test_runner/test:1258:12)
+      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
+      at async Promise.all (index 0)
+      at async Suite.run (node:internal/test_runner/test:1619:7)
+      at async Promise.all (index 0) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 1,
+    expected: 0,
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+
+test at tests/runtime/affinity-spatial-formulas.test.js:315:5
+✖ stacks 1 → 1 (0.34475ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  
+  2 !== 1
+  
+      at TestContext.<anonymous> (file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-spatial-formulas.test.js:315:37)
+      at Test.runInAsyncScope (node:async_hooks:226:14)
+      at Test.run (node:internal/test_runner/test:1201:25)
+      at Test.start (node:internal/test_runner/test:1096:17)
+      at node:internal/test_runner/test:1617:71
+      at node:internal/per_context/primordials:466:82
+      at new Promise (<anonymous>)
+      at new SafePromise (node:internal/per_context/primordials:435:3)
+      at node:internal/per_context/primordials:466:9
+      at Array.map (<anonymous>) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 2,
+    expected: 1,
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+
+test at tests/runtime/affinity-spatial-formulas.test.js:327:5
+✖ stacks 1 → 0 (0.122666ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  
+  1 !== 0
+  
+      at TestContext.<anonymous> (file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-spatial-formulas.test.js:327:37)
+      at Test.runInAsyncScope (node:async_hooks:226:14)
+      at Test.run (node:internal/test_runner/test:1201:25)
+      at Test.start (node:internal/test_runner/test:1096:17)
+      at node:internal/test_runner/test:1617:71
+      at node:internal/per_context/primordials:466:82
+      at new Promise (<anonymous>)
+      at new SafePromise (node:internal/per_context/primordials:435:3)
+      at node:internal/per_context/primordials:466:9
+      at Array.map (<anonymous>) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: 1,
+    expected: 0,
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+
+test at tests/runtime/affinity-spatial-formulas.test.js:374:3
+✖ push d=1 stacks=1 → non-zero alpha (0.264375ms)
+  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
+  
+    assert.ok(computeTileAlpha(1, 1, "push", W) > 0)
+  
+      at TestContext.<anonymous> (file:///Users/darren/intent/workspaces/plan-create/agent-kernel/tests/runtime/affinity-spatial-formulas.test.js:375:12)
+      at Test.runInAsyncScope (node:async_hooks:226:14)
+      at Test.run (node:internal/test_runner/test:1201:25)
+      at Suite.processPendingSubtests (node:internal/test_runner/test:831:18)
+      at Test.postRun (node:internal/test_runner/test:1330:19)
+      at Test.run (node:internal/test_runner/test:1258:12)
+      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
+      at async Suite.processPendingSubtests (node:internal/test_runner/test:831:7) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: false,
+    expected: true,
+    operator: '==',
+    diff: 'simple'
+  }
+ ELIFECYCLE  Test failed. See above for more details.

--- a/tests/adapters-cli/ak-authoring-commands.test.js
+++ b/tests/adapters-cli/ak-authoring-commands.test.js
@@ -7,6 +7,8 @@ const os = require("node:os");
 
 const ROOT = resolve(__dirname, "../..");
 const CLI = resolve(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+const BUDGET = resolve(ROOT, "tests/fixtures/artifacts/budget-artifact-v1-basic.json");
+const PRICE_LIST = resolve(ROOT, "tests/fixtures/artifacts/price-list-artifact-v1-basic.json");
 
 function runCli(args) {
   return spawnSync(process.execPath, [CLI, ...args], {
@@ -37,7 +39,7 @@ test("cli help documents generic create and configure authoring commands", () =>
   assert.match(result.stdout, /--trap/);
 });
 
-test("cli create authors a multi-object scene and writes an agent request artifact", () => {
+test("cli create emits a complete playable artifact bundle for agent requests", () => {
   const outDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-create-authoring-"));
   runCliOk([
     "create",
@@ -57,19 +59,35 @@ test("cli create authors a multi-object scene and writes an agent request artifa
     "run_create_authoring",
     "--created-at",
     "2026-04-08T00:00:00.000Z",
+    "--budget",
+    BUDGET,
+    "--price-list",
+    PRICE_LIST,
     "--out-dir",
     outDir,
   ]);
 
   assert.equal(existsSync(join(outDir, "request.json")), true);
   assert.equal(existsSync(join(outDir, "spec.json")), true);
+  assert.equal(existsSync(join(outDir, "intent.json")), true);
+  assert.equal(existsSync(join(outDir, "plan.json")), true);
+  assert.equal(existsSync(join(outDir, "budget.json")), true);
+  assert.equal(existsSync(join(outDir, "price-list.json")), true);
+  assert.equal(existsSync(join(outDir, "budget-receipt.json")), true);
+  assert.equal(existsSync(join(outDir, "spend-proposal.json")), true);
   assert.equal(existsSync(join(outDir, "sim-config.json")), true);
   assert.equal(existsSync(join(outDir, "initial-state.json")), true);
+  assert.equal(existsSync(join(outDir, "resource-bundle.json")), true);
+  assert.equal(existsSync(join(outDir, "bundle.json")), true);
+  assert.equal(existsSync(join(outDir, "manifest.json")), true);
+  assert.equal(existsSync(join(outDir, "telemetry.json")), true);
 
   const request = readJson(join(outDir, "request.json"));
   const spec = readJson(join(outDir, "spec.json"));
   const simConfig = readJson(join(outDir, "sim-config.json"));
+  const bundle = readJson(join(outDir, "bundle.json"));
   const manifest = readJson(join(outDir, "manifest.json"));
+  const telemetry = readJson(join(outDir, "telemetry.json"));
 
   assert.equal(request.schema, "agent-kernel/AgentCommandRequestArtifact");
   assert.equal(request.command.action, "author");
@@ -93,6 +111,18 @@ test("cli create authors a multi-object scene and writes an agent request artifa
     && entry.affinity?.stacks === 2
   )));
   assert.ok(manifest.artifacts.some((entry) => entry.path === "request.json" && entry.schema === "agent-kernel/AgentCommandRequestArtifact"));
+  assert.ok(manifest.artifacts.some((entry) => entry.path === "spend-proposal.json" && entry.schema === "agent-kernel/SpendProposal"));
+  assert.ok(manifest.artifacts.some((entry) => entry.path === "resource-bundle.json" && entry.schema === "agent-kernel/ResourceBundleArtifact"));
+  assert.ok(bundle.artifacts.some((artifact) => artifact.schema === "agent-kernel/SpendProposal"));
+  assert.ok(bundle.artifacts.some((artifact) => artifact.schema === "agent-kernel/ResourceBundleArtifact"));
+  assert.deepEqual(
+    telemetry.data.artifactRefs,
+    manifest.artifacts.map((entry) => ({
+      id: entry.id,
+      schema: entry.schema,
+      schemaVersion: entry.schemaVersion,
+    })),
+  );
 });
 
 test("cli configure preserves generic parsing but records configure action", () => {

--- a/tests/adapters-cli/ak-schemas.test.js
+++ b/tests/adapters-cli/ak-schemas.test.js
@@ -32,6 +32,7 @@ test("cli schemas prints catalog to stdout", () => {
   assertSortedSchemas(catalog);
 
   const names = catalog.schemas.map((entry) => entry.schema);
+  assert.ok(names.includes("agent-kernel/AgentCommandRequestArtifact"));
   assert.ok(names.includes("agent-kernel/BuildSpec"));
   assert.ok(names.includes("agent-kernel/IntentEnvelope"));
   assert.ok(names.includes("agent-kernel/SimConfigArtifact"));

--- a/tests/contracts/build-spec.test.js
+++ b/tests/contracts/build-spec.test.js
@@ -47,3 +47,27 @@ test("build spec validation rejects non-object configurator inputs", async () =>
   assert.equal(result.ok, false);
   assert.match(result.errors.join("\n"), /configurator\.inputs/);
 });
+
+test("build spec validation accepts agent authoring contract metadata", async () => {
+  const { validateBuildSpec } = await loadValidator();
+  const spec = readFixture("build-spec-v1-agent-authoring.json");
+  const result = validateBuildSpec(spec);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+});
+
+test("build spec validation rejects invalid agent authoring object kind", async () => {
+  const { validateBuildSpec } = await loadValidator();
+  const spec = readFixture("invalid/build-spec-v1-agent-authoring-invalid-kind.json");
+  const result = validateBuildSpec(spec);
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /authoring\.request\.objects\[0\]\.kind/);
+});
+
+test("build spec validation rejects incomplete agent authoring compilation rules", async () => {
+  const { validateBuildSpec } = await loadValidator();
+  const spec = readFixture("invalid/build-spec-v1-agent-authoring-missing-compilation-rule.json");
+  const result = validateBuildSpec(spec);
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /missing compilation rule for trap/);
+});

--- a/tests/fixtures/artifacts/build-spec-v1-agent-authoring.json
+++ b/tests/fixtures/artifacts/build-spec-v1-agent-authoring.json
@@ -1,0 +1,147 @@
+{
+  "schema": "agent-kernel/BuildSpec",
+  "schemaVersion": 1,
+  "meta": {
+    "id": "build_spec_agent_authoring",
+    "runId": "run_build_agent_authoring",
+    "createdAt": "2026-04-08T00:00:00.000Z",
+    "source": "cli-agent"
+  },
+  "intent": {
+    "goal": "Author a playable fire room with one defending warden.",
+    "hints": {
+      "budgetTokens": 120,
+      "levelAffinity": "fire",
+      "roomCount": 1
+    }
+  },
+  "plan": {
+    "hints": {
+      "rooms": [
+        {
+          "affinity": "fire",
+          "count": 1
+        }
+      ]
+    }
+  },
+  "configurator": {
+    "inputs": {
+      "levelAffinity": "fire",
+      "rooms": [
+        {
+          "affinity": "fire",
+          "trapAffinity": "fire"
+        }
+      ],
+      "actors": [
+        {
+          "role": "warden",
+          "count": 1,
+          "affinity": "fire",
+          "motivation": "defending"
+        }
+      ]
+    }
+  },
+  "authoring": {
+    "objectKinds": [
+      "room",
+      "warden",
+      "shared_config"
+    ],
+    "request": {
+      "schema": "agent-kernel/AgentCommandRequestArtifact",
+      "schemaVersion": 1,
+      "meta": {
+        "id": "agent_command_request_basic",
+        "runId": "run_build_agent_authoring",
+        "createdAt": "2026-04-08T00:00:00.000Z",
+        "producedBy": "test"
+      },
+      "command": {
+        "action": "author",
+        "text": "Create a fire room with one defending warden and a small budget.",
+        "source": "cli-agent",
+        "taxonomyVersion": 1
+      },
+      "objects": [
+        {
+          "kind": "room",
+          "prompt": "one fire room",
+          "count": 1
+        },
+        {
+          "kind": "warden",
+          "prompt": "one defending warden",
+          "count": 1
+        },
+        {
+          "kind": "shared_config",
+          "prompt": "small affordable dungeon setup"
+        }
+      ],
+      "sharedConfig": {
+        "dungeonAffinity": "fire",
+        "budgetTokens": 120,
+        "roomCount": 1
+      },
+      "compilation": {
+        "rules": [
+          {
+            "kind": "room",
+            "compileTo": [
+              {
+                "target": "build_spec_plan",
+                "path": "plan.hints.rooms",
+                "legacyFlow": "room-plan"
+              },
+              {
+                "target": "build_spec_configurator",
+                "path": "configurator.inputs.cardSet",
+                "legacyFlow": "room-plan"
+              }
+            ]
+          },
+          {
+            "kind": "warden",
+            "compileTo": [
+              {
+                "target": "build_spec_plan",
+                "path": "plan.hints.cardSet",
+                "legacyFlow": "warden-plan"
+              },
+              {
+                "target": "build_spec_configurator",
+                "path": "configurator.inputs.actors",
+                "legacyFlow": "warden-plan"
+              }
+            ]
+          },
+          {
+            "kind": "shared_config",
+            "compileTo": [
+              {
+                "target": "build_spec_intent",
+                "path": "intent.hints"
+              },
+              {
+                "target": "build_spec_configurator",
+                "path": "configurator.inputs"
+              }
+            ]
+          }
+        ]
+      },
+      "compatibility": {
+        "preserveExistingCommands": true,
+        "supportedLegacyFlows": [
+          "room-plan",
+          "warden-plan",
+          "build",
+          "configurator"
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/artifacts/invalid/build-spec-v1-agent-authoring-invalid-kind.json
+++ b/tests/fixtures/artifacts/invalid/build-spec-v1-agent-authoring-invalid-kind.json
@@ -1,0 +1,54 @@
+{
+  "schema": "agent-kernel/BuildSpec",
+  "schemaVersion": 1,
+  "meta": {
+    "id": "build_spec_agent_authoring_invalid",
+    "runId": "run_build_agent_authoring_invalid",
+    "createdAt": "2026-04-08T00:00:00.000Z",
+    "source": "cli-agent"
+  },
+  "intent": {
+    "goal": "Invalid authored object kind."
+  },
+  "authoring": {
+    "objectKinds": [
+      "room",
+      "boss"
+    ],
+    "request": {
+      "schema": "agent-kernel/AgentCommandRequestArtifact",
+      "schemaVersion": 1,
+      "meta": {
+        "id": "agent_command_request_invalid_kind",
+        "runId": "run_build_agent_authoring_invalid",
+        "createdAt": "2026-04-08T00:00:00.000Z",
+        "producedBy": "test"
+      },
+      "command": {
+        "action": "author",
+        "text": "Create one boss room.",
+        "source": "cli-agent",
+        "taxonomyVersion": 1
+      },
+      "objects": [
+        {
+          "kind": "boss",
+          "prompt": "one boss room"
+        }
+      ],
+      "compilation": {
+        "rules": [
+          {
+            "kind": "boss",
+            "compileTo": [
+              {
+                "target": "build_spec_plan",
+                "path": "plan.hints.cardSet"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/runtime/ui-flow-normalize.test.js
+++ b/tests/runtime/ui-flow-normalize.test.js
@@ -1,0 +1,69 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { moduleUrl } = require("../helpers/esm-runner");
+
+async function loadUiFlow() {
+  return import(moduleUrl("packages/runtime/src/commands/ui-flow.js"));
+}
+
+test("normalizeBuildSpecForUi normalizes singleton authoring request fields", async () => {
+  const { normalizeBuildSpecForUi } = await loadUiFlow();
+
+  const input = {
+    schema: "agent-kernel/BuildSpec",
+    schemaVersion: 1,
+    meta: {
+      id: "build_spec_ui_normalize",
+      runId: "run_ui_normalize",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      source: "ui-web",
+    },
+    intent: {
+      goal: "Normalize authoring fields",
+    },
+    authoring: {
+      objectKinds: "room",
+      request: {
+        schema: "agent-kernel/AgentCommandRequestArtifact",
+        schemaVersion: 1,
+        meta: {
+          id: "agent_command_ui_normalize",
+          runId: "run_ui_normalize",
+          createdAt: "2026-04-08T00:00:00.000Z",
+          producedBy: "test",
+        },
+        command: {
+          action: "author",
+          text: "author one room",
+          source: "ui-web",
+          taxonomyVersion: 1,
+        },
+        objects: {
+          kind: "room",
+          prompt: "one room",
+          count: 1,
+        },
+        compilation: {
+          rules: {
+            kind: "room",
+            compileTo: {
+              target: "build_spec_plan",
+              path: "plan.hints.cardSet",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const normalized = normalizeBuildSpecForUi(input);
+
+  assert.equal(normalized.changed, true);
+  assert.deepEqual(normalized.spec.authoring.objectKinds, ["room"]);
+  assert.equal(Array.isArray(normalized.spec.authoring.request.objects), true);
+  assert.equal(Array.isArray(normalized.spec.authoring.request.compilation.rules), true);
+  assert.equal(
+    Array.isArray(normalized.spec.authoring.request.compilation.rules[0].compileTo),
+    true,
+  );
+});


### PR DESCRIPTION
Implements a full agent-facing CLI surface that allows any game object (room, floor-tile, delver, warden, trap, etc.) to be created and configured via text commands issued from agent skills. When an agent skill submits a command such as "create a large irregular fire-themed room with multiple traps", the CLI assembles all playable artifacts and the generated room image is shown on screen.

**Changes:**
- Add `AgentCommandRequest` artifact contract and typed object taxonomy covering all authoring-relevant game object kinds
- Implement `ak-impl.mjs` CLI authoring commands with full `BuildSpec` compilation and bundle emission
- Add `build-spec.js` contract with validation and `AgentCommandRequest` ↔ `BuildSpec` translation
- Wire `ui-flow.js` command routing so agent requests reach the UI and trigger image display in `preview-view.js`
- Add `build-spec-ui.js` and `design-view.js` components to expose every card-configuration feature in the browser UI
- Extend `bundle-review.js` and `build-orchestrator.js` to emit complete playable artifact bundles
- Comprehensive test coverage: end-to-end agent-authoring flow, CLI authoring commands, UI component tests, contract fixtures, and UI↔CLI equivalence tests

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author