### PR TITLE
[codex] Normalize price list cost handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Claude is the **orchestration and implementation engine**. Codex drives ideation
 
 ## Session-Start Protocol (mandatory before first code change)
 
-Before writing any code in a new session, Claude must complete the checklist in `AGENTS.md → Session-Start Checklist`. The short form:
+Before writing any code in a new session, complete the checklist in `AGENTS.md → Session-Start Checklist`. The short form:
 
 1. Read `~/vault/hot.md` — last-session compounding context
 2. Read `~/vault/index.md` — vault catalog (only if `hot.md` is sparse)
@@ -16,7 +16,7 @@ Before writing any code in a new session, Claude must complete the checklist in 
 6. Rebuild graphify: `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` 
 7. Start CodeContextGraph watch: `mcp__CodeGraphContext__watch_directory` on repo root
 8. Read `graphify-out/wiki/index.md` for community map
-9. Rewrite `local-codex/CodeContext.md` from the three MCP queries (`local-codex/` symlinks resolve to `~/vault/sources/codex-snapshots/`)
+9. Rewrite `local-codex/CodeContext.md` from three MCP queries (`local-codex/` symlinks resolve to `~/vault/sources/codex-snapshots/`)
 
 **This is not optional.** A stale vault context or missing dependencies produces wrong structural answers that compound across milestones.
 
@@ -28,60 +28,38 @@ Before writing any code in a new session, Claude must complete the checklist in 
 |------|-------|---------------|-----------|
 | Ideation, plan authoring | **Codex** | gpt-5.4 / high | `/codex:review` via plugin |
 | Adversarial plan / code verification | **Codex** | gpt-5.4 / high | `/codex:adversarial-review` via plugin |
-| Orchestration — split plans, assign milestones to agents | **Claude Opus** | claude-opus-4-7 / high | Direct — Claude's primary orchestration role |
-| Implementation — write and refactor code | **Claude Sonnet** | claude-sonnet-4-6 / high | Direct — Claude's primary coding role |
+| Orchestration — split plans, assign milestones | **Claude Opus** | claude-opus-4-7 / high | Direct |
+| Implementation — write and refactor code | **Claude Sonnet** | claude-sonnet-4-6 / high | Direct |
 | Author base-level tests (with TODO permutation stubs) | **Claude Sonnet** | claude-sonnet-4-6 / medium | Direct |
-| Expand test permutations from TODO stubs | **Ollama** (local model) | local / — | `/ollama-test-permutations` skill, launched via Claude Code harness |
+| Expand test permutations from TODO stubs | **Ollama** (local model) | local / — | `/ollama-test-permutations` skill |
 | Summarize artifacts, classify schemas, extract structured data | **Ollama** (local model) | local / — | `local_summarize`, `local_classify`, `local_extract` via MCP |
 | Author commit messages, open PRs, update architecture / design / README docs | **GitHub Copilot** | — | Native `gh` CLI + Copilot agent |
 
-**Code navigation (all agents):** Claude, Ollama, and Codex all have live MCP access to CodeContextGraph. Query the graph before opening files or running text searches, and name the query you used when handing off or justifying a target area.
+All agents have live MCP access to CodeContextGraph. Name the query used when handing off or justifying a target area.
 
-### Codex — ideation, planning, adversarial verification
+### Codex
 
-Use the Codex plugin (`/codex:*`) for:
-- **Ideation**: exploring solution approaches before a plan is written.
-- **Plan authoring**: producing `local-codex/Plan.md` (symlink → `~/vault/plans/active/Plan.md`) from a prompt or spec.
-- **Adversarial review**: stress-testing a design decision or a completed diff from a different model family to reduce sycophancy bias.
+Use `/codex:*` for ideation, plan authoring (`local-codex/Plan.md` → `~/vault/plans/active/Plan.md`), and adversarial review. Every adversarial review must answer: (1) **Correctness** — does the diff satisfy the milestone spec? (2) **Simplicity** — is it 3× more complex than the simplest solution? If yes, provide a specific rewrite. Codex does not write production code or tests.
 
-Every adversarial review must explicitly answer two questions:
-1. **Correctness** — does the diff do what the milestone spec requires?
-2. **Simplicity** — is this implementation 3× more complex than the simplest solution that meets the spec? If yes, flag it with a specific rewrite suggestion.
+### Claude
 
-Codex does **not** write production code or tests in this workflow — that is Claude's responsibility.
+**Before any milestone code:** state assumptions explicitly, surface ambiguity (stop and ask rather than guess), present tradeoffs if a simpler path exists.
 
-### Claude — orchestration and implementation
+**Implementation order:** (1) failing tests + TODO permutation stubs → (2) production code → (3) hand TODO stubs to Ollama.
 
-**Orchestration (Opus / high):** When a plan arrives, Claude Opus splits it into bounded milestones, assigns each milestone to the correct agent, and tracks handoff state. Orchestration decisions include: milestone sizing, dependency ordering, and which agent handles each task.
+**Test-first:** every test file ends with `## TODO: Test Permutations` stubs — the handoff trigger for Ollama.
 
-**Coding (Sonnet / high):** Claude Sonnet implements all production code — new features, bug fixes, and architecture-conformance refactors. Claude refactors any code that violates the Ports & Adapters pattern without waiting for permission.
+### Ollama
 
-Before writing any code for a milestone, Claude must:
-1. **State assumptions explicitly** — list what it is assuming about scope, interfaces, and expected behaviour.
-2. **Surface ambiguity** — if anything is unclear, stop and ask rather than guessing. Name what is confusing.
-3. **Present tradeoffs** — if a simpler approach exists, say so before implementing the complex one.
+Reads `## TODO: Test Permutations` stubs and expands them in place via `/ollama-test-permutations`. Read `tests/README.md` first. Do not use for architecture decisions, enforcement reviews, or persona FSM design.
 
-**Test-first authoring (Sonnet / medium → high):** Claude writes failing tests *before* production code. Tests are the success criteria; code is written to make them pass. Every test file must end with a `## TODO: Test Permutations` section with plain-language stubs for edge cases. These stubs are the handoff signal to Ollama.
+### GitHub Copilot
 
-For low-complexity delegated test work, Claude should point the local-model harness at `tests/README.md` first. That file defines the bounded MCP-first workflow for permutation expansion, CLI option-matrix exploration, and narrow test execution.
-
-The implementation order for every milestone is:
-1. State assumptions (pause if unclear)
-2. Write failing tests + TODO permutation stubs
-3. Write production code to make tests pass
-4. Hand TODO stubs to Ollama for expansion
-
-### Ollama — test permutation expansion
-
-Ollama (local model, launched via Claude Code harness) reads the `## TODO: Test Permutations` stubs and generates the concrete test cases in place. Trigger via the `/ollama-test-permutations` skill. Before doing permutation work, read `tests/README.md`. Use the test-harness MCP to discover patterns, scaffold or insert cases, run narrow scopes, and explain failures. Do **not** use Ollama for architecture decisions, enforcement reviews, or persona FSM design.
+Authors commit messages, opens PRs, and updates `docs/architecture-charter.md`, `docs/architecture/diagram.mmd`, `docs/README.md`, `packages/adapters-cli/README.md`, and any README changed by the work. Does not write production code or tests.
 
 ---
 
 ## Code Navigation — CodeContextGraph vs graphify
-
-Two graph tools exist in this repo. They answer different questions. Using the wrong one wastes tokens.
-
-### Decision table
 
 | Question | Use | Never use |
 |---|---|---|
@@ -90,133 +68,45 @@ Two graph tools exist in this repo. They answer different questions. Using the w
 | Which files are riskiest to touch? | CodeContextGraph `find_most_complex_functions` | graphify |
 | Find unused code | CodeContextGraph `find_dead_code` | graphify |
 | Repo-wide file / function counts | CodeContextGraph `get_repository_stats` | graphify |
-| How do concepts cluster in this codebase? | graphify wiki (`graphify-out/wiki/index.md`) | CodeContextGraph |
-| High-level architecture orientation (session start) | graphify wiki | CodeContextGraph |
-| What is this repo actually *about*? | graphify wiki | CodeContextGraph |
+| How do concepts cluster? | graphify wiki (`graphify-out/wiki/index.md`) | CodeContextGraph |
+| High-level architecture orientation | graphify wiki | CodeContextGraph |
 
-### Session-start rule
+**Read `graphify-out/wiki/index.md` before any CodeContextGraph queries** — one file read vs. multiple MCP round-trips. Once oriented, use CodeContextGraph for all structural lookups.
 
-**At the start of every session, read `graphify-out/wiki/index.md` before issuing any CodeContextGraph queries.** The wiki is a pre-built semantic map; reading it costs one file read. Querying CodeContextGraph for the same orientation costs multiple MCP round-trips. Once oriented, switch to CodeContextGraph for all structural lookups.
+**Graph before grep:** query CodeContextGraph before any `grep`/`rg`/`find`/`Glob`. Text search is only permitted for literal content (README prose, fixture strings, exact command examples) — not for code discovery. Before using text search, name the MCP query already tried and why it was insufficient.
 
-### Do not re-run `/graphify` during an active coding session
+**Failure policy:** if CodeContextGraph is unavailable or returns insufficient results, stop and report: which query was attempted, what was missing, and what decision is blocked. Do not silently fall back to filesystem search.
 
-CodeContextGraph handles incremental updates automatically on every file save. Re-running `/graphify` mid-session is expensive and redundant. Reserve `/graphify` for:
-- Post-milestone documentation passes
-- Onboarding a new agent to a large unfamiliar body of content
-- After a major structural refactor when the semantic map is stale
-
-### Mandatory rule: graph before grep
-
-**Claude and Ollama must query CodeContextGraph before using any filesystem search** (`grep`, `rg`, `find`, `Glob`). Filesystem search is not an equal alternative to MCP; it is a narrow exception path only.
-
-| Need | Use instead of grep/find |
-|------|--------------------------|
-| Find where a function is defined | `mcp__CodeGraphContext__find_code` |
-| Understand what a module imports / is imported by | `mcp__CodeGraphContext__analyze_code_relationships` |
-| Find the most complex / risky files | `mcp__CodeGraphContext__find_most_complex_functions` |
-| Count files, functions, modules | `mcp__CodeGraphContext__get_repository_stats` |
-| Arbitrary structural query | `mcp__CodeGraphContext__execute_cypher_query` |
-| Find unused code | `mcp__CodeGraphContext__find_dead_code` |
-
-### Failure policy: stop, then report
-
-If CodeContextGraph is unavailable, stale, misconfigured, or returns insufficient structural results, Claude must stop and report the MCP issue explicitly. Do **not** silently fall back to `grep`, `rg`, `find`, or `Glob` for code discovery or file selection.
-
-A valid report includes:
-- which MCP query was attempted
-- what was missing or broken in the result
-- what decision is blocked until MCP is working
-
-### Narrow exception: literal content search only
-
-Text search is allowed only for exact literal/content matching that CodeContextGraph does not model well, such as:
-- README prose or design-doc wording
-- fixture strings or expected error text
-- known schema names or literal command examples when the task is about the exact text itself
-
-Before using text search for one of those cases, Claude must:
-1. Name the MCP query it already tried.
-2. Explain why the graph is insufficient for this exact content lookup.
-3. Keep the text search scoped to the known content target rather than using it to discover code structure.
+**Re-run `/graphify` only for:** post-milestone docs passes, onboarding a new agent, or after a major structural refactor. CodeContextGraph handles incremental updates automatically on every file save.
 
 ### CodeContext snapshot for Codex handoffs
 
-Codex has direct MCP access to CodeContextGraph via its own MCP config (`codex mcp list` confirms `codegraphcontext` is enabled). Codex can and should query the graph directly during tasks using the same tools Claude uses.
-
-However, Claude should still generate `local-codex/CodeContext.md` before each Codex handoff as a **startup orientation document** — it saves Codex from spending its first turns querying for the overall picture, and gives it a pre-computed starting point. The snapshot must cover:
-
-1. Repository stats (files, functions, modules)
-2. Package dependency summary — which packages import which
-3. Entry points relevant to the milestone's target files
-4. Any dead code or high-complexity hotspots in the affected area
-
-Generate the snapshot with:
-```
-mcp__CodeGraphContext__get_repository_stats        → overall counts
-mcp__CodeGraphContext__analyze_code_relationships  → per-package dependencies
-mcp__CodeGraphContext__find_most_complex_functions → top 10 complexity hotspots
-```
-
-Write the result to `local-codex/CodeContext.md` (symlink → `~/vault/sources/codex-snapshots/CodeContext.md`). Codex reads this file at startup for orientation, then queries the live graph for detail as needed during the task.
-
-Before opening implementation files or proposing edits, Claude should cite the CodeContextGraph query or queries it used to locate the target area. This makes MCP-first navigation auditable in the transcript.
-
-### Keeping the graph current
-
-The watch handles incremental updates automatically. After any large structural refactor (new package, deleted module, renamed file), run:
-```
-mcp__CodeGraphContext__add_package_to_graph  → re-index a whole package
-```
-to force a full re-scan of the affected area.
-
-### GitHub Copilot — documentation and commits only
-
-Copilot's sole responsibilities are:
-- Authoring commit messages.
-- Opening and describing pull requests.
-- Updating system documentation: `docs/architecture-charter.md`, `docs/architecture/diagram.mmd`, `docs/README.md`, `packages/adapters-cli/README.md`, and any other README or design doc that changes as a result of the work.
-
-Copilot does **not** write production code or tests.
+Before each Codex handoff, write `local-codex/CodeContext.md` (symlink → `~/vault/sources/codex-snapshots/CodeContext.md`) covering: repo stats, package dependency summary, entry points for the milestone's target files, and top-10 complexity hotspots (`get_repository_stats`, `analyze_code_relationships`, `find_most_complex_functions`). Cite the queries used before opening any implementation file. After a large structural refactor, run `mcp__CodeGraphContext__add_package_to_graph` to force a full re-scan.
 
 ---
 
 ## Commands
 
 ```bash
-# Install dependencies
-pnpm install
-
-# Compile AssemblyScript → WASM (required before tests that use WASM)
-pnpm run build:wasm
-
-# Run the default Node-side suite (Vitest)
-pnpm run test
-
-# Run a single Vitest-managed test file
-pnpm run test:vitest -- tests/<path>/<name>.test.js
-
-# Run a browser-native Playwright spec
-pnpm run test:playwright -- tests/playwright/<name>.spec.mjs
-
-# Check WASM binary is present
-pnpm run test:wasm-check
-
-# Start UI dev server (http://localhost:8001/packages/ui-web/index.html)
-pnpm run serve:ui
-
-# Run CLI demo
-pnpm run demo:cli
+pnpm install                                                     # Install dependencies
+pnpm run build:wasm                                              # Compile AssemblyScript → WASM
+pnpm run test                                                    # Run Vitest suite
+pnpm run test:vitest -- tests/<path>/<name>.test.js             # Single Vitest file
+pnpm run test:playwright -- tests/playwright/<name>.spec.mjs   # Playwright spec
+pnpm run test:wasm-check                                         # Confirm WASM binary present
+pnpm run serve:ui                                                # UI dev server :8001
+pnpm run demo:cli                                                # CLI demo
 ```
 
-**WASM note:** Tests that require the WASM binary skip gracefully when `build/core-as.wasm` is absent. Run `pnpm run build:wasm` first to enable them.
+Tests requiring the WASM binary skip gracefully when `build/core-as.wasm` is absent — run `pnpm run build:wasm` first.
 
 ---
 
 ## Architecture Overview
 
-This is a WASM-first simulation kernel using **Ports & Adapters** with deterministic persona state machines. It is a `pnpm` monorepo (`packages/*`).
+WASM-first simulation kernel using **Ports & Adapters** with deterministic persona state machines. `pnpm` monorepo (`packages/*`).
 
-### Package Dependency Direction (non-negotiable)
+### Dependency Direction (non-negotiable)
 
 ```
 adapters-* / ui-web
@@ -252,54 +142,19 @@ tests/
 
 ---
 
-## Claude's Role
-
-Claude is the **active orchestrator and implementation engine** on this project.
-
-**As orchestrator (Opus / high):** Claude reads the plan, sizes milestones, and assigns work to the correct agent. It does not start coding until the plan is decomposed and each milestone is bounded.
-
-**As implementer (Sonnet / high):** Claude writes all production code. When code violates the architecture or design pattern, Claude refactors it — restructuring as needed to bring it into conformance while preserving the original intent. Claude does not wait for a human to approve a fix; it makes the fix directly.
-
-Specifically, Claude:
-
-- Reads and understands what the code is trying to do.
-- Identifies any violations of the Ports & Adapters pattern or the persona FSM contract.
-- Rewrites the offending code to conform — moving, splitting, or restructuring files and functions as required.
-- Preserves the semantic meaning of the code throughout. Logic is kept; structure is corrected.
-- Does not add features, extra abstractions, or unrelated improvements beyond what conformance requires.
-
-**As test author (Sonnet / medium):** After each coding milestone Claude writes the base test file and appends a `## TODO: Test Permutations` section with plain-language stubs for edge cases. This section is the handoff trigger for Ollama.
-
----
-
 ## Design Pattern: Ports & Adapters with Persona State Machines
 
-All code must conform to this pattern. Claude enforces it on every diff.
-
-### Dependency Direction (non-negotiable)
-
-```
-adapters-* / ui-web
-      ↓
-   runtime          ← personas live here
-      ↓
- bindings-ts        ← WASM boundary only
-      ↓
-  core-as           ← WASM, pure logic, no IO
-```
-
-Violations of this direction are **blocking** — do not approve.
+All code must conform. Dependency direction is the same as above — violations are **blocking**, do not approve.
 
 ### core-as (WASM)
 
-- Contains **only** deterministic simulation logic: state transitions, validation, render frame generation, and effect emission as data.
-- Must import nothing outside itself. No IO, no environment access, no clock.
-- Effects are emitted as deterministic data (kind + requestId + fulfillment hints). They are not IO.
-- If generated code introduces IO or an external import into `core-as`, Claude moves or rewrites it into the correct layer before the change lands.
+- Contains **only** deterministic logic: state transitions, validation, render frame generation, effects as data.
+- No IO, no environment access, no clock. Must import nothing outside itself.
+- If code introduces IO or an external import into `core-as`, move it to the correct layer before the change lands.
 
 ### Runtime Personas
 
-Each persona is a **deterministic state machine** with this contract:
+Each persona is a **deterministic state machine**:
 
 ```typescript
 // controller.mts
@@ -311,12 +166,7 @@ view(): PersonaState
 advance(event, payload): { state, context, effects }
 ```
 
-- Clock must be injected, not read directly.
-- Context must be serializable.
-- Effects are data — routing happens via `ports/effects.js`, not inside the persona.
-- A persona must not reach outside its defined port interface.
-
-**Defined personas and their phases:**
+Clock injected, never read directly. Context serializable (no class instances, no functions). Effects are data — routed via `ports/effects.js`, never executed inline.
 
 | Persona | Tick Phases | Responsibility |
 |---|---|---|
@@ -328,115 +178,82 @@ advance(event, payload): { state, context, effects }
 | Annotator | emit, summarize | Telemetry capture and normalization |
 | Moderator | all | Tick control, ordering strategy, effect fulfillment |
 
-New personas require a `controller.mts`, `state-machine.mts`, `contracts.ts`, and at minimum one state handler.
+New personas require `controller.mts`, `state-machine.mts`, `contracts.ts`, and at least one state handler.
 
 ### Adapters
 
-- All external IO (LLM, IPFS, blockchain, solver, logging) lives in adapter packages only.
-- Adapters receive effects dispatched from `runtime/src/ports/effects.js`; they do not pull state.
-- Adapter packages: `adapters-web`, `adapters-cli`, `adapters-test`.
-- Test adapters must be fixture-based and produce fully deterministic output.
+All external IO (LLM, IPFS, blockchain, solver, logging) lives in `adapters-web`, `adapters-cli`, or `adapters-test` only. Adapters receive effects from `runtime/src/ports/effects.js`; they do not pull state. Test adapters must be fixture-based and produce fully deterministic output.
 
 ### Artifacts
 
-All data crossing a boundary must use a versioned artifact schema from `packages/runtime/src/contracts/artifacts.ts`:
+All boundary-crossing data must use a versioned schema from `packages/runtime/src/contracts/artifacts.ts`:
 
 ```typescript
-{
-  schema: "agent-kernel/ArtifactName",
-  schemaVersion: 1,
-  meta: ArtifactMeta   // id, runId, createdAt, producedBy, correlationId
-}
+{ schema: "agent-kernel/ArtifactName", schemaVersion: 1, meta: ArtifactMeta }
 ```
 
-- Evolve `schemaVersion` on breaking changes; never remove or rename fields in-place.
+Evolve `schemaVersion` on breaking changes; never remove or rename fields in-place.
 
 ---
 
 ## Claude's Enforcement Checklist
 
-Run this on every diff. For each failed item, Claude fixes the code — not just flags it.
+Run on every diff. Fix failures — don't just flag them.
 
 ### Architecture
-
-- [ ] Dependency direction flows only: adapters/ui → runtime → bindings-ts → core-as
+- [ ] Dependency flows only: adapters/ui → runtime → bindings-ts → core-as
 - [ ] `core-as` has no IO and no imports outside itself
 - [ ] All external IO is behind an adapter in `adapters-web`, `adapters-cli`, or `adapters-test`
-- [ ] No adapter code has leaked into `runtime` or `core-as`
+- [ ] No adapter code in `runtime` or `core-as`
 
 ### Personas
-
-- [ ] Each persona is a pure FSM: `view()` + `advance(event, payload)`
-- [ ] Clock is injected, not read directly
-- [ ] Context is serializable (no class instances, no functions in state)
-- [ ] Effects are returned as data, not executed inline
+- [ ] Pure FSM: `view()` + `advance(event, payload)`
+- [ ] Clock injected, not read directly
+- [ ] Context serializable (no class instances, no functions in state)
+- [ ] Effects returned as data, not executed inline
 - [ ] New persona folders include `controller.mts`, `state-machine.mts`, `contracts.ts`
 
 ### Artifacts
-
 - [ ] All boundary-crossing data uses a schema from `artifacts.ts`
-- [ ] `schema`, `schemaVersion`, and `meta` fields are present
-- [ ] No new field names conflict with existing artifact contracts
+- [ ] `schema`, `schemaVersion`, `meta` present
+- [ ] No new field names conflict with existing contracts
 
 ### Tests
-
-- [ ] Failing tests written *before* production code for this milestone
-- [ ] New behavior has a corresponding test under `tests/`
+- [ ] Failing tests written *before* production code
+- [ ] New behavior has a test under `tests/`
 - [ ] Deterministic behavior uses fixture-based tests
-- [ ] Negative cases have fixtures under `tests/fixtures/artifacts/invalid/`
-- [ ] No test reaches live external services (use `adapters-test` fixtures)
-- [ ] Base test file ends with a `## TODO: Test Permutations` section before Ollama handoff
+- [ ] Negative cases under `tests/fixtures/artifacts/invalid/`
+- [ ] No test reaches live external services
+- [ ] Base test file ends with `## TODO: Test Permutations` before Ollama handoff
 
 ### Code Quality
-
-- [ ] Every changed line traces to the current milestone spec — no adjacent cleanup, reformatting, or drive-by refactoring
-- [ ] Implementation is no more complex than the milestone requires; a senior engineer would not flag it as over-engineered
-- [ ] Assumptions stated explicitly before implementation began; nothing was silently assumed
+- [ ] Every changed line traces to the current milestone spec — no drive-by cleanup or refactoring
+- [ ] Not over-engineered; a senior engineer would not flag it
+- [ ] Assumptions stated before implementation began
 
 ### File Placement
-
-- [ ] Runtime code is in `packages/runtime/src/`
-- [ ] Core logic is in `packages/core-as/assembly/`
-- [ ] Web adapters are in `packages/adapters-web/src/adapters/`
-- [ ] CLI adapters and commands are in `packages/adapters-cli/src/`
-- [ ] Tests are in `tests/**`
-- [ ] Fixtures are in `tests/fixtures/**`
+- [ ] Runtime: `packages/runtime/src/`
+- [ ] Core: `packages/core-as/assembly/`
+- [ ] Web adapters: `packages/adapters-web/src/adapters/`
+- [ ] CLI: `packages/adapters-cli/src/`
+- [ ] Tests: `tests/**` — fixtures: `tests/fixtures/**`
 
 ### Documentation
-
-- [ ] If architecture boundaries changed: `docs/architecture-charter.md` and `docs/architecture/diagram.mmd` are updated — by Copilot in the same PR
-- [ ] If public CLI flags or behavior changed: `packages/adapters-cli/README.md` is updated — by Copilot in the same PR
-
----
-
-## When Claude Refactors Code
-
-Claude refactors any code that fails the enforcement checklist. The guiding principles are:
-
-- **Preserve intent**: the refactored code must do what the original code intended.
-- **Correct structure**: move code to the right layer, split files as required, extract ports where missing.
-- **Minimum footprint**: change only what conformance requires. Do not clean up unrelated code, add comments to unchanged lines, or introduce new abstractions beyond what the architecture demands.
-- **Tests follow**: if a structural change affects test coverage, update or add tests in the same pass.
-
-Claude does not ask for permission before refactoring a clear violation. If the correct fix is ambiguous, see Escalation below.
+- [ ] Architecture boundaries changed → update `docs/architecture-charter.md` + `docs/architecture/diagram.mmd` (Copilot, same PR)
+- [ ] CLI flags/behavior changed → update `packages/adapters-cli/README.md` (Copilot, same PR)
 
 ---
 
-## Escalation
+## Refactoring and Escalation
 
-Claude escalates (rather than refactoring unilaterally) when:
+**Refactor without asking** when the fix is clear: preserve intent, move code to the right layer, extract ports where missing, change only what conformance requires, update tests in the same pass.
 
-- The correct layer for a piece of logic is genuinely ambiguous given the charter.
-- Fixing the violation would require updating `docs/architecture-charter.md` or `docs/architecture/diagram.mmd`.
-- The refactor would touch more than one package boundary and the intended behaviour is unclear.
+**Escalate instead** when:
+- The correct layer is genuinely ambiguous given the charter.
+- The fix requires updating `docs/architecture-charter.md` or `docs/architecture/diagram.mmd`.
+- The refactor touches more than one package boundary with unclear intent.
 
-In those cases Claude:
-
-1. States the specific violation and the relevant charter rule.
-2. Proposes the minimal corrective change and explains the trade-off.
-3. Waits for human confirmation before making the change.
-
-Claude does not silently pass ambiguous code.
+On escalation: state the violation and charter rule, propose the minimal fix with tradeoffs, wait for confirmation. Do not silently pass ambiguous code.
 
 ---
 
@@ -452,40 +269,28 @@ Claude does not silently pass ambiguous code.
 | `packages/runtime/src/ports/effects.js` | Effect dispatch — the adapter boundary |
 | `packages/runtime/src/runner/runtime-fsm.mjs` | Six-phase tick orchestration |
 | `packages/core-as/assembly/index.ts` | WASM export surface |
-| `docs/readme-index.md` | Index of all README files with one-line summaries of what code belongs in each package/directory |
+| `docs/readme-index.md` | Index of all README files with one-line summaries |
 
 ---
 
 ## Vault-Backed Knowledge Management
 
-Non-load-bearing knowledge — historical plans, design rationale, dictation, scratch notes — lives in
-an Obsidian vault outside this repo. Code-binding contracts (charter, vision, runbooks) stay here.
-See the Session-Start Protocol above for the canonical orientation order.
+Non-load-bearing knowledge — plans, design rationale, dictation, scratch notes — lives in the Obsidian vault. Code-binding contracts stay in the repo. See Session-Start Protocol for the canonical orientation order.
 
 ### Vault paths
-
-- **Mac:**     `~/Documents/Obsidian/agent-kernel-vault/`
-- **Linux:**   `~/agent-kernel-vault/`
-- **Both:**    `~/vault` (symlink) — use this in any path you cite
+- **Mac:** `~/Documents/Obsidian/agent-kernel-vault/`
+- **Linux:** `~/agent-kernel-vault/`
+- **Both:** `~/vault` (symlink) — use this in any path you cite
 
 ### Repo-vault interaction
-
-- `local-codex/Plan.md`, `Prompt.md`, `Implement.md`, `Documentation.md`, `Dictation.md`,
-  `CodeContext.md` are **symlinks** into the vault. Read/write them as before — they resolve to
-  `~/vault/plans/active/...` and `~/vault/sources/codex-snapshots/...`.
-- Decisions live in `~/vault/decisions/`. When you make a non-trivial design call, save it via
-  `/save` so it lands there.
-- When citing code from a vault note, use stable IDs: `[[ccg://<pkg>/<path>]]` or
-  `[[graphify://community/<name>]]`. `wiki-lint` validates these on demand.
+- `local-codex/Plan.md`, `Prompt.md`, `Implement.md`, `Documentation.md`, `Dictation.md`, `CodeContext.md` are **symlinks** into the vault — resolve to `~/vault/plans/active/...` and `~/vault/sources/codex-snapshots/...`.
+- Design decisions → `~/vault/decisions/` via `/save`.
+- Cite vault code links as `[[ccg://<pkg>/<path>]]` or `[[graphify://community/<name>]]`; `wiki-lint` validates on demand.
 
 ### What does NOT belong in the vault
-
-Code, tests, fixtures, build outputs, package READMEs, the architecture charter, vision contract,
-CLI runbook, reference handout, or anything else that would break a build/test/agent-workflow if
-moved. The test "would breaking this doc break a build, test, or agent workflow?" still applies.
+Code, tests, fixtures, build outputs, package READMEs, the architecture charter, vision contract, CLI runbook. Rule: "would removing this break a build, test, or agent workflow?"
 
 ### Setup / sync
-
 - Initial setup: `bash scripts/setup/setup-km.sh`
-- Sync: Syncthing peer-to-peer between Mac and Ubuntu (manual pairing once)
+- Sync: Syncthing peer-to-peer (Mac ↔ Ubuntu, manual pairing once)
 - Per-machine `hot.mac.md` / `hot.linux.md`; merged into `hot.md` by SessionStart hook

--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -24,6 +24,7 @@ import {
   calculateRoomCardUnitCost,
 } from "../../../runtime/src/personas/configurator/spend-proposal.js";
 import { validateAffinityPrereqs } from "../../../runtime/src/personas/configurator/cost-model.js";
+import { normalizePriceItems } from "../../../runtime/src/personas/allocator/validate-spend.js";
 import {
   ALLOWED_AFFINITIES,
   ALLOWED_AFFINITY_EXPRESSIONS,
@@ -1290,12 +1291,14 @@ function requiresMovementStamina(card = null) {
   return card?.type === "delver" || hasNonStationaryMobilityMotivation(motivations);
 }
 
+// Build a `${kind}:${id}` -> unitCost map. Accepts both canonical PriceListItemLegacyV1
+// (`unitCost`) and legacy PriceListItemTokenV1 (`costTokens`) shapes via normalizePriceItems.
+// Without this, price maps were always empty for `unitCost` items (BUG-2).
 function buildPriceMap(priceListArtifact) {
-  const items = Array.isArray(priceListArtifact?.items) ? priceListArtifact.items : [];
   return new Map(
-    items
-      .filter((item) => typeof item?.id === "string" && typeof item?.kind === "string" && Number.isFinite(item?.costTokens))
-      .map((item) => [`${item.kind}:${item.id}`, item.costTokens]),
+    Array.from(normalizePriceItems(priceListArtifact))
+      .filter(([key]) => typeof key === "string" && key.includes(":") && !key.startsWith("legacy:"))
+      .map(([key, entry]) => [key, entry.unitCost]),
   );
 }
 

--- a/packages/runtime/src/personas/allocator/layout-spend.js
+++ b/packages/runtime/src/personas/allocator/layout-spend.js
@@ -4,6 +4,7 @@ import {
   LAYOUT_TILE_PRICE_IDS as SHARED_LAYOUT_TILE_PRICE_IDS,
 } from "../../contracts/domain-constants.js";
 import { deriveLayoutFromRoomCards } from "../configurator/card-model.js";
+import { normalizePriceItems } from "./validate-spend.js";
 
 const LAYOUT_TILE_FIELDS = SHARED_LAYOUT_TILE_FIELDS;
 const DEFAULT_TILE_COSTS = SHARED_DEFAULT_LAYOUT_TILE_COSTS;
@@ -13,14 +14,17 @@ function isInteger(value) {
   return Number.isInteger(value);
 }
 
+// Build a `${kind}:${id}` -> unitCost map. Accepts both canonical PriceListItemLegacyV1
+// (`unitCost`) and legacy PriceListItemTokenV1 (`costTokens`) shapes via normalizePriceItems.
+// Without this, price maps were always empty for `unitCost` items (BUG-2).
 function buildPriceMap(priceList) {
-  const items = Array.isArray(priceList?.items) ? priceList.items : [];
+  const normalized = normalizePriceItems(priceList);
   const map = new Map();
-  items.forEach((item) => {
-    if (typeof item?.id === "string" && typeof item?.kind === "string" && Number.isFinite(item?.costTokens)) {
-      map.set(`${item.kind}:${item.id}`, item.costTokens);
+  for (const [key, entry] of normalized) {
+    if (typeof key === "string" && key.includes(":") && !key.startsWith("legacy:")) {
+      map.set(key, entry.unitCost);
     }
-  });
+  }
   return map;
 }
 

--- a/packages/runtime/src/personas/allocator/selection-spend.js
+++ b/packages/runtime/src/personas/allocator/selection-spend.js
@@ -1,17 +1,21 @@
 import { calculateActorConfigurationUnitCost } from "../configurator/spend-proposal.js";
+import { normalizePriceItems } from "./validate-spend.js";
 
 function isInteger(value) {
   return Number.isInteger(value);
 }
 
+// Build a `${kind}:${id}` -> unitCost map. Accepts both canonical PriceListItemLegacyV1
+// (`unitCost`) and legacy PriceListItemTokenV1 (`costTokens`) shapes via normalizePriceItems.
+// Without this, price maps were always empty for `unitCost` items (BUG-2).
 function buildPriceMap(priceList) {
-  const items = Array.isArray(priceList?.items) ? priceList.items : [];
+  const normalized = normalizePriceItems(priceList);
   const map = new Map();
-  items.forEach((item) => {
-    if (typeof item?.id === "string" && typeof item?.kind === "string" && Number.isFinite(item?.costTokens)) {
-      map.set(`${item.kind}:${item.id}`, item.costTokens);
+  for (const [key, entry] of normalized) {
+    if (typeof key === "string" && key.includes(":") && !key.startsWith("legacy:")) {
+      map.set(key, entry.unitCost);
     }
-  });
+  }
   return map;
 }
 

--- a/packages/runtime/src/personas/configurator/spend-proposal.js
+++ b/packages/runtime/src/personas/configurator/spend-proposal.js
@@ -1,4 +1,4 @@
-import { validateSpendProposal } from "../allocator/validate-spend.js";
+import { validateSpendProposal, normalizePriceItems } from "../allocator/validate-spend.js";
 import { evaluateLayoutSpend, evaluateRoomCardLayoutSpend } from "../allocator/layout-spend.js";
 import { normalizeMotivations, MOTIVATION_KIND_IDS } from "./motivation-loadouts.js";
 import { VITAL_KEYS } from "../../contracts/domain-constants.js";
@@ -231,14 +231,19 @@ function scaleTokenCost(value, scale = 1) {
   return scaled > 0 ? scaled : 1;
 }
 
+// Build a `${kind}:${id}` -> unitCost map. Accepts both canonical PriceListItemLegacyV1
+// (`unitCost`) and legacy PriceListItemTokenV1 (`costTokens`) shapes via normalizePriceItems.
+// Without this, price maps were always empty for `unitCost` items (BUG-2).
 function buildPriceMap(priceList) {
-  const items = Array.isArray(priceList?.items) ? priceList.items : [];
+  const normalized = normalizePriceItems(priceList);
   const map = new Map();
-  items.forEach((item) => {
-    if (typeof item?.id !== "string" || typeof item?.kind !== "string") return;
-    if (!Number.isFinite(item?.costTokens) || item.costTokens < 0) return;
-    map.set(`${item.kind}:${item.id}`, item.costTokens);
-  });
+  for (const [key, entry] of normalized) {
+    if (typeof key === "string" && key.includes(":") && !key.startsWith("legacy:")) {
+      if (entry.unitCost >= 0) {
+        map.set(key, entry.unitCost);
+      }
+    }
+  }
   return map;
 }
 

--- a/packages/ui-web/src/design-guidance.js
+++ b/packages/ui-web/src/design-guidance.js
@@ -14,13 +14,16 @@ import {
   DEFAULT_ROOM_CARD_AFFINITY,
   DEFAULT_LLM_BASE_URL,
   DEFAULT_LLM_MODEL,
-  ROOM_AFFINITY_STACK_COST_FACTOR,
   DEFAULT_VITALS,
   VITAL_KEYS,
   normalizeVitals as normalizeDomainVitals,
 } from "../../runtime/src/contracts/domain-constants.js";
+
+// Removed from domain-constants in cost refactor (046f786); kept local to preserve display scale.
+const ROOM_AFFINITY_STACK_COST_FACTOR = 0.1;
 import { resolveIconHTML } from "./icon-resolver.js";
 import { evaluateRoomCardLayoutSpend } from "../../runtime/src/personas/allocator/layout-spend.js";
+import { normalizePriceItems } from "../../runtime/src/personas/allocator/validate-spend.js";
 import {
   calculateActorConfigurationUnitCost,
   buildDesignSpendLedger,
@@ -1194,10 +1197,12 @@ function buildCardReceipt(card, { unitTokens, totalTokens, lineItems: inputLineI
 }
 
 function calculateRoomCardUnitValue(card, { tileCosts, priceList } = {}) {
+  // Accept both canonical PriceListItemLegacyV1 (`unitCost`) and legacy PriceListItemTokenV1
+  // (`costTokens`) shapes via normalizePriceItems (BUG-2 fix).
   const priceMap = new Map(
-    (Array.isArray(priceList?.items) ? priceList.items : [])
-      .filter((item) => typeof item?.id === "string" && typeof item?.kind === "string" && Number.isFinite(item?.costTokens))
-      .map((item) => [`${item.kind}:${item.id}`, item.costTokens]),
+    Array.from(normalizePriceItems(priceList))
+      .filter(([key]) => typeof key === "string" && key.includes(":") && !key.startsWith("legacy:"))
+      .map(([key, entry]) => [key, entry.unitCost]),
   );
   const spend = evaluateRoomCardLayoutSpend({
     cardSet: [{ ...card, count: 1, type: "room" }],
@@ -1239,10 +1244,12 @@ function calculateRoomCardUnitValue(card, { tileCosts, priceList } = {}) {
 }
 
 function calculateActorCardUnitValue(card, { priceList } = {}) {
+  // Accept both canonical PriceListItemLegacyV1 (`unitCost`) and legacy PriceListItemTokenV1
+  // (`costTokens`) shapes via normalizePriceItems (BUG-2 fix).
   const priceMap = new Map(
-    (Array.isArray(priceList?.items) ? priceList.items : [])
-      .filter((item) => typeof item?.id === "string" && typeof item?.kind === "string" && Number.isFinite(item?.costTokens))
-      .map((item) => [`${item.kind}:${item.id}`, item.costTokens]),
+    Array.from(normalizePriceItems(priceList))
+      .filter(([key]) => typeof key === "string" && key.includes(":") && !key.startsWith("legacy:"))
+      .map(([key, entry]) => [key, entry.unitCost]),
   );
   const cost = calculateActorConfigurationUnitCost({
     entry: {

--- a/tests/adapters-cli/ak-budget.test.js
+++ b/tests/adapters-cli/ak-budget.test.js
@@ -50,3 +50,16 @@ test("cli budget prints and writes budget artifacts", () => {
   assert.ok(existsSync(join(outDir, "price-list.json")));
   assert.ok(existsSync(join(outDir, "budget-receipt.json")));
 });
+
+// ## TODO: Test Permutations
+// - Permutation: budget without --price-list — confirm a clear error envelope (GAP-4 evidence:
+//   currently display-only, but the input contract should still validate inputs).
+// - Permutation: budget against a price list whose items use legacy `costTokens` only — confirm
+//   the receipt resolves real unitCost values (BUG-2 regression guard once normalizePriceItems is
+//   adopted by buildPriceMap).
+// - Permutation: budget against a price list whose items use canonical `unitCost` — confirm parity
+//   with the legacy-only case (no field-name divergence in the rendered receipt).
+// - Permutation: budget with a receipt path that is missing — confirm the CLI does not crash and
+//   instead returns ok:false with a stable reason.
+// - Permutation: budget --out-dir present but no write side effects expected (GAP-4) — assert that
+//   the documented limitation still holds and is reported, not silently bypassed.

--- a/tests/adapters-cli/ak-diff.test.js
+++ b/tests/adapters-cli/ak-diff.test.js
@@ -231,3 +231,15 @@ test("cli diff returns structured failure for missing runs", () => {
   assert.equal(output.command, "diff");
   assert.match(output.error, /Run directory not found:/);
 });
+
+// ## TODO: Test Permutations
+// - Permutation: diff between two create-only runs (no run step) — currently fails per GAP-3.
+//   Encode the expected ok:false envelope so the gap stays observable until repaired.
+// - Permutation: diff with --run-a == --run-b — confirm the command short-circuits to a "no diff"
+//   stable result instead of throwing.
+// - Permutation: diff against a run whose tick-frames artifact is missing but run-summary exists —
+//   confirm the error message names the missing artifact, not the run id.
+// - Permutation: diff with both runs containing identical tick-frames — confirm zero divergence
+//   reported in a stable, deterministic envelope.
+// - Permutation: diff where one run has more ticks than the other — confirm the longer run's
+//   tail frames are reported as additions, not as parity errors.

--- a/tests/adapters-cli/ak-runs-list.test.js
+++ b/tests/adapters-cli/ak-runs-list.test.js
@@ -202,3 +202,14 @@ test("cli runs list returns an empty index when artifacts/runs is missing", () =
   assert.equal(result.command, "runs");
   assert.deepEqual(result.runs, []);
 });
+
+// ## TODO: Test Permutations
+// - Permutation: runs list when artifacts/runs/ exists but is empty — confirm ok:true with runs:[].
+// - Permutation: runs list when one run directory has no command subfolders — confirm the run is
+//   surfaced with commandCount:0 and a stable status field instead of being hidden.
+// - Permutation: runs list when a command's spec/bundle is malformed JSON — confirm one run errors
+//   without aborting the whole listing.
+// - Permutation: runs list ordering — confirm runs are sorted by createdAt or runId in a stable,
+//   documented order.
+// - Permutation: runs list against a custom --out-dir created via `create --out-dir` outside the
+//   default path — encode GAP-1 boundary (these runs should not appear under artifacts/runs/).

--- a/tests/adapters-cli/ak-schemas.test.js
+++ b/tests/adapters-cli/ak-schemas.test.js
@@ -50,3 +50,15 @@ test("cli schemas writes schemas.json when --out-dir is provided", () => {
   assert.equal(catalog.generatedAt, FIXED_TIME);
   assertSortedSchemas(catalog);
 });
+
+// ## TODO: Test Permutations
+// - Permutation: schemas with no --out-dir — confirm stdout-only mode emits a parseable JSON
+//   envelope and no file is written.
+// - Permutation: schemas run twice into the same --out-dir — confirm idempotent overwrite (no
+//   stale file left behind, generatedAt updates).
+// - Permutation: schemas catalog includes every artifact schema referenced from artifacts.ts —
+//   guard rail against silent schema drift between contracts and the catalog.
+// - Permutation: schemas with AK_FIXED_TIME unset — confirm a real ISO timestamp is produced
+//   instead of falling back to a placeholder.
+// - Permutation: schemas catalog ordering is stable across runs — confirm the sort is total and
+//   deterministic for diff-friendly output.

--- a/tests/integration/cli-verification.test.js
+++ b/tests/integration/cli-verification.test.js
@@ -1,0 +1,210 @@
+// CLI Verification Ring (M3): the prompt-required acceptance flow
+//
+// Encodes deterministic CLI coverage for the full
+// `create -> run -> inspect/narrate/replay` and `show` chain in a single test
+// file so the M4 repair pass has one authoritative ring to drive against.
+//
+// This file is intentionally fixture-free: it exercises the real CLI binary
+// against authored objects (--room/--delver/--warden) so the artifacts produced
+// match what users actually see on disk, then chains them downstream without
+// re-reading any fixtures.
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, readFileSync, existsSync } = require("node:fs");
+const { resolve, join } = require("node:path");
+const os = require("node:os");
+
+const ROOT = resolve(__dirname, "../..");
+const CLI = resolve(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+const WASM_PATH = resolve(ROOT, "build/core-as.wasm");
+
+function runCli(args, options = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd: options.cwd || ROOT,
+    encoding: "utf8",
+    env: { ...process.env, ...(options.env || {}) },
+  });
+}
+
+function runCliOk(args, options = {}) {
+  const result = runCli(args, options);
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    throw new Error(`CLI failed (${result.status}): ${output}`);
+  }
+  return result;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function makeWorkDir(prefix) {
+  return mkdtempSync(join(os.tmpdir(), prefix));
+}
+
+test("cli verification ring: create -> run -> inspect/narrate/replay", (t) => {
+  if (!existsSync(WASM_PATH)) {
+    t.skip(`Missing WASM at ${WASM_PATH} — run 'pnpm run build:wasm' first.`);
+    return;
+  }
+
+  const workDir = makeWorkDir("agent-kernel-cli-verify-");
+  const createOut = join(workDir, "create");
+  const runOut = join(workDir, "run");
+  const inspectOut = join(workDir, "inspect");
+  const narrateOut = join(workDir, "narrate");
+  const replayOut = join(workDir, "replay");
+
+  // Step 1: create — minimal authored objects so artifacts are deterministic.
+  runCliOk([
+    "create",
+    "--room", "size=small;count=1",
+    "--delver", "count=1;affinity=fire;motivation=attacking",
+    "--warden", "count=1;affinity=dark;motivation=defending",
+    "--run-id", "ring_create_run",
+    "--created-at", "2026-04-26T00:00:00.000Z",
+    "--out-dir", createOut,
+  ]);
+
+  const simConfig = join(createOut, "sim-config.json");
+  const initialState = join(createOut, "initial-state.json");
+  const bundle = join(createOut, "bundle.json");
+  assert.ok(existsSync(simConfig), "create must produce sim-config.json");
+  assert.ok(existsSync(initialState), "create must produce initial-state.json");
+  assert.ok(existsSync(bundle), "create must produce bundle.json");
+
+  const bundlePayload = readJson(bundle);
+  assert.equal(typeof bundlePayload.spec, "object", "bundle must have a spec entry");
+
+  // Step 2: run — drive the simulation forward by one tick.
+  runCliOk([
+    "run",
+    "--sim-config", simConfig,
+    "--initial-state", initialState,
+    "--ticks", "1",
+    "--wasm", WASM_PATH,
+    "--out-dir", runOut,
+  ]);
+
+  const tickFrames = join(runOut, "tick-frames.json");
+  const effectsLog = join(runOut, "effects-log.json");
+  const runSummary = join(runOut, "run-summary.json");
+  assert.ok(existsSync(tickFrames), "run must produce tick-frames.json");
+  assert.ok(existsSync(effectsLog), "run must produce effects-log.json");
+  assert.ok(existsSync(runSummary), "run must produce run-summary.json");
+
+  // Step 3: inspect — produce an inspect-summary from the run output.
+  runCliOk([
+    "inspect",
+    "--tick-frames", tickFrames,
+    "--effects-log", effectsLog,
+    "--out-dir", inspectOut,
+  ]);
+  const inspectSummary = join(inspectOut, "inspect-summary.json");
+  assert.ok(existsSync(inspectSummary), "inspect must produce inspect-summary.json");
+  const inspectPayload = readJson(inspectSummary);
+  // inspect emits a TelemetryRecord scoped to "run" — the per-run summary surface.
+  assert.equal(inspectPayload.schema, "agent-kernel/TelemetryRecord");
+  assert.equal(inspectPayload.scope, "run");
+  assert.ok(inspectPayload.data && typeof inspectPayload.data.ticks === "number");
+
+  // Step 4: narrate — produce a narrative from tick-frames + initial-state.
+  runCliOk([
+    "narrate",
+    "--tick-frames", tickFrames,
+    "--initial-state", initialState,
+    "--out-dir", narrateOut,
+  ]);
+  const narrative = join(narrateOut, "narrative.json");
+  assert.ok(existsSync(narrative), "narrate must produce narrative.json");
+
+  // Step 5: replay — re-execute the recorded tick-frames and confirm the replay summary lands.
+  runCliOk([
+    "replay",
+    "--sim-config", simConfig,
+    "--initial-state", initialState,
+    "--tick-frames", tickFrames,
+    "--wasm", WASM_PATH,
+    "--out-dir", replayOut,
+  ]);
+  const replaySummary = join(replayOut, "replay-summary.json");
+  const replayFrames = join(replayOut, "replay-tick-frames.json");
+  assert.ok(existsSync(replaySummary), "replay must produce replay-summary.json");
+  assert.ok(existsSync(replayFrames), "replay must produce replay-tick-frames.json");
+});
+
+test("cli verification ring: show resolves a default-path run from artifacts/runs/<id>", (t) => {
+  if (!existsSync(WASM_PATH)) {
+    t.skip(`Missing WASM at ${WASM_PATH} — run 'pnpm run build:wasm' first.`);
+    return;
+  }
+  const workDir = makeWorkDir("agent-kernel-show-verify-");
+
+  // Use the default --out-dir so artifacts land under artifacts/runs/<id>.
+  runCliOk([
+    "create",
+    "--room", "size=small;count=1",
+    "--delver", "count=1;affinity=fire;motivation=attacking",
+    "--warden", "count=1;affinity=dark;motivation=defending",
+    "--run-id", "ring_show_run",
+    "--created-at", "2026-04-26T00:00:00.000Z",
+  ], { cwd: workDir });
+
+  const showResult = runCliOk(["show", "--run-id", "ring_show_run"], { cwd: workDir });
+  // The CLI prints both human-readable lines and a final JSON envelope.
+  // Find the JSON envelope on stdout.
+  const lines = showResult.stdout.trim().split("\n");
+  const jsonLine = lines.reverse().find((line) => line.startsWith("{"));
+  assert.ok(jsonLine, "show must emit a JSON envelope on stdout");
+  const payload = JSON.parse(jsonLine);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.runId, "ring_show_run");
+  assert.equal(payload.status, "success");
+  assert.ok(Array.isArray(payload.commands) && payload.commands.length >= 1);
+  assert.equal(payload.commands[0].command, "create");
+});
+
+test("cli verification ring: --from-run chains create into run when default paths are used", (t) => {
+  if (!existsSync(WASM_PATH)) {
+    t.skip(`Missing WASM at ${WASM_PATH} — run 'pnpm run build:wasm' first.`);
+    return;
+  }
+  const workDir = makeWorkDir("agent-kernel-from-run-verify-");
+
+  runCliOk([
+    "create",
+    "--room", "size=small;count=1",
+    "--delver", "count=1;affinity=fire;motivation=attacking",
+    "--warden", "count=1;affinity=dark;motivation=defending",
+    "--run-id", "ring_from_run",
+    "--created-at", "2026-04-26T00:00:00.000Z",
+  ], { cwd: workDir });
+
+  runCliOk([
+    "run",
+    "--from-run", "ring_from_run",
+    "--wasm", WASM_PATH,
+    "--ticks", "1",
+  ], { cwd: workDir });
+
+  const tickFrames = join(workDir, "artifacts", "runs", "ring_from_run", "run", "tick-frames.json");
+  assert.ok(existsSync(tickFrames), "--from-run must produce tick-frames under artifacts/runs/<id>/run/");
+});
+
+// ## TODO: Test Permutations
+// - Permutation: create with only --room (no actors) — confirm artifacts include sim-config and
+//   initial-state with zero actors and that downstream `run` fails fast with a clear reason.
+// - Permutation: run with --ticks 0 — confirm tick-frames is empty but the artifact envelope is
+//   still well-formed (schema + meta present) so inspect/narrate don't NPE.
+// - Permutation: inspect against an empty effects-log — confirm inspect-summary.json still emits
+//   counts (zeros) instead of failing.
+// - Permutation: narrate without --initial-state — confirm the CLI exits non-zero with a stable
+//   error message that names the missing argument.
+// - Permutation: replay with mismatched sim-config / initial-state pair — confirm the CLI surfaces
+//   a deterministic error (no WASM trap) so callers can detect drift.
+// - Permutation: show against a run-id that does not exist — confirm the CLI returns ok:false and
+//   names the missing run directory in the error envelope.
+// - Permutation: --from-run after running create with a custom --out-dir — confirm the documented
+//   GAP-1 limitation surfaces (clear error rather than silent success).

--- a/tests/integration/mcp/mcp-server.test.js
+++ b/tests/integration/mcp/mcp-server.test.js
@@ -411,3 +411,61 @@ testIfWasm("mcp server run and inspect tool calls round-trip over stdio", async 
     await harness.close();
   }
 });
+
+// ## TODO: Test Permutations
+//
+// This file is the authoritative MCP verification surface for this session.
+// Tools verified working above (M5): ak_schemas, ak_create (dry-run + full), ak_configure,
+// ak_llm_plan, ak_room_plan, ak_delver_plan, ak_warden_plan, ak_show, ak_runs_list, ak_run, ak_inspect.
+//
+// The MCP tools below are uncovered at the MCP layer (CLI tests cover the underlying commands,
+// but MCP tool invocation is untested). Each TODO is a distinct failure class, not a duplicate
+// shape, and each names the tool family explicitly so the gap stays observable.
+//
+// Simulation tools:
+// - Permutation: ak_build with a fixture spec — confirm the MCP envelope returns a bundle ref and
+//   the same artifact set as `ak build` on the CLI.
+// - Permutation: ak_solve with --solver-fixture — confirm the MCP server returns the SolverResult
+//   envelope deterministically (no network).
+// - Permutation: ak_configurator with a level-gen + actors fixture — confirm the configurator
+//   FSM result schema matches the CLI's `configurator` command.
+// - Permutation: ak_budget against a fixed budget + price list — confirm the MCP receipt envelope
+//   matches the CLI receipt envelope byte-for-byte except for ids/timestamps.
+// - Permutation: ak_replay against a recorded tick-frames artifact — confirm parity with CLI
+//   `replay` (replay-summary + replay-tick-frames present).
+// - Permutation: ak_scenario with --from-run and a deterministic fixture — confirm scenario
+//   chaining works from MCP without leaking temp paths.
+//
+// LLM tools:
+// - Permutation: ak_llm with --fixture set — confirm fixture-backed text path returns the expected
+//   payload schema and never opens a network socket.
+// - Permutation: ak_ollama against a fixture path — confirm same envelope surface as ak_llm.
+//
+// Inspection tools:
+// - Permutation: ak_diff between two recorded runs — confirm diff envelope contains a stable
+//   shape (added/removed/changed) when both runs have run-step artifacts (covers GAP-3 boundary).
+// - Permutation: ak_narrate against tick-frames + initial-state — confirm the narrative artifact
+//   schema matches the CLI's `narrate` command.
+//
+// External adapters (must remain fixture-backed under test):
+// - Permutation: ak_ipfs with --fixture — confirm payload envelope and no network.
+// - Permutation: ak_ipfs_publish with --fixture-cid — confirm artifact map handling.
+// - Permutation: ak_ipfs_load with --fixture-map — confirm the per-file fetch loop.
+// - Permutation: ak_blockchain with --fixture-chain-id and --fixture-balance — confirm wallet
+//   shape envelope.
+// - Permutation: ak_blockchain_mint with --fixture-mint — confirm token id is echoed back.
+// - Permutation: ak_blockchain_load with --fixture-load — confirm card payload round-trips.
+//
+// Test-tooling MCP surface (lowest priority — verifying the verifier):
+// - Permutation: ak_test_list_suites — confirm the suite list matches the file system.
+// - Permutation: ak_test_discover_patterns — confirm pattern discovery produces a deterministic
+//   list for a fixed snapshot.
+// - Permutation: ak_test_plan_from_change — confirm the plan envelope shape against a known diff.
+// - Permutation: ak_test_run — confirm a single test invocation returns a stable status envelope.
+// - Permutation: ak_test_scaffold_case — confirm the scaffolded test file matches an in-tree
+//   golden.
+// - Permutation: ak_test_insert_case — confirm idempotent insertion (re-running does not duplicate).
+// - Permutation: ak_test_explain_failure — confirm the explanation envelope shape for a stub
+//   failing test.
+// - Permutation: ak_test_lint_structure — confirm the lint envelope shape against a known-good and
+//   a known-bad fixture.

--- a/tests/ui-web/design-guidance-affinity-sync.test.mjs
+++ b/tests/ui-web/design-guidance-affinity-sync.test.mjs
@@ -158,3 +158,26 @@ test("changing card type replaces incompatible card payload", () => {
   assert.equal(switched.card.vitals, undefined);
   assert.ok(["small", "medium", "large"].includes(switched.card.roomSize));
 });
+
+test("design-guidance.js loads as an ES module without import-link errors (BUG-1 regression guard)", async () => {
+  // BUG-1 regression: importing a now-removed constant from domain-constants.js
+  // produced a hard ESM link error that prevented main.js from executing.
+  // The import block was repaired in M2 by defining ROOM_AFFINITY_STACK_COST_FACTOR
+  // locally. This test fails fast if anyone re-introduces a missing import binding.
+  const mod = await import("../../packages/ui-web/src/design-guidance.js");
+  assert.equal(typeof mod.createDesignCard, "function");
+  assert.equal(typeof mod.dropPropertyOnCard, "function");
+  assert.equal(typeof mod.adjustAffinityStack, "function");
+});
+
+// ## TODO: Test Permutations
+// - Permutation: an unrelated removed export added back to the import list — module-load failure
+//   surfaces a clear error and dropPropertyOnCard remains undefined.
+// - Permutation: createDesignCard with type:"room" + size:"small"/"medium"/"large" — verify all three
+//   produce the same empty affinities/expressions invariant the boot path relies on.
+// - Permutation: dropPropertyOnCard called with an unknown group key — ok=false with a stable reason
+//   (no thrown exception) so the design view can render a friendly inline error.
+// - Permutation: adjustAffinityStack with delta=0 — confirm idempotent (no entry added or removed),
+//   so repeated identical drops don't accumulate.
+// - Permutation: dropPropertyOnCard with affinity dropped on a "room" card — should remain a no-op
+//   (rooms carry no affinities) with a stable reason instead of mutating the room.

--- a/tests/ui-web/view-wiring.test.mjs
+++ b/tests/ui-web/view-wiring.test.mjs
@@ -139,3 +139,29 @@ test("diagnostics llm capture extraction deduplicates and filters non-llm captur
   assert.equal(captures[0].meta.id, "capture_trace_1");
   assert.equal(captures[0].source.adapter, "llm");
 });
+
+test("design-view module imports cleanly so wireTabs is reachable from main.js", async () => {
+  // BUG-1 regression: design-view → design-guidance ESM link failure prevented
+  // wireTabs from running, leaving every tab inert. If any view module fails to
+  // load, main.js's tab wiring never executes. This guards the import graph.
+  const designView = await import("../../packages/ui-web/src/views/design-view.js");
+  const previewView = await import("../../packages/ui-web/src/views/preview-view.js");
+  const diagnosticsView = await import("../../packages/ui-web/src/views/diagnostics-view.js");
+  const simulationView = await import("../../packages/ui-web/src/views/simulation-view.js");
+  assert.equal(typeof designView.wireDesignView, "function");
+  assert.equal(typeof previewView.wirePreviewView, "function");
+  assert.equal(typeof diagnosticsView.wireDiagnosticsView, "function");
+  assert.equal(typeof simulationView.wireSimulationView, "function");
+});
+
+// ## TODO: Test Permutations
+// - Permutation: wireDesignView with a root that returns an array from querySelectorAll — confirm
+//   non-empty NodeList paths still tolerate missing per-element attributes without throwing.
+// - Permutation: wireDiagnosticsView called twice on the same root — confirm idempotent wiring
+//   (no double-bound listeners) so re-mounts don't double-fire on bundle load.
+// - Permutation: wireSimulationView with autoBoot=true and a stub clock — confirm boot completes
+//   deterministically and surfaces a status-message with dataset.level set.
+// - Permutation: extractLlmCaptures with an empty captures array but a populated bundle.artifacts —
+//   confirm dedup by meta.id still produces a stable order.
+// - Permutation: simulationView.regenerateLevelArtifacts with malformed tile rows (mixed widths) —
+//   confirm result.ok=false with a clear reason (no throw) so the UI can show the error inline.


### PR DESCRIPTION
## Summary
- Normalizes price-list unit cost handling across CLI, runtime allocator/configurator spend paths, and UI design guidance.
- Restores design-guidance module loading by keeping the affinity stack display factor local after the cost refactor.
- Adds CLI verification-ring coverage and TODO permutation stubs for the local Ollama expansion pass.

## Review
- Reviewed the staged diff for price-list normalization, UI import wiring, CLI verification, and documentation changes.
- No blocking findings found.
- CodeContextGraph stats query succeeded, but live watch was not active in this Codex session.

## Validation
- `git pull --ff-only`
- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm run test` (947 passed, 2 skipped)

## Notes
- `test-results/` is generated local test state and was intentionally left untracked.
- Test permutation expansion is intentionally left for the local Ollama workflow.