### PR TITLE
feat(m8): sandbox bridge server, client, and tests

### DIFF
--- a/packages/adapters-cli/src/mcp/bridge-server.mjs
+++ b/packages/adapters-cli/src/mcp/bridge-server.mjs
@@ -1,0 +1,209 @@
+/**
+ * M8 — Sandbox to UI bridge server
+ *
+ * Manages a WebSocket server bound to 127.0.0.1 only.  Browser clients
+ * connect, identify themselves with ak.uiReady.v1, and receive compiled
+ * gameplay bundles pushed via pushGameplayBundle().
+ *
+ * Exports:
+ *   startSandboxBridgeServer({ host?, port })  → { port, stop }
+ *   getSandboxBridgeState()                    → { connectedClients, latestBundle }
+ *   pushGameplayBundle(message)                → { deliveredClientIds, timedOutClientIds }
+ *   stopSandboxBridgeServer()
+ */
+
+import { createServer } from "node:http";
+import { WebSocketServer } from "ws";
+
+const LOOPBACK = "127.0.0.1";
+const REPLAY_WINDOW_MS = 10_000;
+const ACK_TIMEOUT_MS = 8_000;
+
+/** @type {{ wss: import("ws").WebSocketServer, httpServer: import("node:http").Server } | null} */
+let _server = null;
+
+/** Map<clientId, { ws, capabilities, connectedAt }> */
+const _clients = new Map();
+
+/** { bundle, pushedAt } | null */
+let _pendingReplay = null;
+
+function makeMessageId() {
+  return `msg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+function makeClientId() {
+  return `ui_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+function sendJson(ws, payload) {
+  if (ws.readyState === ws.OPEN) {
+    ws.send(JSON.stringify(payload));
+  }
+}
+
+function replayToClient(clientId, ws) {
+  if (!_pendingReplay) return;
+  const age = Date.now() - _pendingReplay.pushedAt;
+  if (age > REPLAY_WINDOW_MS) {
+    _pendingReplay = null;
+    return;
+  }
+  sendJson(ws, _pendingReplay.bundle);
+}
+
+/**
+ * Start the bridge WebSocket server.
+ * @param {{ host?: string, port: number }} options
+ * @returns {{ port: number, stop: () => Promise<void> }}
+ */
+export async function startSandboxBridgeServer({ host = LOOPBACK, port } = {}) {
+  if (host !== LOOPBACK && host !== "localhost") {
+    throw new Error(
+      `startSandboxBridgeServer: host must be "${LOOPBACK}" (loopback only). Received: "${host}"`,
+    );
+  }
+
+  if (_server) {
+    throw new Error("startSandboxBridgeServer: bridge server is already running.");
+  }
+
+  const httpServer = createServer();
+  const wss = new WebSocketServer({ server: httpServer, path: "/ak-sandbox" });
+
+  wss.on("connection", (ws) => {
+    let clientId = null;
+
+    ws.on("message", (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString("utf8"));
+      } catch {
+        return; // ignore unparseable frames
+      }
+
+      if (msg?.type === "ak.uiReady.v1") {
+        clientId = msg.clientId || makeClientId();
+        _clients.set(clientId, {
+          ws,
+          capabilities: msg.capabilities ?? {},
+          connectedAt: new Date().toISOString(),
+        });
+        // Replay latest bundle within the window
+        replayToClient(clientId, ws);
+      }
+    });
+
+    ws.on("close", () => {
+      if (clientId) _clients.delete(clientId);
+    });
+
+    ws.on("error", () => {
+      if (clientId) _clients.delete(clientId);
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    // Absorb error events on both httpServer and wss so no unhandled error
+    // propagates to the process before the promise rejects cleanly.
+    function onError(err) {
+      httpServer.removeListener("error", onError);
+      wss.removeListener("error", onError);
+      reject(err);
+    }
+    httpServer.once("error", onError);
+    wss.once("error", onError);
+
+    httpServer.listen(port, LOOPBACK, () => {
+      httpServer.removeListener("error", onError);
+      wss.removeListener("error", onError);
+      resolve();
+    });
+  });
+
+  const boundPort = httpServer.address().port;
+  _server = { wss, httpServer };
+
+  return {
+    port: boundPort,
+    stop: stopSandboxBridgeServer,
+  };
+}
+
+/**
+ * @returns {{ connectedClients: number, latestBundle: object | null }}
+ */
+export function getSandboxBridgeState() {
+  return {
+    connectedClients: _clients.size,
+    latestBundle: _pendingReplay?.bundle ?? null,
+  };
+}
+
+/**
+ * Push an ak.gameplayBundle.v1 message to all connected clients.
+ * Stores the message for a 10-second replay window.
+ *
+ * @param {object} message  Full ak.gameplayBundle.v1 envelope
+ * @returns {Promise<{ deliveredClientIds: string[], timedOutClientIds: string[] }>}
+ */
+export async function pushGameplayBundle(message) {
+  // Store for replay window
+  _pendingReplay = { bundle: message, pushedAt: Date.now() };
+
+  const clientEntries = Array.from(_clients.entries());
+  if (clientEntries.length === 0) {
+    return { deliveredClientIds: [], timedOutClientIds: [] };
+  }
+
+  const deliveredClientIds = [];
+  const timedOutClientIds = [];
+
+  const ackPromises = clientEntries.map(([clientId, { ws }]) => {
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        ws.removeListener("message", onMessage);
+        timedOutClientIds.push(clientId);
+        resolve();
+      }, ACK_TIMEOUT_MS);
+
+      function onMessage(raw) {
+        let msg;
+        try { msg = JSON.parse(raw.toString("utf8")); } catch { return; }
+        if (
+          (msg?.type === "ak.bundleLoaded.v1" || msg?.type === "ak.bundleLoadFailed.v1")
+          && msg?.messageId === message.id
+        ) {
+          clearTimeout(timer);
+          ws.removeListener("message", onMessage);
+          if (msg.type === "ak.bundleLoaded.v1") {
+            deliveredClientIds.push(clientId);
+          } else {
+            timedOutClientIds.push(clientId);
+          }
+          resolve();
+        }
+      }
+
+      ws.on("message", onMessage);
+      sendJson(ws, message);
+    });
+  });
+
+  await Promise.all(ackPromises);
+  return { deliveredClientIds, timedOutClientIds };
+}
+
+/**
+ * Stop the bridge server and disconnect all clients cleanly.
+ */
+export async function stopSandboxBridgeServer() {
+  if (!_server) return;
+  const { wss, httpServer } = _server;
+  _server = null;
+  _clients.clear();
+  _pendingReplay = null;
+
+  await new Promise((resolve) => wss.close(resolve));
+  await new Promise((resolve) => httpServer.close(resolve));
+}

--- a/packages/adapters-cli/src/mcp/tools/sandbox-ui.mjs
+++ b/packages/adapters-cli/src/mcp/tools/sandbox-ui.mjs
@@ -1,0 +1,119 @@
+/**
+ * M8 — ak_sandbox_push_ui MCP tool
+ *
+ * Compiles an inline BuildSpec into a gameplay bundle and pushes it to any
+ * connected browser UI via the sandbox bridge WebSocket server.
+ */
+
+import { createHandlerTool } from "./shared.mjs";
+import { compileBuildSpecToGameplayBundle } from "../../cli/ak-impl.mjs";
+import {
+  getSandboxBridgeState,
+  pushGameplayBundle,
+} from "../bridge-server.mjs";
+
+const DEFAULT_BRIDGE_PORT = Number(process.env.AK_SANDBOX_BRIDGE_PORT) || 38487;
+
+function makeMessageId() {
+  return `msg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+export const sandboxUiTools = [
+  createHandlerTool({
+    name: "ak_sandbox_push_ui",
+    description:
+      "Compile a BuildSpec and push the resulting gameplay bundle to the connected browser UI via the sandbox WebSocket bridge. " +
+      "The UI will display the Design cards and launch the Gameplay Phaser dungeon automatically. " +
+      "Use requireClient: false to pre-stage a bundle before the UI connects.",
+    inputSchema: {
+      properties: {
+        buildSpec: {
+          type: "object",
+          additionalProperties: true,
+          description:
+            "Inline BuildSpec artifact to compile. Must conform to agent-kernel/BuildSpec schema. Required.",
+        },
+        targetTab: {
+          type: "string",
+          enum: ["design", "gameplay"],
+          description: "Which UI tab to activate after loading. Defaults to 'gameplay'.",
+          default: "gameplay",
+        },
+        requireClient: {
+          type: "boolean",
+          description:
+            "When true (default), fail immediately if no browser UI is connected. " +
+            "When false, compile and store the bundle for replay when the UI connects.",
+          default: true,
+        },
+        correlationId: {
+          type: "string",
+          description: "Optional caller-supplied correlation ID echoed back in the result.",
+        },
+      },
+      required: ["buildSpec"],
+    },
+
+    async handler({ buildSpec, targetTab = "gameplay", requireClient = true, correlationId }) {
+      // Validate buildSpec presence
+      if (!buildSpec || typeof buildSpec !== "object") {
+        return { ok: false, error: "buildSpec is required and must be an object." };
+      }
+
+      const state = getSandboxBridgeState();
+
+      if (requireClient && state.connectedClients === 0) {
+        return {
+          ok: false,
+          error: "SANDBOX_UI_NOT_CONNECTED",
+          message:
+            "No browser UI is connected to the sandbox bridge. " +
+            "Open the UI dev server and ensure the bridge client is running, or set requireClient: false to pre-stage the bundle.",
+          bridge: { port: DEFAULT_BRIDGE_PORT, connectedClients: 0 },
+        };
+      }
+
+      // Compile the BuildSpec → { simConfig, resourceBundle }
+      let simConfig, resourceBundle;
+      try {
+        ({ simConfig, resourceBundle } = await compileBuildSpecToGameplayBundle(buildSpec));
+      } catch (err) {
+        return {
+          ok: false,
+          error: "BUILD_FAILED",
+          message: err?.message ?? String(err),
+        };
+      }
+
+      const messageId = makeMessageId();
+      const envelope = {
+        type: "ak.gameplayBundle.v1",
+        id: messageId,
+        ...(correlationId ? { correlationId } : {}),
+        createdAt: new Date().toISOString(),
+        targetTab,
+        payload: {
+          bundle: { simConfig, resourceBundle },
+          source: { tool: "ak_sandbox_push_ui" },
+        },
+      };
+
+      const { deliveredClientIds, timedOutClientIds } = await pushGameplayBundle(envelope);
+
+      return {
+        ok: true,
+        ...(correlationId ? { correlationId } : {}),
+        bridge: {
+          port: DEFAULT_BRIDGE_PORT,
+          connectedClients: state.connectedClients,
+          deliveredClientIds,
+          timedOutClientIds,
+        },
+        bundle: {
+          simConfigArtifactId: simConfig?.meta?.id ?? null,
+          resourceBundleArtifactId: resourceBundle?.meta?.id ?? null,
+        },
+      };
+    },
+  }),
+];

--- a/packages/ui-web/src/sandbox-bridge-client.js
+++ b/packages/ui-web/src/sandbox-bridge-client.js
@@ -1,0 +1,160 @@
+/**
+ * M8 — Sandbox bridge client (browser-side)
+ *
+ * Maintains a reconnecting WebSocket connection to the MCP server's bridge.
+ * On connect, announces capabilities. On ak.gameplayBundle.v1, delegates to
+ * the global __ak_loadGameplayBundle and __ak_setActiveTab hooks.
+ *
+ * Exports:
+ *   connectSandboxBridge({ port, onBundle? })  → { disconnect }
+ *   disconnectSandboxBridge()
+ */
+
+const RECONNECT_DELAY_MS = 2_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const BRIDGE_PATH = "/ak-sandbox";
+
+function makeClientId() {
+  return `ui_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+const CLIENT_ID = makeClientId();
+
+let _ws = null;
+let _reconnectTimer = null;
+let _reconnectDelay = RECONNECT_DELAY_MS;
+let _stopped = false;
+let _port = null;
+let _onBundle = null;
+
+function sendJson(ws, payload) {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(payload));
+  }
+}
+
+function announceReady(ws) {
+  sendJson(ws, {
+    type: "ak.uiReady.v1",
+    clientId: CLIENT_ID,
+    createdAt: new Date().toISOString(),
+    capabilities: {
+      loadGameplayBundle: typeof globalThis.__ak_loadGameplayBundle === "function",
+      setActiveTab: typeof globalThis.__ak_setActiveTab === "function",
+    },
+  });
+}
+
+async function handleBundle(ws, msg) {
+  const messageId = msg.id;
+  const bundle = msg?.payload?.bundle;
+  const targetTab = msg?.payload ? (msg.targetTab ?? "gameplay") : "gameplay";
+
+  try {
+    if (typeof globalThis.__ak_loadGameplayBundle !== "function") {
+      throw Object.assign(new Error("__ak_loadGameplayBundle is not available"), {
+        code: "LOAD_GAMEPLAY_BUNDLE_UNAVAILABLE",
+      });
+    }
+
+    await globalThis.__ak_loadGameplayBundle(bundle);
+
+    if (typeof globalThis.__ak_setActiveTab === "function") {
+      globalThis.__ak_setActiveTab(targetTab);
+    }
+
+    if (typeof _onBundle === "function") {
+      _onBundle(bundle);
+    }
+
+    sendJson(ws, {
+      type: "ak.bundleLoaded.v1",
+      clientId: CLIENT_ID,
+      messageId,
+      ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
+      loadedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    sendJson(ws, {
+      type: "ak.bundleLoadFailed.v1",
+      clientId: CLIENT_ID,
+      messageId,
+      ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
+      error: {
+        message: err?.message ?? String(err),
+        code: err?.code ?? "LOAD_GAMEPLAY_BUNDLE_UNAVAILABLE",
+      },
+    });
+  }
+}
+
+function connect() {
+  if (_stopped) return;
+
+  const url = `ws://127.0.0.1:${_port}${BRIDGE_PATH}`;
+  let ws;
+  try {
+    ws = new WebSocket(url);
+  } catch {
+    scheduleReconnect();
+    return;
+  }
+  _ws = ws;
+
+  ws.addEventListener("open", () => {
+    _reconnectDelay = RECONNECT_DELAY_MS;
+    announceReady(ws);
+  });
+
+  ws.addEventListener("message", (event) => {
+    let msg;
+    try { msg = JSON.parse(event.data); } catch { return; }
+    if (msg?.type === "ak.gameplayBundle.v1") {
+      handleBundle(ws, msg);
+    }
+  });
+
+  ws.addEventListener("close", () => {
+    _ws = null;
+    scheduleReconnect();
+  });
+
+  ws.addEventListener("error", () => {
+    // close event fires after error — reconnect handled there
+  });
+}
+
+function scheduleReconnect() {
+  if (_stopped) return;
+  clearTimeout(_reconnectTimer);
+  _reconnectTimer = setTimeout(() => {
+    _reconnectDelay = Math.min(_reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
+    connect();
+  }, _reconnectDelay);
+}
+
+/**
+ * Start connecting to the sandbox bridge.
+ * @param {{ port: number, onBundle?: (bundle: object) => void }} options
+ * @returns {{ disconnect: () => void }}
+ */
+export function connectSandboxBridge({ port, onBundle } = {}) {
+  _stopped = false;
+  _port = port;
+  _onBundle = onBundle ?? null;
+  _reconnectDelay = RECONNECT_DELAY_MS;
+  connect();
+  return { disconnect: disconnectSandboxBridge };
+}
+
+/**
+ * Stop the bridge connection and cancel any pending reconnect.
+ */
+export function disconnectSandboxBridge() {
+  _stopped = true;
+  clearTimeout(_reconnectTimer);
+  if (_ws) {
+    _ws.close();
+    _ws = null;
+  }
+}

--- a/tests/adapters-cli/bridge-server.test.mjs
+++ b/tests/adapters-cli/bridge-server.test.mjs
@@ -1,0 +1,229 @@
+/**
+ * M8 — bridge-server unit tests
+ *
+ * Uses port 0 (OS-assigned) to avoid collisions.
+ * Each test starts its own server instance and stops it in cleanup.
+ */
+
+import assert from "node:assert/strict";
+// Use Node 22's built-in WebSocket (available since Node 21) — no ws import needed in tests.
+const { WebSocket } = globalThis;
+import {
+  startSandboxBridgeServer,
+  stopSandboxBridgeServer,
+  getSandboxBridgeState,
+  pushGameplayBundle,
+} from "../../packages/adapters-cli/src/mcp/bridge-server.mjs";
+
+// Helper: connect a WS client, wait for open, optional send
+// Uses browser-style addEventListener (Node 22 built-in WebSocket API)
+function createTestClient(port) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ak-sandbox`);
+    ws.addEventListener("open", () => resolve(ws));
+    ws.addEventListener("error", (e) => reject(e.error ?? new Error("ws error")));
+  });
+}
+
+// Helper: wait for a single message matching a predicate
+function waitForMessage(ws, predicate, timeoutMs = 4000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.removeEventListener("message", onMsg);
+      reject(new Error(`waitForMessage: timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    function onMsg(event) {
+      let msg;
+      try { msg = JSON.parse(event.data); } catch { return; }
+      if (predicate(msg)) {
+        clearTimeout(timer);
+        ws.removeEventListener("message", onMsg);
+        resolve(msg);
+      }
+    }
+
+    ws.addEventListener("message", onMsg);
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+test("bridge-server: start with port 0 and bind to 127.0.0.1", async () => {
+  const { port, stop } = await startSandboxBridgeServer({ port: 0 });
+  try {
+    assert.ok(typeof port === "number" && port > 0, "bound port must be a positive integer");
+    const state = getSandboxBridgeState();
+    assert.equal(state.connectedClients, 0);
+    assert.equal(state.latestBundle, null);
+  } finally {
+    await stop();
+  }
+});
+
+test("bridge-server: rejects non-loopback host", async () => {
+  await assert.rejects(
+    () => startSandboxBridgeServer({ host: "0.0.0.0", port: 0 }),
+    /loopback only/i,
+  );
+});
+
+test("bridge-server: client sends ak.uiReady.v1 and is tracked", async () => {
+  const { port, stop } = await startSandboxBridgeServer({ port: 0 });
+  let ws;
+  try {
+    ws = await createTestClient(port);
+    ws.send(JSON.stringify({
+      type: "ak.uiReady.v1",
+      clientId: "test-client-1",
+      createdAt: new Date().toISOString(),
+      capabilities: { loadGameplayBundle: true, setActiveTab: true },
+    }));
+    // Small delay for the server to process the message
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(getSandboxBridgeState().connectedClients, 1);
+  } finally {
+    ws?.close();
+    await new Promise((r) => setTimeout(r, 20));
+    await stop();
+  }
+});
+
+test("bridge-server: pushGameplayBundle delivers exact envelope to connected client", { timeout: 20_000 }, async () => {
+  const { port, stop } = await startSandboxBridgeServer({ port: 0 });
+  let ws;
+  try {
+    ws = await createTestClient(port);
+
+    // Announce ready
+    ws.send(JSON.stringify({
+      type: "ak.uiReady.v1",
+      clientId: "test-client-2",
+      createdAt: new Date().toISOString(),
+      capabilities: {},
+    }));
+    await new Promise((r) => setTimeout(r, 30));
+
+    const envelope = {
+      type: "ak.gameplayBundle.v1",
+      id: "msg_test_001",
+      createdAt: new Date().toISOString(),
+      targetTab: "gameplay",
+      payload: {
+        bundle: { simConfig: { schema: "agent-kernel/SimConfigArtifact", schemaVersion: 1, meta: { id: "sc1" } } },
+        source: { tool: "ak_sandbox_push_ui" },
+      },
+    };
+
+    // Set up ACK + message capture before push
+    const receivePromise = waitForMessage(ws, (m) => m.type === "ak.gameplayBundle.v1");
+
+    // Push with ACK timeout — client won't ACK so expect timedOut
+    const pushPromise = pushGameplayBundle(envelope);
+
+    const received = await receivePromise;
+    assert.equal(received.type, "ak.gameplayBundle.v1");
+    assert.equal(received.id, "msg_test_001");
+    assert.deepEqual(received.payload.source, { tool: "ak_sandbox_push_ui" });
+
+    // Let push finish (it will time out waiting for ACK since our test client doesn't ACK)
+    const result = await pushPromise;
+    assert.ok(Array.isArray(result.deliveredClientIds));
+    assert.ok(Array.isArray(result.timedOutClientIds));
+    // The client did not send an ACK, so it should be timed out
+    assert.equal(result.timedOutClientIds.length, 1);
+  } finally {
+    ws?.close();
+    await new Promise((r) => setTimeout(r, 20));
+    await stop();
+  }
+}, 15_000);
+
+test("bridge-server: pushGameplayBundle with ACK returns deliveredClientIds", async () => {
+  const { port, stop } = await startSandboxBridgeServer({ port: 0 });
+  let ws;
+  try {
+    ws = await createTestClient(port);
+
+    ws.send(JSON.stringify({
+      type: "ak.uiReady.v1",
+      clientId: "test-ack-client",
+      createdAt: new Date().toISOString(),
+      capabilities: {},
+    }));
+    await new Promise((r) => setTimeout(r, 30));
+
+    const messageId = "msg_ack_test";
+    const envelope = {
+      type: "ak.gameplayBundle.v1",
+      id: messageId,
+      createdAt: new Date().toISOString(),
+      targetTab: "gameplay",
+      payload: { bundle: {}, source: { tool: "test" } },
+    };
+
+    // Simulate client that ACKs immediately
+    ws.addEventListener("message", (event) => {
+      let msg;
+      try { msg = JSON.parse(event.data); } catch { return; }
+      if (msg?.type === "ak.gameplayBundle.v1") {
+        ws.send(JSON.stringify({
+          type: "ak.bundleLoaded.v1",
+          clientId: "test-ack-client",
+          messageId: msg.id,
+          loadedAt: new Date().toISOString(),
+        }));
+      }
+    });
+
+    const result = await pushGameplayBundle(envelope);
+    assert.equal(result.deliveredClientIds.length, 1);
+    assert.equal(result.timedOutClientIds.length, 0);
+  } finally {
+    ws?.close();
+    await new Promise((r) => setTimeout(r, 20));
+    await stop();
+  }
+}, 15_000);
+
+test("bridge-server: replay window sends latest bundle to late-connecting client", async () => {
+  const { port, stop } = await startSandboxBridgeServer({ port: 0 });
+  try {
+    const envelope = {
+      type: "ak.gameplayBundle.v1",
+      id: "msg_replay_001",
+      createdAt: new Date().toISOString(),
+      targetTab: "gameplay",
+      payload: { bundle: {}, source: { tool: "test" } },
+    };
+
+    // Push with no clients connected
+    const result = await pushGameplayBundle(envelope);
+    assert.equal(result.deliveredClientIds.length, 0);
+
+    // Now a late-connecting client should receive the replay
+    const ws = await createTestClient(port);
+    const receivePromise = waitForMessage(ws, (m) => m.type === "ak.gameplayBundle.v1");
+
+    ws.send(JSON.stringify({
+      type: "ak.uiReady.v1",
+      clientId: "late-client",
+      createdAt: new Date().toISOString(),
+      capabilities: {},
+    }));
+
+    const received = await receivePromise;
+    assert.equal(received.id, "msg_replay_001");
+    ws.close();
+    await new Promise((r) => setTimeout(r, 20));
+  } finally {
+    await stop();
+  }
+}, 10_000);
+
+test("bridge-server: stopSandboxBridgeServer clears state", async () => {
+  await startSandboxBridgeServer({ port: 0 });
+  await stopSandboxBridgeServer();
+  assert.equal(getSandboxBridgeState().connectedClients, 0);
+  assert.equal(getSandboxBridgeState().latestBundle, null);
+});

--- a/tests/runtime/irregular-room-sizes.test.js
+++ b/tests/runtime/irregular-room-sizes.test.js
@@ -1,0 +1,107 @@
+/**
+ * M6 — Irregular room sizes (C-05)
+ *
+ * Verifies that:
+ * - randomIrregularRoomDimensions always produces an aspect ratio >= 1.5
+ * - The function respects min/max bounds
+ * - generateGridLayout produces rooms that are predominantly non-square
+ *   (majority have aspect ratio >= 1.5 with preferIrregular on by default)
+ */
+
+const assert = require("node:assert/strict");
+
+test("randomIrregularRoomDimensions returns { width, height } with aspect ratio >= 1.5", async () => {
+  const { randomIrregularRoomDimensions } = await import(
+    "../../packages/runtime/src/personas/configurator/level-layout.js"
+  );
+  // Use a simple seeded-like rng (deterministic sequence)
+  let seed = 42;
+  const rng = () => {
+    seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+    return (seed >>> 0) / 0x100000000;
+  };
+
+  for (let i = 0; i < 50; i += 1) {
+    const { width, height } = randomIrregularRoomDimensions(rng, 3, 9);
+    const longer = Math.max(width, height);
+    const shorter = Math.min(width, height);
+    assert.ok(
+      longer / shorter >= 1.5,
+      `Expected aspect ratio >= 1.5 but got ${longer}x${shorter} (ratio ${(longer / shorter).toFixed(2)}) on iteration ${i}`,
+    );
+  }
+});
+
+test("randomIrregularRoomDimensions keeps dimensions within [min, max]", async () => {
+  const { randomIrregularRoomDimensions } = await import(
+    "../../packages/runtime/src/personas/configurator/level-layout.js"
+  );
+  let seed = 7;
+  const rng = () => {
+    seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+    return (seed >>> 0) / 0x100000000;
+  };
+
+  for (let i = 0; i < 50; i += 1) {
+    const { width, height } = randomIrregularRoomDimensions(rng, 3, 9);
+    assert.ok(width >= 3 && width <= 9, `width ${width} out of [3,9]`);
+    assert.ok(height >= 3 && height <= 9, `height ${height} out of [3,9]`);
+  }
+});
+
+test("randomIrregularRoomDimensions works when min and max leave little room for aspect ratio", async () => {
+  const { randomIrregularRoomDimensions } = await import(
+    "../../packages/runtime/src/personas/configurator/level-layout.js"
+  );
+  let seed = 99;
+  const rng = () => {
+    seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+    return (seed >>> 0) / 0x100000000;
+  };
+  // min=3, max=4 — very tight range; function must not throw and still produce valid dimensions
+  for (let i = 0; i < 20; i += 1) {
+    const result = randomIrregularRoomDimensions(rng, 3, 4);
+    assert.ok(typeof result.width === "number" && typeof result.height === "number", "must return { width, height }");
+    assert.ok(result.width >= 3 && result.width <= 4, `width out of range: ${result.width}`);
+    assert.ok(result.height >= 3 && result.height <= 4, `height out of range: ${result.height}`);
+  }
+});
+
+test("generateGridLayoutFromInput produces mostly non-square rooms by default (preferIrregular)", async () => {
+  const { generateGridLayoutFromInput } = await import(
+    "../../packages/runtime/src/personas/configurator/level-layout.js"
+  );
+
+  const result = generateGridLayoutFromInput({
+    seed: 12345,
+    width: 60,
+    height: 60,
+    shape: { roomCount: 12, roomMinSize: 3, roomMaxSize: 10 },
+  });
+
+  assert.ok(result.ok, `generateGridLayoutFromInput failed: ${JSON.stringify(result.errors)}`);
+  const rooms = result.value?.rooms ?? [];
+  assert.ok(rooms.length > 0, "layout must produce rooms");
+
+  const irregular = rooms.filter((r) => {
+    const longer = Math.max(r.width, r.height);
+    const shorter = Math.min(r.width, r.height);
+    return longer / shorter >= 1.5;
+  });
+
+  // At least 60% of rooms should be irregular (aspect ratio >= 1.5)
+  const ratio = irregular.length / rooms.length;
+  assert.ok(
+    ratio >= 0.6,
+    `Expected >= 60% irregular rooms but only ${irregular.length}/${rooms.length} (${(ratio * 100).toFixed(0)}%) qualify`,
+  );
+});
+
+/*
+## TODO: Test Permutations
+- randomIrregularRoomDimensions orientation: when wide, width > height; when tall, height > width
+- randomIrregularRoomDimensions distribution: roughly equal wide/tall across many calls (not biased)
+- generateGridLayout with preferIrregular: explicitly disabled produces more square rooms on average
+- preferIrregular coexists with preferLargeRooms: large irregular rooms are produced
+- placeRooms fallback path also uses preferIrregular when set
+*/

--- a/tests/ui-web/design-view.test.mjs
+++ b/tests/ui-web/design-view.test.mjs
@@ -458,11 +458,13 @@ test("wireDesignView refreshes design rail and card icons from the resource bund
   try {
     view.setResourceBundle(createDesignIconBundle());
 
-    const roomChipIcon = elements["#design-property-group-type"]
-      .querySelector('[data-property-value="room"]')
+    // Rooms are rendered as action chips (data-action-value), not property chips.
+    // Delver/warden/hazard/resource are the property chips with icon slots.
+    const delverChipIcon = elements["#design-property-group-type"]
+      .querySelector('[data-property-value="delver"]')
       ?.querySelector(".design-property-chip-icon");
-    assert.ok(roomChipIcon);
-    assert.match(roomChipIcon.innerHTML, /ROOM_ICON/);
+    assert.ok(delverChipIcon, "delver type chip icon must exist");
+    assert.match(delverChipIcon.innerHTML, /DELVER_ICON/);
 
     const fireChipIcon = elements["#design-property-group-affinities"]
       .querySelector('[data-property-value="fire"]')

--- a/tests/ui-web/sandbox-bridge-client-failure.test.mjs
+++ b/tests/ui-web/sandbox-bridge-client-failure.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * M8 — sandbox-bridge-client failure tests
+ *
+ * Covers the case where __ak_loadGameplayBundle throws: the client must send
+ * ak.bundleLoadFailed.v1 with code LOAD_GAMEPLAY_BUNDLE_UNAVAILABLE.
+ */
+
+import assert from "node:assert/strict";
+
+function createMockWebSocket() {
+  const OPEN = 1;
+  let openHandler = null;
+  let messageHandler = null;
+  let closeHandler = null;
+  const sent = [];
+
+  const ws = {
+    readyState: OPEN,
+    OPEN,
+    send(data) { sent.push(data); },
+    close() { closeHandler?.({ code: 1000 }); },
+    addEventListener(event, fn) {
+      if (event === "open") openHandler = fn;
+      if (event === "message") messageHandler = fn;
+      if (event === "close") closeHandler = fn;
+    },
+    _triggerOpen() { openHandler?.(); },
+    _triggerMessage(payload) { messageHandler?.({ data: JSON.stringify(payload) }); },
+    _sent: sent,
+  };
+  return ws;
+}
+
+test("sandbox-bridge-client: throwing loadGameplayBundle → ak.bundleLoadFailed.v1 with LOAD_GAMEPLAY_BUNDLE_UNAVAILABLE", async () => {
+  let mockWs = null;
+  globalThis.WebSocket = function MockWebSocket() {
+    mockWs = createMockWebSocket();
+    return mockWs;
+  };
+  globalThis.WebSocket.OPEN = 1;
+
+  globalThis.__ak_loadGameplayBundle = () => {
+    const err = new Error("Load unavailable");
+    err.code = "LOAD_GAMEPLAY_BUNDLE_UNAVAILABLE";
+    throw err;
+  };
+  globalThis.__ak_setActiveTab = () => {};
+
+  try {
+    const { connectSandboxBridge, disconnectSandboxBridge } = await import(
+      "../../packages/ui-web/src/sandbox-bridge-client.js?t=" + Date.now()
+    );
+
+    connectSandboxBridge({ port: 38487 });
+    mockWs._triggerOpen();
+
+    const messageId = "msg_fail_001";
+    mockWs._triggerMessage({
+      type: "ak.gameplayBundle.v1",
+      id: messageId,
+      targetTab: "gameplay",
+      payload: { bundle: {}, source: { tool: "test" } },
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const failRaw = mockWs._sent.find((s) => {
+      try { return JSON.parse(s)?.type === "ak.bundleLoadFailed.v1"; } catch { return false; }
+    });
+    assert.ok(failRaw, "ak.bundleLoadFailed.v1 must be sent on load failure");
+    const fail = JSON.parse(failRaw);
+    assert.equal(fail.messageId, messageId);
+    assert.equal(fail.error?.code, "LOAD_GAMEPLAY_BUNDLE_UNAVAILABLE");
+
+    disconnectSandboxBridge();
+  } finally {
+    delete globalThis.__ak_loadGameplayBundle;
+    delete globalThis.__ak_setActiveTab;
+    delete globalThis.WebSocket;
+  }
+});
+
+test("sandbox-bridge-client: missing __ak_loadGameplayBundle → ak.bundleLoadFailed.v1", async () => {
+  let mockWs = null;
+  globalThis.WebSocket = function MockWebSocket() {
+    mockWs = createMockWebSocket();
+    return mockWs;
+  };
+  globalThis.WebSocket.OPEN = 1;
+
+  // Deliberately not setting __ak_loadGameplayBundle
+  delete globalThis.__ak_loadGameplayBundle;
+  delete globalThis.__ak_setActiveTab;
+
+  try {
+    const { connectSandboxBridge, disconnectSandboxBridge } = await import(
+      "../../packages/ui-web/src/sandbox-bridge-client.js?t=" + Date.now()
+    );
+
+    connectSandboxBridge({ port: 38487 });
+    mockWs._triggerOpen();
+
+    mockWs._triggerMessage({
+      type: "ak.gameplayBundle.v1",
+      id: "msg_no_fn",
+      targetTab: "gameplay",
+      payload: { bundle: {}, source: { tool: "test" } },
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const failRaw = mockWs._sent.find((s) => {
+      try { return JSON.parse(s)?.type === "ak.bundleLoadFailed.v1"; } catch { return false; }
+    });
+    assert.ok(failRaw, "ak.bundleLoadFailed.v1 must be sent when load fn is missing");
+    const fail = JSON.parse(failRaw);
+    assert.equal(fail.error?.code, "LOAD_GAMEPLAY_BUNDLE_UNAVAILABLE");
+
+    disconnectSandboxBridge();
+  } finally {
+    delete globalThis.WebSocket;
+  }
+});

--- a/tests/ui-web/sandbox-bridge-client.test.mjs
+++ b/tests/ui-web/sandbox-bridge-client.test.mjs
@@ -1,0 +1,147 @@
+/**
+ * M8 — sandbox-bridge-client unit tests
+ *
+ * Mocks the global WebSocket constructor so the client can run in Node.
+ * Tests the happy-path: bundle received → __ak_loadGameplayBundle called →
+ * ak.bundleLoaded.v1 ACK sent back.
+ */
+
+import assert from "node:assert/strict";
+
+// ---------------------------------------------------------------------------
+// Minimal mock WebSocket
+// ---------------------------------------------------------------------------
+
+function createMockWebSocket() {
+  const OPEN = 1;
+  let openHandler = null;
+  let messageHandler = null;
+  let closeHandler = null;
+  const sent = [];
+
+  const ws = {
+    readyState: OPEN,
+    OPEN,
+    send(data) { sent.push(data); },
+    close() { closeHandler?.({ code: 1000, reason: "" }); },
+    addEventListener(event, fn) {
+      if (event === "open") openHandler = fn;
+      if (event === "message") messageHandler = fn;
+      if (event === "close") closeHandler = fn;
+    },
+    // Test helpers
+    _triggerOpen() { openHandler?.(); },
+    _triggerMessage(payload) { messageHandler?.({ data: JSON.stringify(payload) }); },
+    _triggerClose() { closeHandler?.({ code: 1000, reason: "" }); },
+    _sent: sent,
+  };
+  return ws;
+}
+
+// ---------------------------------------------------------------------------
+// Test setup helpers
+// ---------------------------------------------------------------------------
+
+function installMockGlobals({ loadFn, setTabFn } = {}) {
+  globalThis.__ak_loadGameplayBundle = loadFn ?? (() => true);
+  globalThis.__ak_setActiveTab = setTabFn ?? (() => {});
+}
+
+function clearMockGlobals() {
+  delete globalThis.__ak_loadGameplayBundle;
+  delete globalThis.__ak_setActiveTab;
+}
+
+// ---------------------------------------------------------------------------
+
+test("sandbox-bridge-client: bundle received → loadGameplayBundle called → ak.bundleLoaded.v1 sent", async () => {
+  let mockWs = null;
+  globalThis.WebSocket = function MockWebSocket(url) {
+    mockWs = createMockWebSocket();
+    return mockWs;
+  };
+  globalThis.WebSocket.OPEN = 1;
+
+  const receivedBundles = [];
+  const activatedTabs = [];
+
+  installMockGlobals({
+    loadFn: (bundle) => { receivedBundles.push(bundle); return true; },
+    setTabFn: (tab) => { activatedTabs.push(tab); },
+  });
+
+  try {
+    const { connectSandboxBridge, disconnectSandboxBridge } = await import(
+      "../../packages/ui-web/src/sandbox-bridge-client.js?t=" + Date.now()
+    );
+
+    connectSandboxBridge({ port: 38487 });
+    mockWs._triggerOpen();
+
+    const bundle = { simConfig: { schema: "agent-kernel/SimConfigArtifact", schemaVersion: 1, meta: { id: "sc-test" } } };
+    const messageId = "msg_001";
+
+    mockWs._triggerMessage({
+      type: "ak.gameplayBundle.v1",
+      id: messageId,
+      targetTab: "gameplay",
+      payload: { bundle, source: { tool: "ak_sandbox_push_ui" } },
+    });
+
+    // Allow async handleBundle to complete
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Bundle was passed to loadGameplayBundle
+    assert.equal(receivedBundles.length, 1);
+    assert.deepEqual(receivedBundles[0], bundle);
+
+    // Tab was activated
+    assert.ok(activatedTabs.includes("gameplay"), "setActiveTab must be called with 'gameplay'");
+
+    // ACK was sent back
+    const ackRaw = mockWs._sent.find((s) => {
+      try { return JSON.parse(s)?.type === "ak.bundleLoaded.v1"; } catch { return false; }
+    });
+    assert.ok(ackRaw, "ak.bundleLoaded.v1 ACK must be sent");
+    const ack = JSON.parse(ackRaw);
+    assert.equal(ack.messageId, messageId);
+
+    disconnectSandboxBridge();
+  } finally {
+    clearMockGlobals();
+    delete globalThis.WebSocket;
+  }
+});
+
+test("sandbox-bridge-client: ak.uiReady.v1 is sent on connect", async () => {
+  let mockWs = null;
+  globalThis.WebSocket = function MockWebSocket() {
+    mockWs = createMockWebSocket();
+    return mockWs;
+  };
+  globalThis.WebSocket.OPEN = 1;
+
+  installMockGlobals();
+  try {
+    const { connectSandboxBridge, disconnectSandboxBridge } = await import(
+      "../../packages/ui-web/src/sandbox-bridge-client.js?t=" + Date.now()
+    );
+
+    connectSandboxBridge({ port: 38487 });
+    mockWs._triggerOpen();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const readyMsg = mockWs._sent.map((s) => {
+      try { return JSON.parse(s); } catch { return null; }
+    }).find((m) => m?.type === "ak.uiReady.v1");
+
+    assert.ok(readyMsg, "ak.uiReady.v1 must be sent on open");
+    assert.ok(typeof readyMsg.clientId === "string" && readyMsg.clientId.length > 0);
+    assert.ok("loadGameplayBundle" in (readyMsg.capabilities ?? {}));
+
+    disconnectSandboxBridge();
+  } finally {
+    clearMockGlobals();
+    delete globalThis.WebSocket;
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `bridge-server.mjs`: loopback-only WebSocket server with 10s replay window and ACK/timeout tracking per client
- Adds `sandbox-ui.mjs`: `ak_sandbox_push_ui` MCP tool that compiles a BuildSpec → gameplay bundle and pushes it to connected browser clients
- Adds `sandbox-bridge-client.js`: browser-side reconnecting WebSocket client with exponential backoff and capability announcement
- Adds 11 passing tests across `bridge-server`, `sandbox-bridge-client`, and `sandbox-bridge-client-failure` suites
- Adds `irregular-room-sizes.test.js`: M6 `preferIrregular` layout tests (4 tests awaiting source implementation in `level-layout.js`)
- Fixes `design-view.test.mjs`: room chips now render as action chips (`data-action-value`), not property chips; icon assertion updated to delver chip

These 7 files were complete implementations that survived a `git reset --hard` and were not previously committed.

## Test plan

- [x] `pnpm run test:vitest -- tests/adapters-cli/bridge-server.test.mjs` — 7 pass
- [x] `pnpm run test:vitest -- tests/ui-web/sandbox-bridge-client.test.mjs` — 2 pass
- [x] `pnpm run test:vitest -- tests/ui-web/sandbox-bridge-client-failure.test.mjs` — 2 pass
- [x] `pnpm run test:vitest -- tests/ui-web/design-view.test.mjs` — 30 pass
- [ ] `tests/runtime/irregular-room-sizes.test.js` — 4 failing (source not yet implemented; tracked as B2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)