### PR TITLE
feat: affinity-vital matrix — neutralization, hazard durability/regen, and test permutations (M3b–M4)

### DIFF
--- a/packages/core-ts/src/index.ts
+++ b/packages/core-ts/src/index.ts
@@ -67,6 +67,8 @@ export const CORE_API_KEYS = [
   "applyAction",
   "applyActorPlacements",
   "applyAffinityDamage",
+  "applyAffinityDamageToHazard",
+  "applyAffinityPullFromHazard",
   "applyAttack",
   "armStaticTrapAt",
   "clearActorPlacements",
@@ -176,7 +178,12 @@ export const CORE_API_KEYS = [
   "getOppositeAffinityKind",
   "getStaticTrapAffinityAt",
   "getStaticTrapCount",
+  "getStaticTrapDurabilityAt",
+  "getStaticTrapDurabilityMaxAt",
+  "getStaticTrapDurabilityRegenAt",
   "getStaticTrapExpressionAt",
+  "getStaticTrapManaMaxAt",
+  "getStaticTrapManaRegenAt",
   "getStaticTrapManaReserveAt",
   "getStaticTrapStacksAt",
   "getTileActorCount",
@@ -554,9 +561,14 @@ export function createCore(): Record<(typeof CORE_API_KEYS)[number], CoreExport>
   core.disarmStaticTrapAt = world.disarmStaticTrapAt as CoreFunction;
   core.getStaticTrapCount = world.getStaticTrapCount as CoreFunction;
   core.getStaticTrapAffinityAt = world.getStaticTrapAffinityAt as CoreFunction;
+  core.getStaticTrapDurabilityAt = world.getStaticTrapDurabilityAt as CoreFunction;
+  core.getStaticTrapDurabilityMaxAt = world.getStaticTrapDurabilityMaxAt as CoreFunction;
+  core.getStaticTrapDurabilityRegenAt = world.getStaticTrapDurabilityRegenAt as CoreFunction;
   core.getStaticTrapExpressionAt = world.getStaticTrapExpressionAt as CoreFunction;
-  core.getStaticTrapStacksAt = world.getStaticTrapStacksAt as CoreFunction;
+  core.getStaticTrapManaMaxAt = world.getStaticTrapManaMaxAt as CoreFunction;
+  core.getStaticTrapManaRegenAt = world.getStaticTrapManaRegenAt as CoreFunction;
   core.getStaticTrapManaReserveAt = world.getStaticTrapManaReserveAt as CoreFunction;
+  core.getStaticTrapStacksAt = world.getStaticTrapStacksAt as CoreFunction;
   core.clearAffinityField = world.clearAffinityField as CoreFunction;
   core.getAffinityFieldIntensityAt = world.getAffinityFieldIntensityAt as CoreFunction;
   core.getAffinityFieldStacksAt = world.getAffinityFieldStacksAt as CoreFunction;
@@ -586,6 +598,8 @@ export function createCore(): Record<(typeof CORE_API_KEYS)[number], CoreExport>
   core.applyAction = applyAction as CoreFunction;
   core.applyAttack = combat.applyAttack as CoreFunction;
   core.applyAffinityDamage = affinityDamage.applyAffinityDamage as CoreFunction;
+  core.applyAffinityDamageToHazard = affinityDamage.applyAffinityDamageToHazard as CoreFunction;
+  core.applyAffinityPullFromHazard = affinityDamage.applyAffinityPullFromHazard as CoreFunction;
 
   return core;
 }

--- a/packages/core-ts/src/index.ts
+++ b/packages/core-ts/src/index.ts
@@ -11,6 +11,7 @@ import {
   resolveAffinityRelationshipCode,
 } from "./state/affinity.ts";
 import { createEffectsPort, EffectKind } from "./ports/effects.ts";
+import { createAffinityDamageRules } from "./rules/affinity-damage.ts";
 import { createCombatRules } from "./rules/combat.ts";
 import { createMoveRules } from "./rules/move.ts";
 import {
@@ -65,6 +66,7 @@ export const CORE_API_KEYS = [
   "affinityExpressionIsPersistentField",
   "applyAction",
   "applyActorPlacements",
+  "applyAffinityDamage",
   "applyAttack",
   "armStaticTrapAt",
   "clearActorPlacements",
@@ -264,6 +266,7 @@ export function createCore(): Record<(typeof CORE_API_KEYS)[number], CoreExport>
   const motivation = createMotivationState();
   const move = createMoveRules(world);
   const combat = createCombatRules(world);
+  const affinityDamage = createAffinityDamageRules(world);
 
   function emitBudgetEffects(category: number, spent: number): void {
     const cap = budget.getBudgetCap(category);
@@ -582,6 +585,7 @@ export function createCore(): Record<(typeof CORE_API_KEYS)[number], CoreExport>
   core.step = (() => { applyAction(ActionKind.IncrementCounter, 1); }) as CoreFunction;
   core.applyAction = applyAction as CoreFunction;
   core.applyAttack = combat.applyAttack as CoreFunction;
+  core.applyAffinityDamage = affinityDamage.applyAffinityDamage as CoreFunction;
 
   return core;
 }

--- a/packages/core-ts/src/rules/affinity-damage.ts
+++ b/packages/core-ts/src/rules/affinity-damage.ts
@@ -1,0 +1,131 @@
+/**
+ * core-ts affinity damage rules — M3 of feat/affinity-vital-matrix
+ *
+ * Pure deterministic primitive that routes (affinity, expression, stacks)
+ * through the M2 matrix to the correct vital(s) on a target actor.
+ *
+ * No IO, no clock, no runtime imports. Pattern mirrors rules/combat.ts.
+ *
+ * Contract:
+ *   applyAffinityDamage(attackerIndex, targetIndex, affinityKind, expression, stacks) -> 0 | 1
+ *     0 = rejected (invalid args, out-of-range push/pull, self-target)
+ *     1 = accepted (effect applied to target's matrix-routed vital, clamped to [0, max])
+ *
+ * Range semantics:
+ *   - Push / Pull: single-target, Chebyshev distance must be <= stacks
+ *     (e.g. fire+4+push reaches up to 4 tiles away).
+ *   - Emit / Draw: continuous diffuse area effects. No range constraint at this
+ *     per-target primitive level — the caller iterates the area and calls
+ *     applyAffinityDamage once per affected target.
+ *
+ * Effect routing:
+ *   For each vital index 0..3, look up the matrix cell. Cells with effect == 0
+ *   are skipped (no-op for non-primary vitals). The loop generalizes for
+ *   future cross-vital matrix extensions without changing the call surface.
+ */
+import {
+  AffinityExpression,
+  getAffinityVitalEffect,
+  isValidAffinityExpression,
+  isValidAffinityKind,
+} from "../state/affinity.ts";
+
+const VITAL_COUNT = 4;
+
+type WorldLike = {
+  getMotivatedActorCount(): number;
+  getMotivatedActorXByIndex(index: number): number;
+  getMotivatedActorYByIndex(index: number): number;
+  getMotivatedActorVitalCurrentByIndex(index: number, vital: number): number;
+  getMotivatedActorVitalMaxByIndex(index: number, vital: number): number;
+  getMotivatedActorVitalRegenByIndex(index: number, vital: number): number;
+  setMotivatedActorVital(
+    index: number,
+    vital: number,
+    current: number,
+    max: number,
+    regen: number,
+  ): void;
+};
+
+export function createAffinityDamageRules(world: WorldLike) {
+  /**
+   * Apply a matrix-routed affinity effect from attacker to target.
+   *
+   * @param attackerIndex  Motivated-actor index of the source actor
+   * @param targetIndex    Motivated-actor index of the target actor
+   * @param affinityKind   AffinityKind code (1..10)
+   * @param expression     AffinityExpression code (1..4: push, pull, emit, draw)
+   * @param stacks         Positive integer; doubles as projectile range for push/pull
+   * @returns 0 on rejection, 1 on acceptance
+   */
+  function applyAffinityDamage(
+    attackerIndex: number,
+    targetIndex: number,
+    affinityKind: number,
+    expression: number,
+    stacks: number,
+  ): number {
+    // --- Guard: actor indices and self-target ---
+    const actorCount = world.getMotivatedActorCount();
+    if (
+      attackerIndex < 0 ||
+      attackerIndex >= actorCount ||
+      targetIndex < 0 ||
+      targetIndex >= actorCount ||
+      attackerIndex === targetIndex
+    ) {
+      return 0;
+    }
+
+    // --- Guard: affinity + expression validity ---
+    if (!isValidAffinityKind(affinityKind)) return 0;
+    if (!isValidAffinityExpression(expression)) return 0;
+
+    // --- Guard: positive integer stacks ---
+    if (!Number.isInteger(stacks) || stacks <= 0) return 0;
+
+    // --- Range check: push/pull require Chebyshev distance <= stacks ---
+    if (
+      expression === AffinityExpression.Push ||
+      expression === AffinityExpression.Pull
+    ) {
+      const ax = world.getMotivatedActorXByIndex(attackerIndex);
+      const ay = world.getMotivatedActorYByIndex(attackerIndex);
+      const tx = world.getMotivatedActorXByIndex(targetIndex);
+      const ty = world.getMotivatedActorYByIndex(targetIndex);
+      const chebyshev = Math.max(Math.abs(ax - tx), Math.abs(ay - ty));
+      if (chebyshev > stacks) return 0;
+    }
+
+    // --- Apply matrix-routed effects to every non-zero vital ---
+    // Loop generalizes for future cross-vital matrices; today each affinity
+    // has only its primary vital non-zero, so only one apply happens.
+    for (let vital = 0; vital < VITAL_COUNT; vital += 1) {
+      const effect = getAffinityVitalEffect(
+        affinityKind,
+        expression,
+        vital,
+        stacks,
+      );
+      if (effect === 0) continue;
+
+      const current = world.getMotivatedActorVitalCurrentByIndex(
+        targetIndex,
+        vital,
+      );
+      const max = world.getMotivatedActorVitalMaxByIndex(targetIndex, vital);
+      const regen = world.getMotivatedActorVitalRegenByIndex(
+        targetIndex,
+        vital,
+      );
+      // Clamp to [0, max]: drain stops at 0, buff stops at max.
+      const next = Math.max(0, Math.min(max, current + effect));
+      world.setMotivatedActorVital(targetIndex, vital, next, max, regen);
+    }
+
+    return 1;
+  }
+
+  return { applyAffinityDamage };
+}

--- a/packages/core-ts/src/rules/affinity-damage.ts
+++ b/packages/core-ts/src/rules/affinity-damage.ts
@@ -29,6 +29,7 @@ import {
   isValidAffinityExpression,
   isValidAffinityKind,
 } from "../state/affinity.ts";
+import { VitalKind } from "../state/vitals.ts";
 
 const VITAL_COUNT = 4;
 
@@ -46,6 +47,20 @@ type WorldLike = {
     max: number,
     regen: number,
   ): void;
+  // M3b: actor affinity state for neutralization detection
+  getMotivatedActorAffinityKindByIndex(index: number): number;
+  getMotivatedActorAffinityExpressionByIndex(index: number): number;
+  clearMotivatedActorAffinity(index: number): number;
+  // M3b: static trap access for hazard pulls
+  getStaticTrapAffinityAt(x: number, y: number): number;
+  getStaticTrapExpressionAt(x: number, y: number): number;
+  getStaticTrapManaReserveAt(x: number, y: number): number;
+  setStaticTrapManaCurrentAt(x: number, y: number, current: number): number;
+  disarmStaticTrapAt(x: number, y: number): number;
+  // M3c: hazard durability
+  getStaticTrapDurabilityAt(x: number, y: number): number;
+  getStaticTrapDurabilityMaxAt(x: number, y: number): number;
+  setStaticTrapDurabilityCurrentAt(x: number, y: number, current: number): number;
 };
 
 export function createAffinityDamageRules(world: WorldLike) {
@@ -98,6 +113,18 @@ export function createAffinityDamageRules(world: WorldLike) {
       if (chebyshev > stacks) return 0;
     }
 
+    // --- M3b: neutralization branch (Pull + matching active affinity on target) ---
+    if (expression === AffinityExpression.Pull) {
+      const targetKind = world.getMotivatedActorAffinityKindByIndex(targetIndex);
+      const targetExpr = world.getMotivatedActorAffinityExpressionByIndex(targetIndex);
+      const isNeutralizable =
+        targetKind === affinityKind &&
+        (targetExpr === AffinityExpression.Emit || targetExpr === AffinityExpression.Push);
+      if (isNeutralizable) {
+        return applyNeutralizationTransfer(attackerIndex, targetIndex);
+      }
+    }
+
     // --- Apply matrix-routed effects to every non-zero vital ---
     // Loop generalizes for future cross-vital matrices; today each affinity
     // has only its primary vital non-zero, so only one apply happens.
@@ -127,5 +154,136 @@ export function createAffinityDamageRules(world: WorldLike) {
     return 1;
   }
 
-  return { applyAffinityDamage };
+  /**
+   * Drain the source actor's mana to 0, transfer as much as fits to the
+   * attacker, and clear the source's active affinity expression.
+   * Returns 1 (always accepted when called).
+   */
+  function applyNeutralizationTransfer(
+    attackerIndex: number,
+    sourceIndex: number,
+  ): number {
+    const sourceMana    = world.getMotivatedActorVitalCurrentByIndex(sourceIndex,   VitalKind.Mana);
+    const sourceMax     = world.getMotivatedActorVitalMaxByIndex(sourceIndex,       VitalKind.Mana);
+    const sourceRegen   = world.getMotivatedActorVitalRegenByIndex(sourceIndex,     VitalKind.Mana);
+    const attackerMana  = world.getMotivatedActorVitalCurrentByIndex(attackerIndex, VitalKind.Mana);
+    const attackerMax   = world.getMotivatedActorVitalMaxByIndex(attackerIndex,     VitalKind.Mana);
+    const attackerRegen = world.getMotivatedActorVitalRegenByIndex(attackerIndex,   VitalKind.Mana);
+
+    const capacity = attackerMax - attackerMana;
+    const transfer = Math.min(sourceMana, capacity);
+
+    world.setMotivatedActorVital(sourceIndex,   VitalKind.Mana, 0,                      sourceMax,   sourceRegen);
+    world.setMotivatedActorVital(attackerIndex, VitalKind.Mana, attackerMana + transfer, attackerMax, attackerRegen);
+    // Clear the source's active affinity expression (sentinel = 0)
+    world.clearMotivatedActorAffinity(sourceIndex);
+    return 1;
+  }
+
+  /**
+   * Pull from a static trap hazard at (hazardX, hazardY).
+   *
+   * Accepted when:
+   *   - attackerIndex is valid
+   *   - affinityKind is valid and matches the trap's kind
+   *   - stacks > 0
+   *   - A trap exists at (hazardX, hazardY) with expression Emit or Push
+   *
+   * On acceptance: trap is disarmed and its mana is transferred to the attacker
+   * (clamped to attacker's remaining mana capacity). Returns 1.
+   * Returns 0 on any rejection.
+   */
+  function applyAffinityPullFromHazard(
+    attackerIndex: number,
+    hazardX: number,
+    hazardY: number,
+    affinityKind: number,
+    stacks: number,
+  ): number {
+    const actorCount = world.getMotivatedActorCount();
+    if (attackerIndex < 0 || attackerIndex >= actorCount) return 0;
+    if (!isValidAffinityKind(affinityKind)) return 0;
+    if (!Number.isInteger(stacks) || stacks <= 0) return 0;
+
+    const trapKind = world.getStaticTrapAffinityAt(hazardX, hazardY);
+    if (trapKind !== affinityKind) return 0;
+
+    const trapExpr = world.getStaticTrapExpressionAt(hazardX, hazardY);
+    if (
+      trapExpr !== AffinityExpression.Emit &&
+      trapExpr !== AffinityExpression.Push
+    ) return 0;
+
+    const trapMana = world.getStaticTrapManaReserveAt(hazardX, hazardY);
+    if (trapMana <= 0) return 0; // nothing to neutralize
+
+    // Drain mana to 0 but keep the trap structure so it can regen (M3d)
+    world.setStaticTrapManaCurrentAt(hazardX, hazardY, 0);
+
+    const attackerMana  = world.getMotivatedActorVitalCurrentByIndex(attackerIndex, VitalKind.Mana);
+    const attackerMax   = world.getMotivatedActorVitalMaxByIndex(attackerIndex,     VitalKind.Mana);
+    const attackerRegen = world.getMotivatedActorVitalRegenByIndex(attackerIndex,   VitalKind.Mana);
+
+    const capacity = attackerMax - attackerMana;
+    const transfer = Math.min(trapMana, capacity);
+    world.setMotivatedActorVital(attackerIndex, VitalKind.Mana, attackerMana + transfer, attackerMax, attackerRegen);
+    return 1;
+  }
+
+  /**
+   * Apply a matrix-routed affinity effect to a static trap's durability vital.
+   *
+   * Only affinities whose primary vital is VitalKind.Durability (Earth, Corrode,
+   * Fortify) are routed; all others return 0 — hazards have no Health/Mana/Stamina.
+   *
+   * Traps armed with durabilityMax == 0 are immortal; damage is rejected (0).
+   *
+   * When durability reaches 0 the trap is destroyed via disarmStaticTrapAt.
+   *
+   * @returns 0 on rejection, 1 on acceptance
+   */
+  function applyAffinityDamageToHazard(
+    attackerIndex: number,
+    hazardX: number,
+    hazardY: number,
+    affinityKind: number,
+    expression: number,
+    stacks: number,
+  ): number {
+    const actorCount = world.getMotivatedActorCount();
+    if (attackerIndex < 0 || attackerIndex >= actorCount) return 0;
+    if (!isValidAffinityKind(affinityKind)) return 0;
+    if (!isValidAffinityExpression(expression)) return 0;
+    if (!Number.isInteger(stacks) || stacks <= 0) return 0;
+
+    // Reject if no trap at target cell
+    if (world.getStaticTrapAffinityAt(hazardX, hazardY) === 0) return 0;
+
+    // Only durability-routing affinities affect hazards
+    const effect = getAffinityVitalEffect(affinityKind, expression, VitalKind.Durability, stacks);
+    if (effect === 0) return 0;
+
+    // Immortal trap guard
+    const durMax = world.getStaticTrapDurabilityMaxAt(hazardX, hazardY);
+    if (durMax === 0) return 0;
+
+    // Range check for Push/Pull
+    if (expression === AffinityExpression.Push || expression === AffinityExpression.Pull) {
+      const ax = world.getMotivatedActorXByIndex(attackerIndex);
+      const ay = world.getMotivatedActorYByIndex(attackerIndex);
+      const chebyshev = Math.max(Math.abs(ax - hazardX), Math.abs(ay - hazardY));
+      if (chebyshev > stacks) return 0;
+    }
+
+    const current = world.getStaticTrapDurabilityAt(hazardX, hazardY);
+    const next = Math.max(0, Math.min(durMax, current + effect));
+    if (next === 0) {
+      world.disarmStaticTrapAt(hazardX, hazardY);
+    } else {
+      world.setStaticTrapDurabilityCurrentAt(hazardX, hazardY, next);
+    }
+    return 1;
+  }
+
+  return { applyAffinityDamage, applyAffinityPullFromHazard, applyAffinityDamageToHazard };
 }

--- a/packages/core-ts/src/state/affinity.ts
+++ b/packages/core-ts/src/state/affinity.ts
@@ -151,3 +151,146 @@ export function affinityExpressionIsPersistentField(
   );
 }
 
+// ── PR #43 M2: Affinity x Expression x Vital matrix ────────────────────────
+//
+// 3D matrix mapping (AffinityKind, AffinityExpression, VitalKind) -> signed
+// integer base magnitude. Stored as a flat Int32Array of size 10 * 4 * 4 = 160.
+//
+// Sign convention:
+//   - Each affinity has an intrinsic polarity (+1 = buff, -1 = drain) on
+//     exactly one primary vital. All other (vital) cells store explicit 0.
+//   - Push and Emit carry the polarity sign.
+//   - Pull and Draw carry the OPPOSITE sign (sign-reversal pair on same vital).
+//   - Push/Pull base magnitude = 2 (single-target, focused intensity).
+//   - Emit/Draw base magnitude = 1 (diffuse area, lower per-target intensity).
+//
+// "No effect" cells are explicit 0 — they reserve the slot so future
+// milestones can introduce non-zero cross-vital effects without changing
+// the matrix shape or any consumer's lookup contract.
+
+const PRIMARY_VITAL_BY_AFFINITY = new Int32Array(11);
+PRIMARY_VITAL_BY_AFFINITY[0] = -1;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Fire] = VitalKind.Health;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Water] = VitalKind.Health;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Earth] = VitalKind.Durability;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Wind] = VitalKind.Stamina;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Life] = VitalKind.Health;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Decay] = VitalKind.Health;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Corrode] = VitalKind.Durability;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Fortify] = VitalKind.Durability;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Light] = VitalKind.Mana;
+PRIMARY_VITAL_BY_AFFINITY[AffinityKind.Dark] = VitalKind.Mana;
+
+const POLARITY_BY_AFFINITY = new Int32Array(11);
+POLARITY_BY_AFFINITY[0] = 0;
+POLARITY_BY_AFFINITY[AffinityKind.Fire] = -1;
+POLARITY_BY_AFFINITY[AffinityKind.Water] = +1;
+POLARITY_BY_AFFINITY[AffinityKind.Earth] = +1;
+POLARITY_BY_AFFINITY[AffinityKind.Wind] = -1;
+POLARITY_BY_AFFINITY[AffinityKind.Life] = +1;
+POLARITY_BY_AFFINITY[AffinityKind.Decay] = -1;
+POLARITY_BY_AFFINITY[AffinityKind.Corrode] = -1;
+POLARITY_BY_AFFINITY[AffinityKind.Fortify] = +1;
+POLARITY_BY_AFFINITY[AffinityKind.Light] = +1;
+POLARITY_BY_AFFINITY[AffinityKind.Dark] = -1;
+
+const BASE_MAGNITUDE_PUSH_PULL = 2;
+const BASE_MAGNITUDE_EMIT_DRAW = 1;
+
+const VITAL_KIND_COUNT = 4;
+const AFFINITY_VITAL_MATRIX_SIZE =
+  AFFINITY_KIND_COUNT * AFFINITY_EXPRESSION_COUNT * VITAL_KIND_COUNT;
+
+const AFFINITY_VITAL_MATRIX = buildAffinityVitalMatrix();
+
+function isValidVitalKind(vital: number): boolean {
+  return Number.isInteger(vital) && vital >= 0 && vital < VITAL_KIND_COUNT;
+}
+
+function matrixIndex(kind: number, expression: number, vital: number): number {
+  // Flatten (kind, expression, vital) into a row-major flat index.
+  // kind ∈ [1, 10] is stored at row (kind - 1) so indices stay in [0, 160).
+  return (
+    (kind - 1) * AFFINITY_EXPRESSION_COUNT * VITAL_KIND_COUNT
+    + (expression - 1) * VITAL_KIND_COUNT
+    + vital
+  );
+}
+
+function buildAffinityVitalMatrix(): Int32Array {
+  const table = new Int32Array(AFFINITY_VITAL_MATRIX_SIZE);
+  for (let kind = AFFINITY_KIND_MIN; kind <= AFFINITY_KIND_MAX; kind += 1) {
+    const primaryVital = PRIMARY_VITAL_BY_AFFINITY[kind];
+    const polarity = POLARITY_BY_AFFINITY[kind];
+    for (
+      let expr = AFFINITY_EXPRESSION_MIN;
+      expr <= AFFINITY_EXPRESSION_MAX;
+      expr += 1
+    ) {
+      const isFocused =
+        expr === AffinityExpression.Push || expr === AffinityExpression.Pull;
+      const isReversed =
+        expr === AffinityExpression.Pull || expr === AffinityExpression.Draw;
+      const magnitude = isFocused
+        ? BASE_MAGNITUDE_PUSH_PULL
+        : BASE_MAGNITUDE_EMIT_DRAW;
+      const sign = isReversed ? -polarity : polarity;
+      const cellValue = sign * magnitude;
+      for (let vital = 0; vital < VITAL_KIND_COUNT; vital += 1) {
+        // Only the primary vital carries a non-zero magnitude.
+        // All other vital cells default to 0 (explicit "no effect").
+        table[matrixIndex(kind, expr, vital)] =
+          vital === primaryVital ? cellValue : 0;
+      }
+    }
+  }
+  return table;
+}
+
+/**
+ * Look up the signed base magnitude for an (affinity, expression, vital)
+ * cell in the matrix. Returns 0 for any out-of-range input and for
+ * "no effect" cells (every cell that is not on the affinity's primary vital).
+ */
+export function getAffinityVitalEffectBase(
+  kind: number,
+  expression: number,
+  vital: number,
+): number {
+  if (!isValidAffinityKind(kind)) return 0;
+  if (!isValidAffinityExpression(expression)) return 0;
+  if (!isValidVitalKind(vital)) return 0;
+  return AFFINITY_VITAL_MATRIX[matrixIndex(kind, expression, vital)];
+}
+
+/**
+ * Pure stack-scaling formula. For this milestone the formula is uniform
+ * linear `effect = base * stacks`. Negative stacks are rejected (return 0)
+ * so callers don't accidentally invert sign by passing a negative count.
+ *
+ * Exposed as a separate function so future milestones can introduce
+ * per-triple custom formulas without touching call sites.
+ */
+export function scaleAffinityVitalEffect(base: number, stacks: number): number {
+  if (!Number.isInteger(stacks) || stacks < 0) return 0;
+  if (!Number.isFinite(base)) return 0;
+  // Short-circuit when either operand is 0 to avoid -0 from base < 0.
+  // JS treats `-2 * 0` as -0, which Object.is distinguishes from +0.
+  if (stacks === 0 || base === 0) return 0;
+  return base * stacks;
+}
+
+/**
+ * Convenience composition: the scaled signed effect for an
+ * (affinity, expression, vital, stacks) tuple. Equivalent to
+ * `scaleAffinityVitalEffect(getAffinityVitalEffectBase(kind, expression, vital), stacks)`.
+ */
+export function getAffinityVitalEffect(
+  kind: number,
+  expression: number,
+  vital: number,
+  stacks: number,
+): number {
+  const base = getAffinityVitalEffectBase(kind, expression, vital);
+  return scaleAffinityVitalEffect(base, stacks);
+}

--- a/packages/core-ts/src/state/world.ts
+++ b/packages/core-ts/src/state/world.ts
@@ -73,6 +73,11 @@ export function createWorldState() {
   let staticTrapExpressionByCell = new Int32Array(0);
   let staticTrapStacksByCell = new Int32Array(0);
   let staticTrapManaReserveByCell = new Int32Array(0);
+  let staticTrapManaMaxByCell = new Int32Array(0);
+  let staticTrapManaRegenByCell = new Int32Array(0);
+  let staticTrapDurabilityCurrentByCell = new Int32Array(0);
+  let staticTrapDurabilityMaxByCell = new Int32Array(0);
+  let staticTrapDurabilityRegenByCell = new Int32Array(0);
   let staticTrapCount = 0;
 
   // ── Resources ──
@@ -169,6 +174,11 @@ export function createWorldState() {
     staticTrapExpressionByCell = new Int32Array(cellCount);
     staticTrapStacksByCell = new Int32Array(cellCount);
     staticTrapManaReserveByCell = new Int32Array(cellCount);
+    staticTrapManaMaxByCell = new Int32Array(cellCount);
+    staticTrapManaRegenByCell = new Int32Array(cellCount);
+    staticTrapDurabilityCurrentByCell = new Int32Array(cellCount);
+    staticTrapDurabilityMaxByCell = new Int32Array(cellCount);
+    staticTrapDurabilityRegenByCell = new Int32Array(cellCount);
     resourceVitalKindByCell = new Int32Array(cellCount);
     resourceDeltaByCell = new Int32Array(cellCount);
     resourceModeByCell = new Int32Array(cellCount);
@@ -280,6 +290,11 @@ export function createWorldState() {
     staticTrapExpressionByCell[index] = 0;
     staticTrapStacksByCell[index] = 0;
     staticTrapManaReserveByCell[index] = 0;
+    staticTrapManaMaxByCell[index] = 0;
+    staticTrapManaRegenByCell[index] = 0;
+    staticTrapDurabilityCurrentByCell[index] = 0;
+    staticTrapDurabilityMaxByCell[index] = 0;
+    staticTrapDurabilityRegenByCell[index] = 0;
   }
 
   function clearStaticTraps(): void {
@@ -288,6 +303,11 @@ export function createWorldState() {
     staticTrapExpressionByCell.fill(0);
     staticTrapStacksByCell.fill(0);
     staticTrapManaReserveByCell.fill(0);
+    staticTrapManaMaxByCell.fill(0);
+    staticTrapManaRegenByCell.fill(0);
+    staticTrapDurabilityCurrentByCell.fill(0);
+    staticTrapDurabilityMaxByCell.fill(0);
+    staticTrapDurabilityRegenByCell.fill(0);
   }
 
   // ── Resource helpers ──
@@ -570,9 +590,7 @@ export function createWorldState() {
       for (let i = 0; i < motivatedActorCount; i++) {
         applyRegenForActorIndex(i);
       }
-      return;
-    }
-    if (actorActive) {
+    } else if (actorActive) {
       for (let kind = 0; kind < VITAL_COUNT; kind++) {
         if (kind === VitalKind.Durability) continue;
         actorVitalCurrent[kind] = clampVitalValue(
@@ -580,6 +598,29 @@ export function createWorldState() {
           actorVitalMax[kind],
           actorVitalRegen[kind],
         );
+      }
+    }
+    // Per-trap mana and durability regen (independent of actor regen)
+    if (staticTrapCount > 0) {
+      const cellCount = width * height;
+      for (let idx = 0; idx < cellCount; idx++) {
+        if (staticTrapAffinityByCell[idx] === STATIC_TRAP_NONE) continue;
+        const manaRegen = staticTrapManaRegenByCell[idx];
+        if (manaRegen > 0) {
+          const manaMax = staticTrapManaMaxByCell[idx];
+          const manaCur = staticTrapManaReserveByCell[idx];
+          if (manaCur < manaMax) {
+            staticTrapManaReserveByCell[idx] = Math.min(manaMax, manaCur + manaRegen);
+          }
+        }
+        const durRegen = staticTrapDurabilityRegenByCell[idx];
+        if (durRegen > 0) {
+          const durMax = staticTrapDurabilityMaxByCell[idx];
+          const durCur = staticTrapDurabilityCurrentByCell[idx];
+          if (durCur < durMax) {
+            staticTrapDurabilityCurrentByCell[idx] = Math.min(durMax, durCur + durRegen);
+          }
+        }
       }
     }
   }
@@ -1124,6 +1165,11 @@ export function createWorldState() {
       expression: number,
       stacks: number,
       manaReserve: number,
+      durabilityCurrentOpt = 0,
+      durabilityMaxOpt = 0,
+      durabilityRegenOpt = 0,
+      manaMaxOpt = -1,   // -1 sentinel → default to manaReserve
+      manaRegenOpt = 0,
     ): number {
       if (!withinBounds(x, y)) return 0;
       if (affinityKind <= 0 || expression <= 0) return 0;
@@ -1135,6 +1181,11 @@ export function createWorldState() {
       staticTrapExpressionByCell[idx] = expression;
       staticTrapStacksByCell[idx] = stacks;
       staticTrapManaReserveByCell[idx] = manaReserve;
+      staticTrapManaMaxByCell[idx] = manaMaxOpt < 0 ? manaReserve : Math.max(0, manaMaxOpt);
+      staticTrapManaRegenByCell[idx] = Math.max(0, manaRegenOpt);
+      staticTrapDurabilityCurrentByCell[idx] = Math.max(0, durabilityCurrentOpt);
+      staticTrapDurabilityMaxByCell[idx] = Math.max(0, durabilityMaxOpt);
+      staticTrapDurabilityRegenByCell[idx] = Math.max(0, durabilityRegenOpt);
       return 1;
     },
 
@@ -1166,6 +1217,47 @@ export function createWorldState() {
     getStaticTrapManaReserveAt(x: number, y: number): number {
       if (!withinBounds(x, y)) return 0;
       return staticTrapManaReserveByCell[indexFor(x, y)];
+    },
+
+    getStaticTrapManaMaxAt(x: number, y: number): number {
+      if (!withinBounds(x, y)) return 0;
+      return staticTrapManaMaxByCell[indexFor(x, y)];
+    },
+
+    getStaticTrapManaRegenAt(x: number, y: number): number {
+      if (!withinBounds(x, y)) return 0;
+      return staticTrapManaRegenByCell[indexFor(x, y)];
+    },
+
+    setStaticTrapManaCurrentAt(x: number, y: number, current: number): number {
+      if (!withinBounds(x, y)) return 0;
+      const idx = indexFor(x, y);
+      if (!hasStaticTrapAtIndex(idx)) return 0;
+      staticTrapManaReserveByCell[idx] = Math.max(0, current);
+      return 1;
+    },
+
+    getStaticTrapDurabilityAt(x: number, y: number): number {
+      if (!withinBounds(x, y)) return 0;
+      return staticTrapDurabilityCurrentByCell[indexFor(x, y)];
+    },
+
+    getStaticTrapDurabilityMaxAt(x: number, y: number): number {
+      if (!withinBounds(x, y)) return 0;
+      return staticTrapDurabilityMaxByCell[indexFor(x, y)];
+    },
+
+    getStaticTrapDurabilityRegenAt(x: number, y: number): number {
+      if (!withinBounds(x, y)) return 0;
+      return staticTrapDurabilityRegenByCell[indexFor(x, y)];
+    },
+
+    setStaticTrapDurabilityCurrentAt(x: number, y: number, current: number): number {
+      if (!withinBounds(x, y)) return 0;
+      const idx = indexFor(x, y);
+      if (!hasStaticTrapAtIndex(idx)) return 0;
+      staticTrapDurabilityCurrentByCell[idx] = Math.max(0, current);
+      return 1;
     },
 
     // ── Resources ──
@@ -1297,6 +1389,14 @@ export function createWorldState() {
       motivatedActorAffinityKindArr[index] = kind;
       motivatedActorAffinityExpressionArr[index] = expression;
       motivatedActorAffinityStacksArr[index] = stacks;
+      return 1;
+    },
+
+    clearMotivatedActorAffinity(index: number): number {
+      if (!isValidMotivatedActorIndex(index)) return 0;
+      motivatedActorAffinityKindArr[index] = 0;
+      motivatedActorAffinityExpressionArr[index] = 0;
+      motivatedActorAffinityStacksArr[index] = 0;
       return 1;
     },
 

--- a/packages/runtime/src/contracts/domain-constants.js
+++ b/packages/runtime/src/contracts/domain-constants.js
@@ -1,17 +1,11 @@
-export const AFFINITY_KINDS = Object.freeze([
-  "fire",
-  "water",
-  "earth",
-  "wind",
-  "life",
-  "decay",
-  "corrode",
-  "fortify",
-  "light",
-  "dark",
-]);
+import {
+  GAME_AFFINITY_EXPRESSIONS,
+  GAME_AFFINITY_KINDS,
+  GAME_VITAL_KEYS,
+} from "./game-elements.js";
 
-export const AFFINITY_EXPRESSIONS = Object.freeze(["push", "pull", "emit", "draw"]);
+export const AFFINITY_KINDS = GAME_AFFINITY_KINDS;
+export const AFFINITY_EXPRESSIONS = GAME_AFFINITY_EXPRESSIONS;
 export const AFFINITY_TARGET_TYPES = Object.freeze(["self", "ally", "enemy", "area", "barrier", "floor"]);
 export const DEFAULT_DUNGEON_AFFINITY = AFFINITY_KINDS[0];
 export const DEFAULT_AFFINITY_EXPRESSION = AFFINITY_EXPRESSIONS[0];
@@ -107,7 +101,7 @@ export const PHI4_OLLAMA_OPTIONS = Object.freeze({
   repeat_penalty: 1.05,
 });
 
-export const VITAL_KEYS = Object.freeze(["health", "mana", "stamina", "durability"]);
+export const VITAL_KEYS = GAME_VITAL_KEYS;
 export const TRAP_VITAL_KEYS = Object.freeze(["mana", "durability"]);
 
 // Per-actor-type vital constraints

--- a/packages/runtime/src/contracts/game-elements.js
+++ b/packages/runtime/src/contracts/game-elements.js
@@ -1,0 +1,719 @@
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  Object.values(value).forEach((entry) => deepFreeze(entry));
+  return Object.freeze(value);
+}
+
+function titleLabel(value) {
+  return String(value || "")
+    .split(/[._-]+/g)
+    .filter(Boolean)
+    .map((part) => `${part[0].toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function relativePathForGameAssetId(assetId) {
+  const id = String(assetId || "").trim();
+  if (id.startsWith("overlay.tile.")) {
+    const parts = id.split(".");
+    const tile = parts[2] || "tile";
+    const affinity = parts[4] || "unknown";
+    return `visual-assets/tiles/overlays/${tile}-affinity-${affinity}.png`;
+  }
+  if (id.startsWith("tile.")) {
+    return `visual-assets/tiles/${id.slice("tile.".length).replace(/\./g, "-")}.png`;
+  }
+  if (id.startsWith("actor.")) {
+    return `visual-assets/actors/${id.slice("actor.".length).replace(/\./g, "-")}.png`;
+  }
+  if (id.startsWith("card.")) {
+    return `visual-assets/cards/${id.slice("card.".length).replace(/\./g, "-")}.png`;
+  }
+  if (id.startsWith("overlay.")) {
+    return `visual-assets/overlays/${id.slice("overlay.".length).replace(/\./g, "-")}.png`;
+  }
+  if (id.startsWith("affinity.") || id.startsWith("motivation.") || id.startsWith("expression.")) {
+    return `visual-assets/overlays/${id.replace(/\./g, "-")}.png`;
+  }
+  return `visual-assets/misc/${id.replace(/\./g, "-")}.png`;
+}
+
+function ipfsUriForAssetId(assetId, version = 2) {
+  const slug = String(assetId || "").replace(/\./g, "-");
+  return `ipfs://ak-resource-bundle-v${version}/${slug}.png`;
+}
+
+function element({
+  group,
+  key,
+  label = titleLabel(key),
+  unicodeIcon,
+  defaultColor,
+  description,
+  assetId,
+  assetKind,
+  legacyAssetId = "",
+  iconAssetId = "",
+  imageRelativePath,
+  imageIpfsUri,
+  meta,
+}) {
+  const resolvedAssetId = assetId || iconAssetId || legacyAssetId || key;
+  return {
+    id: `${group}.${key}`,
+    group,
+    key,
+    label,
+    unicodeIcon,
+    assetId: resolvedAssetId,
+    assetKind,
+    legacyAssetId,
+    iconAssetId,
+    defaultColor,
+    description,
+    imageResource: {
+      assetId: resolvedAssetId,
+      relativePath: imageRelativePath || relativePathForGameAssetId(resolvedAssetId),
+      ipfsUri: imageIpfsUri || ipfsUriForAssetId(resolvedAssetId, 2),
+    },
+    ...(meta ? { meta } : {}),
+  };
+}
+
+function byKey(entries) {
+  return Object.fromEntries(entries.map((entry) => [entry.key, entry]));
+}
+
+export const GAME_AFFINITY_KINDS = Object.freeze([
+  "fire",
+  "water",
+  "earth",
+  "wind",
+  "life",
+  "decay",
+  "corrode",
+  "fortify",
+  "light",
+  "dark",
+]);
+
+export const GAME_AFFINITY_EXPRESSIONS = Object.freeze(["push", "pull", "emit", "draw"]);
+export const GAME_VITAL_KEYS = Object.freeze(["health", "mana", "stamina", "durability"]);
+
+export const GAME_MOTIVATION_FAMILIES = deepFreeze({
+  mobility: ["random", "stationary", "exploring", "patrolling"],
+  posture: ["attacking", "defending", "stealthy", "friendly"],
+  cognition: ["reflexive", "goal_oriented", "strategy_focused"],
+  control: ["user_controlled"],
+});
+
+export const GAME_MOTIVATION_KINDS = Object.freeze([
+  ...GAME_MOTIVATION_FAMILIES.mobility,
+  ...GAME_MOTIVATION_FAMILIES.posture,
+  ...GAME_MOTIVATION_FAMILIES.cognition,
+  ...GAME_MOTIVATION_FAMILIES.control,
+]);
+
+export const GAME_MOTIVATION_KIND_IDS = deepFreeze(
+  Object.fromEntries(GAME_MOTIVATION_KINDS.map((kind) => [kind, `motivation_${kind}`])),
+);
+
+export const GAME_MOTIVATION_DISPLAY_GROUPS = deepFreeze([
+  { id: "mobility_random_stationary", kinds: ["random", "stationary"] },
+  { id: "mobility_exploring_patrolling", kinds: ["exploring", "patrolling"] },
+  { id: "posture_attacking_defending", kinds: ["attacking", "defending"] },
+  { id: "posture_stealthy_friendly", kinds: ["stealthy", "friendly"] },
+  { id: "cognition_reflexive_goal_oriented", kinds: ["reflexive", "goal_oriented"] },
+  { id: "cognition_strategy_focused", kinds: ["strategy_focused"] },
+  { id: "control_user_controlled", kinds: ["user_controlled"] },
+]);
+
+const AFFINITY_COLORS = Object.freeze({
+  fire: "#f05a28",
+  water: "#2b7fff",
+  earth: "#7a5c33",
+  wind: "#8fd3ff",
+  life: "#49b96b",
+  decay: "#6f7b46",
+  corrode: "#7fbf42",
+  fortify: "#8c6dd7",
+  light: "#f5d14d",
+  dark: "#3a2a57",
+});
+
+const VITAL_COLORS = Object.freeze({
+  health: "#ff4455",
+  mana: "#4499ff",
+  stamina: "#44cc77",
+  durability: "#ffaa33",
+  defence: "#ffaa33",
+});
+
+const GAME_ELEMENT_VISUALS_VALUE = {
+  tiles: byKey([
+    element({
+      group: "tiles",
+      key: "floor",
+      unicodeIcon: ".",
+      defaultColor: "#241f22",
+      assetId: "tile.floor",
+      assetKind: "tile",
+      description: "Walkable dungeon floor tile.",
+    }),
+    element({
+      group: "tiles",
+      key: "wall",
+      unicodeIcon: "#",
+      defaultColor: "#3b3237",
+      assetId: "tile.wall",
+      assetKind: "tile",
+      description: "Blocking dungeon wall tile.",
+    }),
+    element({
+      group: "tiles",
+      key: "barrier",
+      unicodeIcon: "B",
+      defaultColor: "#654a3d",
+      assetId: "tile.barrier",
+      assetKind: "tile",
+      description: "Constructed obstacle or temporary barrier.",
+    }),
+    element({
+      group: "tiles",
+      key: "spawn",
+      unicodeIcon: "S",
+      defaultColor: "#2b5f48",
+      assetId: "tile.spawn",
+      assetKind: "tile",
+      description: "Starting tile or entry point.",
+    }),
+    element({
+      group: "tiles",
+      key: "exit",
+      unicodeIcon: "E",
+      defaultColor: "#83704d",
+      assetId: "tile.exit",
+      assetKind: "tile",
+      description: "Exit tile or level objective.",
+    }),
+    element({
+      group: "tiles",
+      key: "inaccessible",
+      unicodeIcon: "X",
+      defaultColor: "#101113",
+      assetId: "tile.inaccessible",
+      assetKind: "tile",
+      description: "Void or inaccessible map space.",
+    }),
+    element({
+      group: "tiles",
+      key: "fog",
+      unicodeIcon: "?",
+      defaultColor: "#12181c",
+      assetId: "tile.fog",
+      assetKind: "tile",
+      description: "Fog-of-war or obscured tile.",
+    }),
+  ]),
+  actors: byKey([
+    element({
+      group: "actors",
+      key: "delver",
+      unicodeIcon: "○",
+      defaultColor: "#d8d2bf",
+      assetId: "actor.delver",
+      assetKind: "actor",
+      description: "Mobile explorer actor trying to traverse the dungeon.",
+    }),
+    element({
+      group: "actors",
+      key: "warden",
+      unicodeIcon: "△",
+      defaultColor: "#b18edc",
+      assetId: "actor.warden",
+      assetKind: "actor",
+      description: "Defensive actor controlling dungeon space.",
+    }),
+  ]),
+  items: byKey([
+    element({
+      group: "items",
+      key: "hazard",
+      unicodeIcon: "☠",
+      defaultColor: "#b85a4a",
+      assetId: "item.hazard",
+      assetKind: "item",
+      description: "Static danger source, trap, or hostile environmental object.",
+    }),
+    element({
+      group: "items",
+      key: "resource",
+      unicodeIcon: "◆",
+      defaultColor: "#49b96b",
+      assetId: "item.resource",
+      assetKind: "item",
+      description: "Collectible or usable dungeon resource.",
+    }),
+  ]),
+  cards: byKey([
+    element({
+      group: "cards",
+      key: "room",
+      unicodeIcon: "□",
+      defaultColor: "#83704d",
+      assetId: "card.room",
+      assetKind: "card",
+      description: "Room card or authored dungeon-space template.",
+    }),
+    element({
+      group: "cards",
+      key: "delver",
+      unicodeIcon: "○",
+      defaultColor: "#d8d2bf",
+      assetId: "card.delver",
+      assetKind: "card",
+      description: "Delver card template.",
+    }),
+    element({
+      group: "cards",
+      key: "warden",
+      unicodeIcon: "△",
+      defaultColor: "#b18edc",
+      assetId: "card.warden",
+      assetKind: "card",
+      description: "Warden card template.",
+    }),
+  ]),
+  types: byKey([
+    element({
+      group: "types",
+      key: "room",
+      unicodeIcon: "□",
+      defaultColor: "#83704d",
+      assetId: "icon.type.room",
+      assetKind: "icon",
+      description: "Room type marker.",
+    }),
+    element({
+      group: "types",
+      key: "delver",
+      unicodeIcon: "○",
+      defaultColor: "#d8d2bf",
+      assetId: "icon.type.delver",
+      assetKind: "icon",
+      description: "Delver type marker.",
+    }),
+    element({
+      group: "types",
+      key: "attacker",
+      unicodeIcon: "!",
+      defaultColor: "#f05a28",
+      assetId: "icon.type.attacker",
+      assetKind: "icon",
+      description: "Attacker type marker.",
+    }),
+    element({
+      group: "types",
+      key: "warden",
+      unicodeIcon: "△",
+      defaultColor: "#b18edc",
+      assetId: "icon.type.warden",
+      assetKind: "icon",
+      description: "Warden type marker.",
+    }),
+    element({
+      group: "types",
+      key: "defender",
+      unicodeIcon: "▣",
+      defaultColor: "#8c6dd7",
+      assetId: "icon.type.defender",
+      assetKind: "icon",
+      description: "Defender type marker.",
+    }),
+    element({
+      group: "types",
+      key: "hazard",
+      unicodeIcon: "☠",
+      defaultColor: "#b85a4a",
+      assetId: "icon.type.hazard",
+      assetKind: "icon",
+      description: "Hazard type marker.",
+    }),
+    element({
+      group: "types",
+      key: "untyped",
+      unicodeIcon: "◇",
+      defaultColor: "#8a8588",
+      assetId: "icon.type.untyped",
+      assetKind: "icon",
+      description: "Fallback type marker.",
+    }),
+  ]),
+  affinities: byKey(
+    GAME_AFFINITY_KINDS.map((kind) => element({
+      group: "affinities",
+      key: kind,
+      label: `${titleLabel(kind)} Affinity`,
+      unicodeIcon: {
+        fire: "♨",
+        water: "◍",
+        earth: "◆",
+        wind: "〰",
+        life: "♧",
+        decay: "☠",
+        corrode: "◌",
+        fortify: "⬟",
+        light: "✦",
+        dark: "☾",
+      }[kind],
+      defaultColor: AFFINITY_COLORS[kind],
+      assetId: `overlay.affinity.${kind}`,
+      legacyAssetId: `affinity.${kind}`,
+      iconAssetId: `icon.affinity.${kind}`,
+      assetKind: "overlay",
+      description: `${titleLabel(kind)} affinity glyph and color identity.`,
+    })),
+  ),
+  affinityStacks: byKey([
+    element({
+      group: "affinityStacks",
+      key: "tier1",
+      label: "Stack Tier 1",
+      unicodeIcon: "①",
+      defaultColor: "#8a8588",
+      assetId: "overlay.stack-tier.tier1",
+      assetKind: "overlay",
+      description: "Low intensity affinity stack marker.",
+    }),
+    element({
+      group: "affinityStacks",
+      key: "tier2",
+      label: "Stack Tier 2",
+      unicodeIcon: "②",
+      defaultColor: "#8c6dd7",
+      assetId: "overlay.stack-tier.tier2",
+      assetKind: "overlay",
+      description: "Medium intensity affinity stack marker.",
+    }),
+    element({
+      group: "affinityStacks",
+      key: "tier3",
+      label: "Stack Tier 3",
+      unicodeIcon: "③",
+      defaultColor: "#f5d14d",
+      assetId: "overlay.stack-tier.tier3",
+      assetKind: "overlay",
+      description: "High intensity affinity stack marker.",
+    }),
+  ]),
+  affinityExpressions: byKey(
+    GAME_AFFINITY_EXPRESSIONS.map((kind) => element({
+      group: "affinityExpressions",
+      key: kind,
+      label: `${titleLabel(kind)} Expression`,
+      unicodeIcon: {
+        push: "⇢",
+        pull: "⇠",
+        emit: "⊙",
+        draw: "⟲",
+      }[kind],
+      defaultColor: {
+        push: "#f05a28",
+        pull: "#2b7fff",
+        emit: "#f5d14d",
+        draw: "#8c6dd7",
+      }[kind],
+      assetId: `overlay.expression.${kind}`,
+      legacyAssetId: `expression.${kind}`,
+      iconAssetId: `icon.expression.${kind}`,
+      assetKind: "overlay",
+      description: `${titleLabel(kind)} affinity expression marker.`,
+    })),
+  ),
+  motivations: byKey(
+    GAME_MOTIVATION_KINDS.map((kind) => element({
+      group: "motivations",
+      key: kind,
+      label: `${titleLabel(kind)} Motivation`,
+      unicodeIcon: {
+        random: "?",
+        stationary: "■",
+        exploring: "⌖",
+        patrolling: "◇",
+        attacking: "!",
+        defending: "▣",
+        stealthy: "◐",
+        friendly: "+",
+        reflexive: "↯",
+        goal_oriented: "◎",
+        strategy_focused: "♟",
+        user_controlled: "◉",
+      }[kind],
+      defaultColor: {
+        random: "#8a8588",
+        stationary: "#7a5c33",
+        exploring: "#8fd3ff",
+        patrolling: "#49b96b",
+        attacking: "#f05a28",
+        defending: "#8c6dd7",
+        stealthy: "#3a2a57",
+        friendly: "#49b96b",
+        reflexive: "#f5d14d",
+        goal_oriented: "#2b7fff",
+        strategy_focused: "#8c6dd7",
+        user_controlled: "#d8d2bf",
+      }[kind],
+      assetId: `overlay.motivation.${kind}`,
+      legacyAssetId: `motivation.${kind}`,
+      iconAssetId: `icon.motivation.${kind}`,
+      assetKind: "overlay",
+      description: `${titleLabel(kind)} actor motivation marker.`,
+    })),
+  ),
+  vitals: byKey(
+    [...GAME_VITAL_KEYS, "defence"].map((kind) => element({
+      group: "vitals",
+      key: kind,
+      label: `${titleLabel(kind)} Vital`,
+      unicodeIcon: {
+        health: "♥",
+        mana: "◆",
+        stamina: "↯",
+        durability: "▰",
+        defence: "⬢",
+      }[kind],
+      defaultColor: VITAL_COLORS[kind],
+      assetId: `icon.vital.${kind}`,
+      assetKind: "icon",
+      description: kind === "defence"
+        ? "Legacy defense icon alias for durability-oriented UI surfaces."
+        : `${titleLabel(kind)} vital meter and state marker.`,
+    })),
+  ),
+  ui: byKey([
+    element({
+      group: "ui",
+      key: "playing-surface",
+      unicodeIcon: "▦",
+      defaultColor: "#8a8588",
+      assetId: "icon.ui.playing-surface",
+      assetKind: "icon",
+      description: "Playing surface navigation icon.",
+    }),
+    element({
+      group: "ui",
+      key: "card-builder",
+      unicodeIcon: "▤",
+      defaultColor: "#8a8588",
+      assetId: "icon.ui.card-builder",
+      assetKind: "icon",
+      description: "Card builder navigation icon.",
+    }),
+    element({
+      group: "ui",
+      key: "game-preview",
+      unicodeIcon: "▣",
+      defaultColor: "#8a8588",
+      assetId: "icon.ui.game-preview",
+      assetKind: "icon",
+      description: "Game preview navigation icon.",
+    }),
+    element({
+      group: "ui",
+      key: "system-console",
+      unicodeIcon: "▥",
+      defaultColor: "#8a8588",
+      assetId: "icon.ui.system-console",
+      assetKind: "icon",
+      description: "System console navigation icon.",
+    }),
+    element({
+      group: "ui",
+      key: "game-inspector",
+      unicodeIcon: "⌕",
+      defaultColor: "#8a8588",
+      assetId: "icon.ui.game-inspector",
+      assetKind: "icon",
+      description: "Game inspector navigation icon.",
+    }),
+  ]),
+  overlays: byKey([
+    element({
+      group: "overlays",
+      key: "darkness-mask",
+      label: "Darkness Mask",
+      unicodeIcon: "◑",
+      defaultColor: "#101113",
+      assetId: "overlay.darkness-mask",
+      assetKind: "overlay",
+      description: "Darkness and visibility mask overlay.",
+    }),
+  ]),
+};
+
+export const GAME_ELEMENT_VISUALS = deepFreeze(GAME_ELEMENT_VISUALS_VALUE);
+
+function assetIdMap(group) {
+  return Object.fromEntries(Object.entries(group).map(([key, value]) => [key, value.assetId]));
+}
+
+export const GAME_ELEMENT_ASSET_IDS = deepFreeze({
+  tiles: assetIdMap(GAME_ELEMENT_VISUALS.tiles),
+  actors: assetIdMap(GAME_ELEMENT_VISUALS.actors),
+  items: assetIdMap(GAME_ELEMENT_VISUALS.items),
+  cards: assetIdMap(GAME_ELEMENT_VISUALS.cards),
+  stackTiers: assetIdMap(GAME_ELEMENT_VISUALS.affinityStacks),
+  darknessMask: GAME_ELEMENT_VISUALS.overlays["darkness-mask"].assetId,
+});
+
+export const GAME_ELEMENT_ICON_KEYS = deepFreeze({
+  types: Object.keys(GAME_ELEMENT_VISUALS.types),
+  items: Object.keys(GAME_ELEMENT_VISUALS.items),
+  motivations: Object.keys(GAME_ELEMENT_VISUALS.motivations),
+  vitals: Object.keys(GAME_ELEMENT_VISUALS.vitals),
+  ui: Object.keys(GAME_ELEMENT_VISUALS.ui),
+});
+
+export const GAME_AFFINITY_COLOR_HEX = deepFreeze(
+  Object.fromEntries(
+    Object.entries(GAME_ELEMENT_VISUALS.affinities).map(([kind, visual]) => [kind, visual.defaultColor]),
+  ),
+);
+
+export const GAME_ICON_FALLBACKS = deepFreeze({
+  types: Object.fromEntries(Object.entries(GAME_ELEMENT_VISUALS.types).map(([key, visual]) => [key, visual.unicodeIcon])),
+  affinities: Object.fromEntries(Object.entries(GAME_ELEMENT_VISUALS.affinities).map(([key, visual]) => [key, visual.unicodeIcon])),
+  items: Object.fromEntries(Object.entries(GAME_ELEMENT_VISUALS.items).map(([key, visual]) => [key, visual.unicodeIcon])),
+  expressions: Object.fromEntries(Object.entries(GAME_ELEMENT_VISUALS.affinityExpressions).map(([key, visual]) => [key, visual.unicodeIcon])),
+  motivations: Object.fromEntries(Object.entries(GAME_ELEMENT_VISUALS.motivations).map(([key, visual]) => [key, visual.unicodeIcon])),
+  vitals: Object.fromEntries(Object.entries(GAME_ELEMENT_VISUALS.vitals).map(([key, visual]) => [key, visual.unicodeIcon])),
+  ui: Object.fromEntries(Object.entries(GAME_ELEMENT_VISUALS.ui).map(([key, visual]) => [key, visual.unicodeIcon])),
+});
+
+function specForVisual(visual, { assetId = visual.assetId, kind = visual.assetKind, label = visual.label, version = 2 } = {}) {
+  return {
+    id: assetId,
+    kind,
+    label,
+    ipfsUri: ipfsUriForAssetId(assetId, version),
+    visualId: visual.id,
+  };
+}
+
+function pushUniqueSpec(target, seen, spec) {
+  if (!spec?.id || seen.has(spec.id)) return;
+  seen.add(spec.id);
+  target.push(spec);
+}
+
+export function getGameElementVisual(group, key) {
+  return GAME_ELEMENT_VISUALS?.[group]?.[key] || null;
+}
+
+export function getGameElementVisualEntries() {
+  return Object.values(GAME_ELEMENT_VISUALS).flatMap((group) => Object.values(group));
+}
+
+export function getResourceBundleAssetSpecs({ emitVisualAssets = false } = {}) {
+  const specs = [];
+  const seen = new Set();
+  const push = (spec) => pushUniqueSpec(specs, seen, spec);
+  const visuals = GAME_ELEMENT_VISUALS;
+
+  ["floor", "wall", "barrier", "spawn", "exit", "inaccessible"].forEach((key) => {
+    push(specForVisual(visuals.tiles[key], { version: 1 }));
+  });
+  Object.values(visuals.actors).forEach((visual) => push(specForVisual(visual, { version: 1 })));
+  Object.values(visuals.items).forEach((visual) => push(specForVisual(visual, { version: 1 })));
+  Object.values(visuals.cards).forEach((visual) => push(specForVisual(visual, { version: 1 })));
+
+  if (!emitVisualAssets) {
+    Object.values(visuals.affinities).forEach((visual) => {
+      push(specForVisual(visual, {
+        assetId: visual.legacyAssetId,
+        kind: "affinity",
+        label: visual.label,
+        version: 1,
+      }));
+    });
+    Object.values(visuals.motivations).forEach((visual) => {
+      push(specForVisual(visual, {
+        assetId: visual.legacyAssetId,
+        kind: "motivation",
+        label: visual.label,
+        version: 1,
+      }));
+    });
+    Object.values(visuals.affinityExpressions).forEach((visual) => {
+      push(specForVisual(visual, {
+        assetId: visual.legacyAssetId,
+        kind: "expression",
+        label: visual.label,
+        version: 1,
+      }));
+    });
+    return specs;
+  }
+
+  push(specForVisual(visuals.tiles.fog));
+  Object.keys(visuals.affinities).forEach((affinity) => {
+    ["delver", "warden"].forEach((role) => {
+      const roleVisual = visuals.actors[role];
+      push(specForVisual(roleVisual, {
+        assetId: `actor.${role}.${affinity}`,
+        kind: "actor",
+        label: `${roleVisual.label} ${titleLabel(affinity)}`,
+      }));
+    });
+    const affinityVisual = visuals.affinities[affinity];
+    push(specForVisual(affinityVisual));
+    push(specForVisual(affinityVisual, {
+      assetId: `overlay.tile.floor.affinity.${affinity}`,
+      kind: "overlay",
+      label: `Floor ${titleLabel(affinity)} Affinity Overlay`,
+    }));
+    push(specForVisual(affinityVisual, {
+      assetId: `overlay.tile.wall.affinity.${affinity}`,
+      kind: "overlay",
+      label: `Wall ${titleLabel(affinity)} Affinity Overlay`,
+    }));
+  });
+  Object.values(visuals.affinityExpressions).forEach((visual) => push(specForVisual(visual)));
+  Object.values(visuals.affinityStacks).forEach((visual) => push(specForVisual(visual)));
+  Object.values(visuals.motivations).forEach((visual) => push(specForVisual(visual)));
+  push(specForVisual(visuals.overlays["darkness-mask"]));
+
+  Object.values(visuals.types).forEach((visual) => push(specForVisual(visual)));
+  Object.values(visuals.items).forEach((visual) => {
+    push(specForVisual(visual, {
+      assetId: `icon.item.${visual.key}`,
+      kind: "icon",
+      label: `${visual.label} Icon`,
+    }));
+  });
+  Object.values(visuals.affinities).forEach((visual) => {
+    push(specForVisual(visual, {
+      assetId: visual.iconAssetId,
+      kind: "icon",
+      label: `${visual.label} Icon`,
+    }));
+  });
+  Object.values(visuals.affinityExpressions).forEach((visual) => {
+    push(specForVisual(visual, {
+      assetId: visual.iconAssetId,
+      kind: "icon",
+      label: `${visual.label} Icon`,
+    }));
+  });
+  Object.values(visuals.motivations).forEach((visual) => {
+    push(specForVisual(visual, {
+      assetId: visual.iconAssetId,
+      kind: "icon",
+      label: `${visual.label} Icon`,
+    }));
+  });
+  Object.values(visuals.vitals).forEach((visual) => push(specForVisual(visual)));
+  Object.values(visuals.ui).forEach((visual) => push(specForVisual(visual)));
+
+  return specs;
+}

--- a/packages/runtime/src/personas/configurator/motivation-loadouts.js
+++ b/packages/runtime/src/personas/configurator/motivation-loadouts.js
@@ -1,30 +1,18 @@
-export const MOTIVATION_FAMILIES = Object.freeze({
-  mobility: Object.freeze(["random", "stationary", "exploring", "patrolling"]),
-  posture: Object.freeze(["attacking", "defending", "stealthy", "friendly"]),
-  cognition: Object.freeze(["reflexive", "goal_oriented", "strategy_focused"]),
-  control: Object.freeze(["user_controlled"]),
-});
+import {
+  GAME_MOTIVATION_DISPLAY_GROUPS,
+  GAME_MOTIVATION_FAMILIES,
+  GAME_MOTIVATION_KIND_IDS,
+  GAME_MOTIVATION_KINDS,
+} from "../../contracts/game-elements.js";
 
-export const MOTIVATION_KINDS = Object.freeze([
-  ...MOTIVATION_FAMILIES.mobility,
-  ...MOTIVATION_FAMILIES.posture,
-  ...MOTIVATION_FAMILIES.cognition,
-  ...MOTIVATION_FAMILIES.control,
-]);
+export const MOTIVATION_FAMILIES = GAME_MOTIVATION_FAMILIES;
+export const MOTIVATION_KINDS = GAME_MOTIVATION_KINDS;
 export const MOTIVATION_EXCLUSIVE_GROUPS = Object.freeze([
   Object.freeze({ id: "mobility", kinds: MOTIVATION_FAMILIES.mobility }),
   Object.freeze({ id: "posture", kinds: MOTIVATION_FAMILIES.posture }),
   Object.freeze({ id: "cognition", kinds: MOTIVATION_FAMILIES.cognition }),
 ]);
-export const MOTIVATION_DISPLAY_GROUPS = Object.freeze([
-  Object.freeze({ id: "mobility_random_stationary", kinds: Object.freeze(["random", "stationary"]) }),
-  Object.freeze({ id: "mobility_exploring_patrolling", kinds: Object.freeze(["exploring", "patrolling"]) }),
-  Object.freeze({ id: "posture_attacking_defending", kinds: Object.freeze(["attacking", "defending"]) }),
-  Object.freeze({ id: "posture_stealthy_friendly", kinds: Object.freeze(["stealthy", "friendly"]) }),
-  Object.freeze({ id: "cognition_reflexive_goal_oriented", kinds: Object.freeze(["reflexive", "goal_oriented"]) }),
-  Object.freeze({ id: "cognition_strategy_focused", kinds: Object.freeze(["strategy_focused"]) }),
-  Object.freeze({ id: "control_user_controlled", kinds: Object.freeze(["user_controlled"]) }),
-]);
+export const MOTIVATION_DISPLAY_GROUPS = GAME_MOTIVATION_DISPLAY_GROUPS;
 export const MOTIVATION_PATTERNS = Object.freeze({
   patrolling: Object.freeze(["loop", "ping_pong", "random_walk"]),
   attacking: Object.freeze(["melee", "ranged", "mixed"]),
@@ -49,20 +37,7 @@ export const MOTIVATION_DEFAULTS = Object.freeze({
   }),
 });
 
-export const MOTIVATION_KIND_IDS = Object.freeze({
-  random: "motivation_random",
-  stationary: "motivation_stationary",
-  exploring: "motivation_exploring",
-  patrolling: "motivation_patrolling",
-  attacking: "motivation_attacking",
-  defending: "motivation_defending",
-  stealthy: "motivation_stealthy",
-  friendly: "motivation_friendly",
-  reflexive: "motivation_reflexive",
-  goal_oriented: "motivation_goal_oriented",
-  strategy_focused: "motivation_strategy_focused",
-  user_controlled: "motivation_user_controlled",
-});
+export const MOTIVATION_KIND_IDS = GAME_MOTIVATION_KIND_IDS;
 
 const MOTIVATION_FLAG_KEYS = Object.freeze(["canMove", "prefersStealth", "prefersCover", "aggroRangeBoost"]);
 const MOTIVATION_MAX_INTENSITY = 10;

--- a/packages/runtime/src/personas/configurator/motivation-rules.js
+++ b/packages/runtime/src/personas/configurator/motivation-rules.js
@@ -1,3 +1,8 @@
+import {
+  GAME_MOTIVATION_KIND_IDS,
+  GAME_MOTIVATION_KINDS,
+} from "../../contracts/game-elements.js";
+
 export const BEHAVIOR_COMPLEXITY_CLASSES = Object.freeze(["instinctual", "tactical", "strategic"]);
 
 export const MOTIVATION_AXIS_VALUES = Object.freeze({
@@ -19,20 +24,7 @@ export const DEFAULT_MOTIVATION_FLAGS = Object.freeze({
   aggroRangeBoost: false,
 });
 
-export const MOTIVATION_KIND_IDS = Object.freeze({
-  random: "motivation_random",
-  stationary: "motivation_stationary",
-  exploring: "motivation_exploring",
-  attacking: "motivation_attacking",
-  defending: "motivation_defending",
-  patrolling: "motivation_patrolling",
-  stealthy: "motivation_stealthy",
-  friendly: "motivation_friendly",
-  reflexive: "motivation_reflexive",
-  goal_oriented: "motivation_goal_oriented",
-  strategy_focused: "motivation_strategy_focused",
-  user_controlled: "motivation_user_controlled",
-});
+export const MOTIVATION_KIND_IDS = GAME_MOTIVATION_KIND_IDS;
 
 export const MOTIVATION_PROFILE_ITEM_IDS = Object.freeze({
   mobility: Object.freeze({
@@ -54,7 +46,7 @@ export const MOTIVATION_PROFILE_ITEM_IDS = Object.freeze({
 });
 
 export const MOTIVATION_FLAG_KEYS = Object.freeze(Object.keys(DEFAULT_MOTIVATION_FLAGS));
-export const MOTIVATION_KINDS = Object.freeze(Object.keys(MOTIVATION_KIND_IDS));
+export const MOTIVATION_KINDS = GAME_MOTIVATION_KINDS;
 
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));

--- a/packages/runtime/src/render/affinity-palette.js
+++ b/packages/runtime/src/render/affinity-palette.js
@@ -13,23 +13,13 @@
  */
 
 import { AFFINITY_KINDS } from "../contracts/domain-constants.js";
+import { GAME_AFFINITY_COLOR_HEX } from "../contracts/game-elements.js";
 
 /**
  * Canonical hex color for each affinity kind.
  * Used for sprite generation and visual styling.
  */
-export const AFFINITY_COLOR_HEX = Object.freeze({
-  fire: "#f05a28",
-  water: "#2b7fff",
-  earth: "#7a5c33",
-  wind: "#8fd3ff",
-  life: "#49b96b",
-  decay: "#6f7b46",
-  corrode: "#7fbf42",
-  fortify: "#8c6dd7",
-  light: "#f5d14d",
-  dark: "#3a2a57",
-});
+export const AFFINITY_COLOR_HEX = GAME_AFFINITY_COLOR_HEX;
 
 /**
  * Stack intensity progression rules.

--- a/packages/runtime/src/render/resource-bundle.js
+++ b/packages/runtime/src/render/resource-bundle.js
@@ -1,14 +1,18 @@
 import {
-  ALLOWED_AFFINITIES,
-  ALLOWED_AFFINITY_EXPRESSIONS,
-  ALLOWED_MOTIVATIONS,
-} from "../personas/orchestrator/prompt-contract.js";
-import {
   AFFINITY_COLOR_HEX,
   hexToRgba as sharedHexToRgba,
   normalizeHex as sharedNormalizeHex,
   resolveStackIntensity,
 } from "./affinity-palette.js";
+import {
+  GAME_AFFINITY_EXPRESSIONS,
+  GAME_AFFINITY_KINDS,
+  GAME_ELEMENT_ASSET_IDS,
+  GAME_ELEMENT_ICON_KEYS,
+  GAME_MOTIVATION_KINDS,
+  getResourceBundleAssetSpecs,
+  relativePathForGameAssetId,
+} from "../contracts/game-elements.js";
 import { computeTileAlpha } from "./affinity-spatial-formulas.js";
 import {
   applyAuraMask,
@@ -30,56 +34,19 @@ const RESOURCE_BUNDLE_VERSION_V2 = 2;
 
 const PNG_SIGNATURE = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
 
-const DEFAULT_TILE_ASSET_IDS = Object.freeze({
-  floor: "tile.floor",
-  wall: "tile.wall",
-  barrier: "tile.barrier",
-  spawn: "tile.spawn",
-  exit: "tile.exit",
-  inaccessible: "tile.inaccessible",
-  fog: "tile.fog",
-});
-
-const DEFAULT_ACTOR_ASSET_IDS = Object.freeze({
-  delver: "actor.delver",
-  warden: "actor.warden",
-});
-
-const DEFAULT_ITEM_ASSET_IDS = Object.freeze({
-  hazard: "item.hazard",
-  resource: "item.resource",
-});
-
-const DEFAULT_CARD_ASSET_IDS = Object.freeze({
-  room: "card.room",
-  delver: "card.delver",
-  warden: "card.warden",
-});
-
-const STACK_TIER_IDS = Object.freeze({
-  tier1: "overlay.stack-tier.tier1",
-  tier2: "overlay.stack-tier.tier2",
-  tier3: "overlay.stack-tier.tier3",
-});
-
-const ICON_TYPE_KEYS = Object.freeze(["room", "delver", "attacker", "warden", "defender", "hazard", "untyped"]);
-const ICON_ITEM_KEYS = Object.freeze(["hazard", "resource"]);
-const ICON_MOTIVATION_KEYS = Object.freeze([
-  "random",
-  "stationary",
-  "exploring",
-  "attacking",
-  "defending",
-  "stealthy",
-  "friendly",
-  "patrolling",
-  "reflexive",
-  "goal_oriented",
-  "strategy_focused",
-  "user_controlled",
-]);
-const ICON_VITAL_KEYS = Object.freeze(["health", "mana", "stamina", "durability", "defence"]);
-const ICON_UI_KEYS = Object.freeze(["playing-surface", "card-builder", "game-preview", "system-console", "game-inspector"]);
+const ALLOWED_AFFINITIES = GAME_AFFINITY_KINDS;
+const ALLOWED_AFFINITY_EXPRESSIONS = GAME_AFFINITY_EXPRESSIONS;
+const ALLOWED_MOTIVATIONS = GAME_MOTIVATION_KINDS;
+const DEFAULT_TILE_ASSET_IDS = GAME_ELEMENT_ASSET_IDS.tiles;
+const DEFAULT_ACTOR_ASSET_IDS = GAME_ELEMENT_ASSET_IDS.actors;
+const DEFAULT_ITEM_ASSET_IDS = GAME_ELEMENT_ASSET_IDS.items;
+const DEFAULT_CARD_ASSET_IDS = GAME_ELEMENT_ASSET_IDS.cards;
+const STACK_TIER_IDS = GAME_ELEMENT_ASSET_IDS.stackTiers;
+const ICON_TYPE_KEYS = GAME_ELEMENT_ICON_KEYS.types;
+const ICON_ITEM_KEYS = GAME_ELEMENT_ICON_KEYS.items;
+const ICON_MOTIVATION_KEYS = GAME_ELEMENT_ICON_KEYS.motivations;
+const ICON_VITAL_KEYS = GAME_ELEMENT_ICON_KEYS.vitals;
+const ICON_UI_KEYS = GAME_ELEMENT_ICON_KEYS.ui;
 
 function mapKeys(keys, prefix) {
   return Object.fromEntries(keys.map((key) => [key, `${prefix}.${key}`]));
@@ -240,22 +207,7 @@ function decodePngDataUri(dataUri) {
 }
 
 function relativePathForAssetId(id) {
-  if (id.startsWith("tile.")) {
-    return `visual-assets/tiles/${id.slice("tile.".length).replace(/\./g, "-")}.png`;
-  }
-  if (id.startsWith("actor.")) {
-    return `visual-assets/actors/${id.slice("actor.".length).replace(/\./g, "-")}.png`;
-  }
-  if (id.startsWith("card.")) {
-    return `visual-assets/cards/${id.slice("card.".length).replace(/\./g, "-")}.png`;
-  }
-  if (id.startsWith("overlay.")) {
-    return `visual-assets/overlays/${id.slice("overlay.".length).replace(/\./g, "-")}.png`;
-  }
-  if (id.startsWith("affinity.") || id.startsWith("motivation.") || id.startsWith("expression.")) {
-    return `visual-assets/overlays/${id.replace(/\./g, "-")}.png`;
-  }
-  return `visual-assets/misc/${id.replace(/\./g, "-")}.png`;
+  return relativePathForGameAssetId(id);
 }
 
 function createGeneratedAssetEntry(id, kind, label, ipfsUri) {
@@ -281,84 +233,8 @@ function createGeneratedAssetEntry(id, kind, label, ipfsUri) {
 
 function createDefaultAssets({ emitVisualAssets = false } = {}) {
   const makeEntry = emitVisualAssets ? createGeneratedAssetEntry : createAssetEntry;
-  const assets = [
-    makeEntry(DEFAULT_TILE_ASSET_IDS.floor, "tile", "Floor Tile", "ipfs://ak-resource-bundle-v1/tile-floor.png"),
-    makeEntry(DEFAULT_TILE_ASSET_IDS.wall, "tile", "Wall Tile", "ipfs://ak-resource-bundle-v1/tile-wall.png"),
-    makeEntry(DEFAULT_TILE_ASSET_IDS.barrier, "tile", "Barrier Tile", "ipfs://ak-resource-bundle-v1/tile-barrier.png"),
-    makeEntry(DEFAULT_TILE_ASSET_IDS.spawn, "tile", "Spawn Tile", "ipfs://ak-resource-bundle-v1/tile-spawn.png"),
-    makeEntry(DEFAULT_TILE_ASSET_IDS.exit, "tile", "Exit Tile", "ipfs://ak-resource-bundle-v1/tile-exit.png"),
-    makeEntry(DEFAULT_TILE_ASSET_IDS.inaccessible, "tile", "Inaccessible Tile", "ipfs://ak-resource-bundle-v1/tile-inaccessible.png"),
-    makeEntry(DEFAULT_ACTOR_ASSET_IDS.delver, "actor", "Generic Delver", "ipfs://ak-resource-bundle-v1/actor-delver.png"),
-    makeEntry(DEFAULT_ACTOR_ASSET_IDS.warden, "actor", "Generic Warden", "ipfs://ak-resource-bundle-v1/actor-warden.png"),
-    makeEntry(DEFAULT_ITEM_ASSET_IDS.hazard, "item", "Generic Hazard", "ipfs://ak-resource-bundle-v1/item-hazard.png"),
-    makeEntry(DEFAULT_ITEM_ASSET_IDS.resource, "item", "Generic Resource", "ipfs://ak-resource-bundle-v1/item-resource.png"),
-    makeEntry(DEFAULT_CARD_ASSET_IDS.room, "card", "Room Card", "ipfs://ak-resource-bundle-v1/card-room.png"),
-    makeEntry(DEFAULT_CARD_ASSET_IDS.delver, "card", "Delver Card", "ipfs://ak-resource-bundle-v1/card-delver.png"),
-    makeEntry(DEFAULT_CARD_ASSET_IDS.warden, "card", "Warden Card", "ipfs://ak-resource-bundle-v1/card-warden.png"),
-  ];
-
-  if (emitVisualAssets) {
-    assets.push(makeEntry(DEFAULT_TILE_ASSET_IDS.fog, "tile", "Fog Tile", "ipfs://ak-resource-bundle-v2/tile-fog.png"));
-    ALLOWED_AFFINITIES.forEach((kind) => {
-      assets.push(makeEntry(`actor.delver.${kind}`, "actor", `Delver ${kind}`, `ipfs://ak-resource-bundle-v2/actor-delver-${kind}.png`));
-      assets.push(makeEntry(`actor.warden.${kind}`, "actor", `Warden ${kind}`, `ipfs://ak-resource-bundle-v2/actor-warden-${kind}.png`));
-      assets.push(makeEntry(`overlay.affinity.${kind}`, "overlay", `${kind} Overlay`, `ipfs://ak-resource-bundle-v2/overlay-affinity-${kind}.png`));
-      assets.push(makeEntry(`overlay.tile.floor.affinity.${kind}`, "overlay", `Floor ${kind} Affinity Overlay`, `ipfs://ak-resource-bundle-v2/overlay-tile-floor-affinity-${kind}.png`));
-      assets.push(makeEntry(`overlay.tile.wall.affinity.${kind}`, "overlay", `Wall ${kind} Affinity Overlay`, `ipfs://ak-resource-bundle-v2/overlay-tile-wall-affinity-${kind}.png`));
-    });
-    ALLOWED_AFFINITY_EXPRESSIONS.forEach((kind) => {
-      assets.push(makeEntry(`overlay.expression.${kind}`, "overlay", `${kind} Expression Overlay`, `ipfs://ak-resource-bundle-v2/overlay-expression-${kind}.png`));
-    });
-    assets.push(makeEntry(STACK_TIER_IDS.tier1, "overlay", "Stack Tier 1", "ipfs://ak-resource-bundle-v2/overlay-stack-tier-1.png"));
-    assets.push(makeEntry(STACK_TIER_IDS.tier2, "overlay", "Stack Tier 2", "ipfs://ak-resource-bundle-v2/overlay-stack-tier-2.png"));
-    assets.push(makeEntry(STACK_TIER_IDS.tier3, "overlay", "Stack Tier 3", "ipfs://ak-resource-bundle-v2/overlay-stack-tier-3.png"));
-    ALLOWED_MOTIVATIONS.forEach((kind) => {
-      assets.push(makeEntry(`overlay.motivation.${kind}`, "overlay", `${kind} Motivation Overlay`, `ipfs://ak-resource-bundle-v2/overlay-motivation-${kind}.png`));
-    });
-    assets.push(makeEntry("overlay.darkness-mask", "overlay", "Darkness Mask", "ipfs://ak-resource-bundle-v2/overlay-darkness-mask.png"));
-
-    ICON_TYPE_KEYS.forEach((kind) => {
-      assets.push(makeEntry(`icon.type.${kind}`, "icon", `${kind} Type Icon`, `ipfs://ak-resource-bundle-v2/icon-type-${kind}.png`));
-    });
-
-    ICON_ITEM_KEYS.forEach((kind) => {
-      assets.push(makeEntry(`icon.item.${kind}`, "icon", `${kind} Item Icon`, `ipfs://ak-resource-bundle-v2/icon-item-${kind}.png`));
-    });
-
-    ALLOWED_AFFINITIES.forEach((kind) => {
-      assets.push(makeEntry(`icon.affinity.${kind}`, "icon", `${kind} Affinity Icon`, `ipfs://ak-resource-bundle-v2/icon-affinity-${kind}.png`));
-    });
-
-    ALLOWED_AFFINITY_EXPRESSIONS.forEach((kind) => {
-      assets.push(makeEntry(`icon.expression.${kind}`, "icon", `${kind} Expression Icon`, `ipfs://ak-resource-bundle-v2/icon-expression-${kind}.png`));
-    });
-
-    ICON_MOTIVATION_KEYS.forEach((kind) => {
-      assets.push(makeEntry(`icon.motivation.${kind}`, "icon", `${kind} Motivation Icon`, `ipfs://ak-resource-bundle-v2/icon-motivation-${kind}.png`));
-    });
-
-    ICON_VITAL_KEYS.forEach((kind) => {
-      assets.push(makeEntry(`icon.vital.${kind}`, "icon", `${kind} Vital Icon`, `ipfs://ak-resource-bundle-v2/icon-vital-${kind}.png`));
-    });
-
-    ICON_UI_KEYS.forEach((kind) => {
-      assets.push(makeEntry(`icon.ui.${kind}`, "icon", `${kind} UI Icon`, `ipfs://ak-resource-bundle-v2/icon-ui-${kind}.png`));
-    });
-
-    return assets;
-  }
-
-  ALLOWED_AFFINITIES.forEach((kind) => {
-    assets.push(createAssetEntry(`affinity.${kind}`, "affinity", `${kind} Affinity`, `ipfs://ak-resource-bundle-v1/affinity-${kind}.png`));
-  });
-  ALLOWED_MOTIVATIONS.forEach((kind) => {
-    assets.push(createAssetEntry(`motivation.${kind}`, "motivation", `${kind} Motivation`, `ipfs://ak-resource-bundle-v1/motivation-${kind}.png`));
-  });
-  ALLOWED_AFFINITY_EXPRESSIONS.forEach((kind) => {
-    assets.push(createAssetEntry(`expression.${kind}`, "expression", `${kind} Expression`, `ipfs://ak-resource-bundle-v1/expression-${kind}.png`));
-  });
-
-  return assets;
+  return getResourceBundleAssetSpecs({ emitVisualAssets })
+    .map((spec) => makeEntry(spec.id, spec.kind, spec.label, spec.ipfsUri));
 }
 
 export function createDefaultResourceBundleArtifact({

--- a/packages/ui-web/src/icon-resolver.js
+++ b/packages/ui-web/src/icon-resolver.js
@@ -2,6 +2,7 @@
  * icon-resolver.js
  * Resolves icons from resource bundle mappings, with text label fallback.
  */
+import { GAME_ICON_FALLBACKS } from "../../runtime/src/contracts/game-elements.js";
 
 /**
  * Unicode icon fallbacks for each category and key.
@@ -9,67 +10,7 @@
  */
 const DEFAULT_UI_ICON = "◈";
 
-const TEXT_LABELS = Object.freeze({
-  types: {
-    room: "🏛️",
-    delver: "⚔️",
-    attacker: "⚔️",
-    warden: "🛡️",
-    defender: "🛡️",
-    hazard: "☠️",
-    untyped: "◻️",
-  },
-  affinities: {
-    fire: "🔥",
-    water: "💧",
-    earth: "🪨",
-    wind: "🌪️",
-    life: "🌿",
-    decay: "🧪",
-    corrode: "🧫",
-    fortify: "🧱",
-    light: "🌟",
-    dark: "🌑",
-  },
-  items: {
-    hazard: "☠️",
-    resource: "💎",
-  },
-  expressions: {
-    push: "⬆️",
-    pull: "⬇️",
-    emit: "📡",
-    draw: "🧲",
-  },
-  motivations: {
-    random: "🎲",
-    stationary: "🧱",
-    exploring: "🧭",
-    attacking: "⚔️",
-    defending: "🛡️",
-    stealthy: "🥷",
-    friendly: "🤝",
-    patrolling: "👣",
-    reflexive: "⚡",
-    goal_oriented: "🎯",
-    strategy_focused: "♟️",
-    user_controlled: "🎮",
-  },
-  vitals: {
-    health: "❤️",
-    mana: "🔷",
-    stamina: "🏃",
-    defence: "🛡️",
-    durability: "⛓️",
-  },
-  ui: {
-    "playing-surface": "◈",
-    "card-builder": DEFAULT_UI_ICON,
-    "game-preview": "◈",
-    "system-console": "◈",
-    "game-inspector": "◈",
-  },
-});
+const TEXT_LABELS = GAME_ICON_FALLBACKS;
 
 /**
  * Check if a dataUri string is valid and not a placeholder image.

--- a/tests/core-ts/affinity-damage.test.mts
+++ b/tests/core-ts/affinity-damage.test.mts
@@ -42,15 +42,25 @@ type Core = ReturnType<typeof createCore>;
 
 /**
  * Build a 7×7 floor grid with two motivated actors placed at the given positions.
- * Returns the configured core with full vitals set on both actors.
+ * Returns the configured core with vitals set on both actors.
  *
- *   index 0 = attacker, HP 10, mana 10, stamina 10, durability 5
- *   index 1 = defender, HP 10, mana 10, stamina 10, durability 5
+ * `current` and `maxes` are passed independently so buff tests can start with
+ * current < max (e.g. current health 5, max health 10). Defaults:
+ *   current = { health: 10, mana: 10, stamina: 10, durability: 5 }
+ *   maxes   = { health: 10, mana: 10, stamina: 10, durability: 5 }
+ *
+ * Passing only `current: { health: 5 }` lowers the current to 5 but the max
+ * stays at the default of 10, so a +2 buff produces 7 (not clamped to 5).
+ *
+ * Passing both lets you exercise the clamp-to-max path explicitly.
  */
 function buildTwoActorWorld(
   attackerXY: [number, number] = [1, 1],
   defenderXY: [number, number] = [2, 1],
-  vitals: { health?: number; mana?: number; stamina?: number; durability?: number } = {},
+  options: {
+    current?: { health?: number; mana?: number; stamina?: number; durability?: number };
+    maxes?:   { health?: number; mana?: number; stamina?: number; durability?: number };
+  } = {},
 ): Core {
   const core = createCore();
   call(core.configureGrid, 7, 7);
@@ -63,16 +73,21 @@ function buildTwoActorWorld(
   call(core.addActorPlacement, 1, ...attackerXY);
   call(core.addActorPlacement, 2, ...defenderXY);
   call(core.applyActorPlacements);
-  // Full vitals (override via vitals arg)
-  const v = {
-    health: 10, mana: 10, stamina: 10, durability: 5,
-    ...vitals,
+  const defaultMax = { health: 10, mana: 10, stamina: 10, durability: 5 };
+  const maxes = { ...defaultMax, ...(options.maxes ?? {}) };
+  const current = {
+    // Each current defaults to the resolved max so the actor starts full.
+    health: maxes.health,
+    mana: maxes.mana,
+    stamina: maxes.stamina,
+    durability: maxes.durability,
+    ...(options.current ?? {}),
   };
   for (const actorIdx of [0, 1]) {
-    call(core.setMotivatedActorVital, actorIdx, VitalKind.Health, v.health, v.health, 0);
-    call(core.setMotivatedActorVital, actorIdx, VitalKind.Mana, v.mana, v.mana, 0);
-    call(core.setMotivatedActorVital, actorIdx, VitalKind.Stamina, v.stamina, v.stamina, 0);
-    call(core.setMotivatedActorVital, actorIdx, VitalKind.Durability, v.durability, v.durability, 0);
+    call(core.setMotivatedActorVital, actorIdx, VitalKind.Health,     current.health,     maxes.health,     0);
+    call(core.setMotivatedActorVital, actorIdx, VitalKind.Mana,       current.mana,       maxes.mana,       0);
+    call(core.setMotivatedActorVital, actorIdx, VitalKind.Stamina,    current.stamina,    maxes.stamina,    0);
+    call(core.setMotivatedActorVital, actorIdx, VitalKind.Durability, current.durability, maxes.durability, 0);
   }
   return core;
 }
@@ -151,7 +166,7 @@ describe("applyAffinityDamage: drain effects (negative matrix entries)", () => {
 
 describe("applyAffinityDamage: buff effects (positive matrix entries)", () => {
   test("life+push (buff Health, base 2) at stack 1 increases target HP by 2 (clamped to max)", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 5 }); // start half-HP so we can see the buff
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 5 } }); // start half-HP so we can see the buff
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -161,7 +176,7 @@ describe("applyAffinityDamage: buff effects (positive matrix entries)", () => {
   });
 
   test("life+emit at stack 1 buffs target Health by 1 (diffuse intensity)", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 5 });
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 5 } });
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -171,7 +186,7 @@ describe("applyAffinityDamage: buff effects (positive matrix entries)", () => {
   });
 
   test("fortify+2+push (worked example) replenishes target Durability by 4", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { durability: 1 }); // start at 1
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { durability: 1 } }); // start at 1
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -181,7 +196,7 @@ describe("applyAffinityDamage: buff effects (positive matrix entries)", () => {
   });
 
   test("earth+emit buffs target Durability by 1 (diffuse intensity)", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { durability: 1 });
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { durability: 1 } });
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -191,7 +206,7 @@ describe("applyAffinityDamage: buff effects (positive matrix entries)", () => {
   });
 
   test("light+push buffs target Mana by 2", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { mana: 5 });
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { mana: 5 } });
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -207,11 +222,11 @@ describe("applyAffinityDamage: buff effects (positive matrix entries)", () => {
 
 describe("applyAffinityDamage: sign-reversal pair behaviour", () => {
   test("life+pull DRAINS the same Health amount that life+push BUFFS (sign reversal)", () => {
-    const a = buildTwoActorWorld([1, 1], [2, 1], { health: 5 });
+    const a = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 5 } });
     call((a as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Push, 1);
     const afterPush = vitalOf(a, 1, VitalKind.Health); // 5 + 2 = 7
 
-    const b = buildTwoActorWorld([1, 1], [2, 1], { health: 5 });
+    const b = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 5 } });
     call((b as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Pull, 1);
     const afterPull = vitalOf(b, 1, VitalKind.Health); // 5 - 2 = 3
 
@@ -219,7 +234,7 @@ describe("applyAffinityDamage: sign-reversal pair behaviour", () => {
   });
 
   test("corrode+pull buffs Durability (sign-reversed: corrode+push drains, so pull buffs)", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { durability: 1 });
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { durability: 1 } });
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -246,7 +261,7 @@ describe("applyAffinityDamage: stack scaling (linear effect = base * stacks)", (
   });
 
   test("stacks=5 multiplies emit base by 5 (life+emit at stacks=5 buffs 5 HP)", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 1 });
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 1 } });
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -262,7 +277,7 @@ describe("applyAffinityDamage: stack scaling (linear effect = base * stacks)", (
 
 describe("applyAffinityDamage: vital clamping", () => {
   test("lethal overkill clamps Health to 0 (does not go negative)", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 3 });
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 3 } });
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -272,8 +287,11 @@ describe("applyAffinityDamage: vital clamping", () => {
   });
 
   test("buff that would exceed max clamps to max", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 9 }); // max 9 effectively (set by buildTwoActorWorld)
-    // Default max from buildTwoActorWorld is whatever 'health' is passed; we set 9 → max 9
+    // Explicit max=9 so the buff clamps at 9 (life+push at stacks=5 would add 10).
+    const core = buildTwoActorWorld([1, 1], [2, 1], {
+      current: { health: 9 },
+      maxes: { health: 9 },
+    });
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -283,7 +301,7 @@ describe("applyAffinityDamage: vital clamping", () => {
   });
 
   test("Durability drain clamps at 0", () => {
-    const core = buildTwoActorWorld([1, 1], [2, 1], { durability: 1 });
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { durability: 1 } });
     call(
       (core as Record<string, unknown>).applyAffinityDamage,
       0, 1,
@@ -342,7 +360,7 @@ describe("applyAffinityDamage: push/pull range == stacks (Chebyshev)", () => {
   });
 
   test("pull also enforces range == stacks (same rule, sign-reversed)", () => {
-    const core = buildTwoActorWorld([1, 1], [3, 1], { health: 5 }); // Chebyshev = 2
+    const core = buildTwoActorWorld([1, 1], [3, 1], { current: { health: 5 } }); // Chebyshev = 2
     // life+pull at stacks=1 would be out of range
     const rejected = call(
       (core as Record<string, unknown>).applyAffinityDamage,
@@ -368,11 +386,11 @@ describe("applyAffinityDamage: push/pull range == stacks (Chebyshev)", () => {
 
 describe("applyAffinityDamage: emit/draw have no range constraint at the per-target level", () => {
   test("emit at any distance applies the diffuse per-target effect (area iteration is the caller's job)", () => {
-    const close = buildTwoActorWorld([1, 1], [2, 1], { health: 5 });
+    const close = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 5 } });
     call((close as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Emit, 1);
     expect(vitalOf(close, 1, VitalKind.Health)).toBe(5 + 1);
 
-    const far = buildTwoActorWorld([1, 1], [5, 5], { health: 5 });
+    const far = buildTwoActorWorld([1, 1], [5, 5], { current: { health: 5 } });
     call((far as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Emit, 1);
     expect(vitalOf(far, 1, VitalKind.Health)).toBe(5 + 1);
   });

--- a/tests/core-ts/affinity-damage.test.mts
+++ b/tests/core-ts/affinity-damage.test.mts
@@ -1,0 +1,505 @@
+/**
+ * M1 — `applyAffinityDamage` core entry point: failing tests
+ *
+ * These tests specify the contract for the new `core.applyAffinityDamage`
+ * primitive that PR #43 will add. It must:
+ *   - Route (affinity, expression, stacks) through the M2 matrix to the
+ *     correct vital(s) on the target actor
+ *   - Apply signed effects (positive = buff, negative = drain), clamped to [0, max]
+ *   - Scale magnitude linearly by stacks
+ *   - Enforce push/pull as single-target with max Chebyshev range == stacks
+ *   - Treat emit/draw as per-target diffuse applications (no range constraint
+ *     at this primitive level; area iteration is deferred per M3 plan)
+ *   - Be PURE: no IO, no clocks, no runtime imports
+ *   - Leave PR #42's `applyAttack` entry point untouched
+ *
+ * Tests MUST FAIL until M3 implements `packages/core-ts/src/rules/affinity-damage.ts`
+ * and wires `core.applyAffinityDamage` from `createCore()` with the alphabetically-sorted
+ * CORE_API_KEYS entry preserved.
+ *
+ * Architecture: core-ts only.
+ */
+import { describe, expect, test } from "vitest";
+import { createCore } from "../../packages/core-ts/src/index.ts";
+import {
+  AffinityExpression,
+  AffinityKind,
+} from "../../packages/core-ts/src/state/affinity.ts";
+import { VitalKind } from "../../packages/core-ts/src/state/vitals.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers — multi-actor world setup
+// ---------------------------------------------------------------------------
+
+function call(fn: unknown, ...args: unknown[]): unknown {
+  if (typeof fn !== "function") {
+    throw new Error("expected callable core export — M3 must wire this");
+  }
+  return fn(...args);
+}
+
+type Core = ReturnType<typeof createCore>;
+
+/**
+ * Build a 7×7 floor grid with two motivated actors placed at the given positions.
+ * Returns the configured core with full vitals set on both actors.
+ *
+ *   index 0 = attacker, HP 10, mana 10, stamina 10, durability 5
+ *   index 1 = defender, HP 10, mana 10, stamina 10, durability 5
+ */
+function buildTwoActorWorld(
+  attackerXY: [number, number] = [1, 1],
+  defenderXY: [number, number] = [2, 1],
+  vitals: { health?: number; mana?: number; stamina?: number; durability?: number } = {},
+): Core {
+  const core = createCore();
+  call(core.configureGrid, 7, 7);
+  // Make the entire interior walkable
+  for (let y = 1; y <= 5; y++) {
+    for (let x = 1; x <= 5; x++) {
+      call(core.setTileAt, x, y, 1); // floor
+    }
+  }
+  call(core.addActorPlacement, 1, ...attackerXY);
+  call(core.addActorPlacement, 2, ...defenderXY);
+  call(core.applyActorPlacements);
+  // Full vitals (override via vitals arg)
+  const v = {
+    health: 10, mana: 10, stamina: 10, durability: 5,
+    ...vitals,
+  };
+  for (const actorIdx of [0, 1]) {
+    call(core.setMotivatedActorVital, actorIdx, VitalKind.Health, v.health, v.health, 0);
+    call(core.setMotivatedActorVital, actorIdx, VitalKind.Mana, v.mana, v.mana, 0);
+    call(core.setMotivatedActorVital, actorIdx, VitalKind.Stamina, v.stamina, v.stamina, 0);
+    call(core.setMotivatedActorVital, actorIdx, VitalKind.Durability, v.durability, v.durability, 0);
+  }
+  return core;
+}
+
+function vitalOf(core: Core, actorIdx: number, vital: number): number {
+  return call(core.getMotivatedActorVitalCurrentByIndex, actorIdx, vital) as number;
+}
+
+// ---------------------------------------------------------------------------
+// API presence
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: API surface", () => {
+  test("applyAffinityDamage is exported from createCore()", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).applyAffinityDamage).toBe("function");
+  });
+
+  test("applyAttack from PR #42 is still exported and unchanged", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).applyAttack).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Matrix routing — drain cases (negative effects reduce target vital)
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: drain effects (negative matrix entries)", () => {
+  test("fire+push (drain Health, base 2) at stack 1 reduces target HP by 2", () => {
+    // attacker(0) at (1,1), defender(1) at (2,1) — adjacent (Chebyshev 1, within range 1)
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    expect(result).not.toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10 - 2);
+  });
+
+  test("corrode+push drains target Durability by 2 per stack", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(vitalOf(core, 1, VitalKind.Durability)).toBe(5 - 2);
+  });
+
+  test("dark+push drains target Mana by 2 per stack", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Dark, AffinityExpression.Push, 1,
+    );
+    expect(vitalOf(core, 1, VitalKind.Mana)).toBe(10 - 2);
+  });
+
+  test("wind+push drains target Stamina by 2 per stack", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Wind, AffinityExpression.Push, 1,
+    );
+    expect(vitalOf(core, 1, VitalKind.Stamina)).toBe(10 - 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Matrix routing — buff cases (positive effects increase target vital)
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: buff effects (positive matrix entries)", () => {
+  test("life+push (buff Health, base 2) at stack 1 increases target HP by 2 (clamped to max)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 5 }); // start half-HP so we can see the buff
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Life, AffinityExpression.Push, 1,
+    );
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(5 + 2);
+  });
+
+  test("life+emit at stack 1 buffs target Health by 1 (diffuse intensity)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 5 });
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Life, AffinityExpression.Emit, 1,
+    );
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(5 + 1);
+  });
+
+  test("fortify+2+push (worked example) replenishes target Durability by 4", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { durability: 1 }); // start at 1
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Fortify, AffinityExpression.Push, 2,
+    );
+    expect(vitalOf(core, 1, VitalKind.Durability)).toBe(1 + 4);
+  });
+
+  test("earth+emit buffs target Durability by 1 (diffuse intensity)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { durability: 1 });
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Earth, AffinityExpression.Emit, 1,
+    );
+    expect(vitalOf(core, 1, VitalKind.Durability)).toBe(1 + 1);
+  });
+
+  test("light+push buffs target Mana by 2", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { mana: 5 });
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Light, AffinityExpression.Push, 1,
+    );
+    expect(vitalOf(core, 1, VitalKind.Mana)).toBe(5 + 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sign reversal observed end-to-end through applyAffinityDamage
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: sign-reversal pair behaviour", () => {
+  test("life+pull DRAINS the same Health amount that life+push BUFFS (sign reversal)", () => {
+    const a = buildTwoActorWorld([1, 1], [2, 1], { health: 5 });
+    call((a as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Push, 1);
+    const afterPush = vitalOf(a, 1, VitalKind.Health); // 5 + 2 = 7
+
+    const b = buildTwoActorWorld([1, 1], [2, 1], { health: 5 });
+    call((b as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Pull, 1);
+    const afterPull = vitalOf(b, 1, VitalKind.Health); // 5 - 2 = 3
+
+    expect(afterPush - 5).toBe(-(afterPull - 5));
+  });
+
+  test("corrode+pull buffs Durability (sign-reversed: corrode+push drains, so pull buffs)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { durability: 1 });
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Corrode, AffinityExpression.Pull, 1,
+    );
+    expect(vitalOf(core, 1, VitalKind.Durability)).toBe(1 + 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stack scaling — magnitude = base * stacks
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: stack scaling (linear effect = base * stacks)", () => {
+  test("stacks=3 multiplies push base by 3 (fire+push at stacks=3 drains 6 HP)", () => {
+    // Place defender 1 tile away so range==1 ≤ stacks==3 (within range)
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Fire, AffinityExpression.Push, 3,
+    );
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10 - 6);
+  });
+
+  test("stacks=5 multiplies emit base by 5 (life+emit at stacks=5 buffs 5 HP)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 1 });
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Life, AffinityExpression.Emit, 5,
+    );
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(1 + 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clamping — drain stops at 0, buff stops at max
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: vital clamping", () => {
+  test("lethal overkill clamps Health to 0 (does not go negative)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 3 });
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Fire, AffinityExpression.Push, 10, // 20 damage vs 3 HP
+    );
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(0);
+  });
+
+  test("buff that would exceed max clamps to max", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { health: 9 }); // max 9 effectively (set by buildTwoActorWorld)
+    // Default max from buildTwoActorWorld is whatever 'health' is passed; we set 9 → max 9
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Life, AffinityExpression.Push, 5,
+    );
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(9);
+  });
+
+  test("Durability drain clamps at 0", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { durability: 1 });
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 5, // 10 damage vs 1 durability
+    );
+    expect(vitalOf(core, 1, VitalKind.Durability)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Push/pull range semantics (single-target, range == stacks)
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: push/pull range == stacks (Chebyshev)", () => {
+  test("push at stacks=1 succeeds against a target 1 tile away (range matches stacks)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]); // Chebyshev = 1
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    expect(result).not.toBe(0);
+  });
+
+  test("push at stacks=1 is rejected against a target 2 tiles away (out of range)", () => {
+    const core = buildTwoActorWorld([1, 1], [3, 1]); // Chebyshev = 2
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10); // unchanged
+  });
+
+  test("push at stacks=4 succeeds against a target 4 tiles away (fireball example)", () => {
+    const core = buildTwoActorWorld([1, 1], [5, 1]); // Chebyshev = 4
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Fire, AffinityExpression.Push, 4,
+    );
+    expect(result).not.toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10 - 8); // 2 * 4
+  });
+
+  test("push at stacks=3 is rejected against a target 4 tiles away (range < distance)", () => {
+    const core = buildTwoActorWorld([1, 1], [5, 1]); // Chebyshev = 4
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Fire, AffinityExpression.Push, 3,
+    );
+    expect(result).toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10);
+  });
+
+  test("pull also enforces range == stacks (same rule, sign-reversed)", () => {
+    const core = buildTwoActorWorld([1, 1], [3, 1], { health: 5 }); // Chebyshev = 2
+    // life+pull at stacks=1 would be out of range
+    const rejected = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Life, AffinityExpression.Pull, 1,
+    );
+    expect(rejected).toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(5); // unchanged
+    // life+pull at stacks=2 reaches the target — drains health
+    const accepted = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1,
+      AffinityKind.Life, AffinityExpression.Pull, 2,
+    );
+    expect(accepted).not.toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(5 - 4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Emit/draw — no range constraint at this primitive level (area iteration deferred)
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: emit/draw have no range constraint at the per-target level", () => {
+  test("emit at any distance applies the diffuse per-target effect (area iteration is the caller's job)", () => {
+    const close = buildTwoActorWorld([1, 1], [2, 1], { health: 5 });
+    call((close as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Emit, 1);
+    expect(vitalOf(close, 1, VitalKind.Health)).toBe(5 + 1);
+
+    const far = buildTwoActorWorld([1, 1], [5, 5], { health: 5 });
+    call((far as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Emit, 1);
+    expect(vitalOf(far, 1, VitalKind.Health)).toBe(5 + 1);
+  });
+
+  test("draw at any distance applies the diffuse per-target drain", () => {
+    const core = buildTwoActorWorld([1, 1], [5, 5]);
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Life, AffinityExpression.Draw, 1);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10 - 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection cases
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: rejection cases", () => {
+  test("invalid attacker index returns 0", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      99, 1, AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("invalid target index returns 0", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 99, AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("invalid affinity kind returns 0", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, 99, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("invalid expression returns 0", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, 99, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("zero stacks returns 0 (no-op rejected)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Push, 0,
+    );
+    expect(result).toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10);
+  });
+
+  test("negative stacks returns 0", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Push, -1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("attacker == target (self-affinity) returns 0", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 0, AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("no-effect matrix cell (decay on durability via push) returns 0 and leaves target unchanged", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    // Decay's primary vital is Health, not Durability. Routing Decay against the Durability vital
+    // is not how the API is called; the API routes via the matrix. The behaviour we want here is:
+    // a Decay+Push call routes to Health (matrix says so), NOT Durability. Verify durability untouched.
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Decay, AffinityExpression.Push, 1);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10 - 2);   // routed correctly
+    expect(vitalOf(core, 1, VitalKind.Durability)).toBe(5);    // unaffected
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #42 regression — applyAttack must still work and be untouched
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: PR #42 applyAttack non-regression", () => {
+  test("applyAttack still reduces target Health by the given damage (adjacency check intact)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAttack,
+      0, 1, 3,
+    );
+    expect(result).not.toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10 - 3);
+  });
+
+  test("applyAttack still rejects non-adjacent attacks (Chebyshev > 1)", () => {
+    const core = buildTwoActorWorld([1, 1], [3, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAttack,
+      0, 1, 3,
+    );
+    expect(result).toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10);
+  });
+});
+
+// ## TODO: Test Permutations
+//
+// 1. applyAffinityDamage with every (kind, expression) pair × stacks ∈ {1, 2, 3} → verify each routes
+//    to the affinity's primary vital with the matrix-computed signed magnitude
+// 2. Sequence of drains until vital reaches 0 — subsequent calls succeed but leave vital at 0 (clamp)
+// 3. Sequence of buffs until vital reaches max — subsequent calls succeed but leave vital at max (clamp)
+// 4. applyAffinityDamage with kind/expression that has a 0 cell on the routed vital — call accepted
+//    but no change to any vital (effect == 0 still returns 1? or 0? — locked by M3 contract)
+// 5. Push/pull at stacks=0 is rejected even when distance is 0 (zero-magnitude no-op)
+// 6. Emit/draw against the attacker itself (self-target) — rejected by the self-target rule
+// 7. Multiple actors in a row: applyAffinityDamage only mutates the named target index, not neighbors
+// 8. After applyAffinityDamage modifies a vital, getMotivatedActorVitalCurrentByIndex reflects the change
+//    immediately on the next call (no buffer / no batching)

--- a/tests/core-ts/affinity-damage.test.mts
+++ b/tests/core-ts/affinity-damage.test.mts
@@ -508,16 +508,155 @@ describe("applyAffinityDamage: PR #42 applyAttack non-regression", () => {
   });
 });
 
-// ## TODO: Test Permutations
-//
-// 1. applyAffinityDamage with every (kind, expression) pair × stacks ∈ {1, 2, 3} → verify each routes
-//    to the affinity's primary vital with the matrix-computed signed magnitude
-// 2. Sequence of drains until vital reaches 0 — subsequent calls succeed but leave vital at 0 (clamp)
-// 3. Sequence of buffs until vital reaches max — subsequent calls succeed but leave vital at max (clamp)
-// 4. applyAffinityDamage with kind/expression that has a 0 cell on the routed vital — call accepted
-//    but no change to any vital (effect == 0 still returns 1? or 0? — locked by M3 contract)
-// 5. Push/pull at stacks=0 is rejected even when distance is 0 (zero-magnitude no-op)
-// 6. Emit/draw against the attacker itself (self-target) — rejected by the self-target rule
-// 7. Multiple actors in a row: applyAffinityDamage only mutates the named target index, not neighbors
-// 8. After applyAffinityDamage modifies a vital, getMotivatedActorVitalCurrentByIndex reflects the change
-//    immediately on the next call (no buffer / no batching)
+// ---------------------------------------------------------------------------
+// Permutations: all 40 (kind × expression) pairs route to the correct primary vital
+// ---------------------------------------------------------------------------
+
+describe("permutations: all 40 (kind × expression) pairs route to the correct primary vital", () => {
+  // Mirrors the contract in affinity-vital-matrix.test.mts PRIMARY table
+  const ROUTE: Record<number, { vital: number; polarity: number }> = {
+    [AffinityKind.Fire]:    { vital: VitalKind.Health,     polarity: -1 },
+    [AffinityKind.Water]:   { vital: VitalKind.Health,     polarity: +1 },
+    [AffinityKind.Earth]:   { vital: VitalKind.Durability, polarity: +1 },
+    [AffinityKind.Wind]:    { vital: VitalKind.Stamina,    polarity: -1 },
+    [AffinityKind.Life]:    { vital: VitalKind.Health,     polarity: +1 },
+    [AffinityKind.Decay]:   { vital: VitalKind.Health,     polarity: -1 },
+    [AffinityKind.Corrode]: { vital: VitalKind.Durability, polarity: -1 },
+    [AffinityKind.Fortify]: { vital: VitalKind.Durability, polarity: +1 },
+    [AffinityKind.Light]:   { vital: VitalKind.Mana,       polarity: +1 },
+    [AffinityKind.Dark]:    { vital: VitalKind.Mana,       polarity: -1 },
+  };
+
+  // Mid-range starting vitals — stacks=1 never saturates at either bound
+  const START: Record<number, number> = {
+    [VitalKind.Health]: 5, [VitalKind.Mana]: 5,
+    [VitalKind.Stamina]: 5, [VitalKind.Durability]: 2,
+  };
+  const MAX: Record<number, number> = {
+    [VitalKind.Health]: 10, [VitalKind.Mana]: 10,
+    [VitalKind.Stamina]: 10, [VitalKind.Durability]: 5,
+  };
+  const startCurrent = { health: 5, mana: 5, stamina: 5, durability: 2 };
+  const startMaxes   = { health: 10, mana: 10, stamina: 10, durability: 5 };
+  const ALL_KINDS = [
+    AffinityKind.Fire, AffinityKind.Water, AffinityKind.Earth, AffinityKind.Wind,
+    AffinityKind.Life, AffinityKind.Decay, AffinityKind.Corrode, AffinityKind.Fortify,
+    AffinityKind.Light, AffinityKind.Dark,
+  ];
+  const ALL_EXPRS = [
+    AffinityExpression.Push, AffinityExpression.Pull,
+    AffinityExpression.Emit, AffinityExpression.Draw,
+  ];
+  const ALL_VITAL_KINDS = [VitalKind.Health, VitalKind.Mana, VitalKind.Stamina, VitalKind.Durability];
+
+  test("each combination applies to the primary vital and leaves all other vitals unchanged", () => {
+    for (const kind of ALL_KINDS) {
+      for (const expr of ALL_EXPRS) {
+        // Fresh world for each combination
+        const core = buildTwoActorWorld([1, 1], [2, 1], { current: startCurrent, maxes: startMaxes });
+        const { vital: pVital, polarity } = ROUTE[kind]!;
+        const base = (expr === AffinityExpression.Push || expr === AffinityExpression.Pull) ? 2 : 1;
+        const sign = (expr === AffinityExpression.Pull || expr === AffinityExpression.Draw) ? -polarity : polarity;
+        const effect = sign * base;
+
+        call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, kind, expr, 1);
+
+        // Primary vital must reflect the effect (clamped to [0, max])
+        const expected = Math.max(0, Math.min(MAX[pVital]!, START[pVital]! + effect));
+        expect(vitalOf(core, 1, pVital)).toBe(expected);
+
+        // All other vitals must be unchanged
+        for (const other of ALL_VITAL_KINDS) {
+          if (other !== pVital) {
+            expect(vitalOf(core, 1, other)).toBe(START[other]!);
+          }
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: drain-to-zero sequence — vital clamps at 0, does not go negative
+// ---------------------------------------------------------------------------
+
+describe("permutations: repeated drain calls clamp vital at 0 without going negative", () => {
+  test("fire+push repeated until health hits 0 — health stays at 0 on subsequent accepted calls", () => {
+    // health starts at 4, each push drains by 2 → hits 0 after 2 calls
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 4 } });
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Fire, AffinityExpression.Push, 1);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(2);
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Fire, AffinityExpression.Push, 1);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(0);
+    // additional calls accepted but vital stays at 0
+    const result = call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Fire, AffinityExpression.Push, 1) as number;
+    expect(result).not.toBe(0); // still accepted
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(0); // still clamped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: buff-to-max sequence — vital clamps at max, does not overflow
+// ---------------------------------------------------------------------------
+
+describe("permutations: repeated buff calls clamp vital at max without overflowing", () => {
+  test("water+push repeated until health hits max — health stays at max on subsequent accepted calls", () => {
+    // health starts at 4 max=10, each push buffs by 2 → hits 10 after 3 calls (4→6→8→10)
+    const core = buildTwoActorWorld([1, 1], [2, 1], { current: { health: 4 } });
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Water, AffinityExpression.Push, 1);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(6);
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Water, AffinityExpression.Push, 1);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(8);
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Water, AffinityExpression.Push, 1);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10);
+    // additional buff accepted but vital stays at max
+    const result = call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Water, AffinityExpression.Push, 1) as number;
+    expect(result).not.toBe(0);
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: multiple actors — only the named target is mutated
+// ---------------------------------------------------------------------------
+
+describe("permutations: only the named target actor is mutated by applyAffinityDamage", () => {
+  test("applying fire+push to actor 1 does not change actor 0 (attacker) or actor 2 (bystander)", () => {
+    // Build a 3-actor world manually: actor 0 at (1,1), actor 1 at (2,1), actor 2 at (3,1)
+    const core = createCore();
+    call(core.configureGrid, 7, 7);
+    for (let y = 1; y <= 5; y++) {
+      for (let x = 1; x <= 5; x++) call(core.setTileAt, x, y, 1);
+    }
+    call(core.addActorPlacement, 1, 1, 1);
+    call(core.addActorPlacement, 2, 2, 1);
+    call(core.addActorPlacement, 3, 3, 1);
+    call(core.applyActorPlacements);
+    for (const idx of [0, 1, 2]) {
+      call(core.setMotivatedActorVital, idx, VitalKind.Health,     10, 10, 0);
+      call(core.setMotivatedActorVital, idx, VitalKind.Mana,       10, 10, 0);
+      call(core.setMotivatedActorVital, idx, VitalKind.Stamina,    10, 10, 0);
+      call(core.setMotivatedActorVital, idx, VitalKind.Durability,  5,  5, 0);
+    }
+
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Fire, AffinityExpression.Push, 1);
+
+    expect(vitalOf(core, 0, VitalKind.Health)).toBe(10); // attacker unchanged
+    expect(vitalOf(core, 1, VitalKind.Health)).toBe(8);  // target drained
+    expect(vitalOf(core, 2, VitalKind.Health)).toBe(10); // bystander unchanged
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: getMotivatedActorVitalCurrentByIndex reflects changes immediately
+// ---------------------------------------------------------------------------
+
+describe("permutations: vital changes are reflected by the getter on the very next call", () => {
+  test("getter returns updated value immediately after applyAffinityDamage returns", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1]);
+    const before = vitalOf(core, 1, VitalKind.Health);
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Fire, AffinityExpression.Push, 1);
+    const after = vitalOf(core, 1, VitalKind.Health);
+    expect(after).toBe(before - 2);
+  });
+});

--- a/tests/core-ts/affinity-neutralization.test.mts
+++ b/tests/core-ts/affinity-neutralization.test.mts
@@ -1,0 +1,722 @@
+/**
+ * M3b — Same-affinity Pull neutralization + mana transfer: failing tests
+ *
+ * When an actor uses Pull with the same AffinityKind as the target's active
+ * expression (Emit or Push), `applyAffinityDamage` branches to a
+ * neutralization-and-transfer path instead of the standard matrix lookup.
+ *
+ * Two target types:
+ *   - Actor target  : `applyAffinityDamage(attacker, target, kind, Pull, stacks)`
+ *                     detects target's active affinity internally.
+ *   - Hazard target : `applyAffinityPullFromHazard(attacker, x, y, kind, stacks)`
+ *                     new function; reads the static trap at (x, y).
+ *
+ * Mana transfer contract:
+ *   - Attacker gains min(sourceMana, maxMana - currentMana) of the attacker
+ *   - Excess is discarded (not refunded to source)
+ *   - Source mana is always set to 0 on accepted neutralization
+ *
+ * Tests MUST FAIL until M3b implements:
+ *   1. Neutralization branch in `packages/core-ts/src/rules/affinity-damage.ts`
+ *   2. New `applyAffinityPullFromHazard` rule in the same file
+ *   3. `applyAffinityPullFromHazard` wired into `createCore()` with
+ *      `CORE_API_KEYS` kept alphabetical
+ */
+import { describe, expect, test } from "vitest";
+import { createCore } from "../../packages/core-ts/src/index.ts";
+import {
+  AffinityExpression,
+  AffinityKind,
+} from "../../packages/core-ts/src/state/affinity.ts";
+import { VitalKind } from "../../packages/core-ts/src/state/vitals.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function call(fn: unknown, ...args: unknown[]): unknown {
+  if (typeof fn !== "function") {
+    throw new Error("expected callable core export — M3b must wire this");
+  }
+  return fn(...args);
+}
+
+type Core = ReturnType<typeof createCore>;
+
+/**
+ * 7×7 walkable interior, two motivated actors with default vitals.
+ * current defaults equal max so each actor starts full.
+ */
+function buildTwoActorWorld(
+  attackerXY: [number, number] = [1, 1],
+  defenderXY: [number, number] = [2, 1],
+  options: {
+    attackerVitals?: { mana?: number; manaCurrent?: number };
+    defenderVitals?: { mana?: number; manaCurrent?: number };
+  } = {},
+): Core {
+  const core = createCore();
+  call(core.configureGrid, 7, 7);
+  for (let y = 1; y <= 5; y++) {
+    for (let x = 1; x <= 5; x++) {
+      call(core.setTileAt, x, y, 1);
+    }
+  }
+  call(core.addActorPlacement, 1, ...attackerXY);
+  call(core.addActorPlacement, 2, ...defenderXY);
+  call(core.applyActorPlacements);
+
+  const attackerManaMax     = options.attackerVitals?.mana        ?? 10;
+  const attackerManaCurrent = options.attackerVitals?.manaCurrent ?? attackerManaMax;
+  const defenderManaMax     = options.defenderVitals?.mana        ?? 10;
+  const defenderManaCurrent = options.defenderVitals?.manaCurrent ?? defenderManaMax;
+
+  call(core.setMotivatedActorVital, 0, VitalKind.Health,     10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Mana,       attackerManaCurrent, attackerManaMax, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Stamina,    10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Durability,  5,  5, 0);
+
+  call(core.setMotivatedActorVital, 1, VitalKind.Health,     10, 10, 0);
+  call(core.setMotivatedActorVital, 1, VitalKind.Mana,       defenderManaCurrent, defenderManaMax, 0);
+  call(core.setMotivatedActorVital, 1, VitalKind.Stamina,    10, 10, 0);
+  call(core.setMotivatedActorVital, 1, VitalKind.Durability,  5,  5, 0);
+
+  return core;
+}
+
+/**
+ * Build a world with one actor (index 0) and one static trap at (trapX, trapY).
+ */
+function buildTrapWorld(
+  actorXY: [number, number] = [1, 1],
+  trapXY: [number, number] = [3, 1],
+  trapKind: number = AffinityKind.Fire,
+  trapExpression: number = AffinityExpression.Emit,
+  trapStacks: number = 2,
+  trapMana: number = 8,
+  actorManaMax: number = 10,
+  actorManaCurrent: number = 2,
+): Core {
+  const core = createCore();
+  call(core.configureGrid, 7, 7);
+  for (let y = 1; y <= 5; y++) {
+    for (let x = 1; x <= 5; x++) {
+      call(core.setTileAt, x, y, 1);
+    }
+  }
+  call(core.addActorPlacement, 1, ...actorXY);
+  call(core.applyActorPlacements);
+
+  call(core.setMotivatedActorVital, 0, VitalKind.Health,     10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Mana,       actorManaCurrent, actorManaMax, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Stamina,    10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Durability,  5,  5, 0);
+
+  call(core.armStaticTrapAt, ...trapXY, trapKind, trapExpression, trapStacks, trapMana);
+  return core;
+}
+
+function manaOf(core: Core, actorIdx: number): number {
+  return call(core.getMotivatedActorVitalCurrentByIndex, actorIdx, VitalKind.Mana) as number;
+}
+
+function affinityExprOf(core: Core, actorIdx: number): number {
+  return call(core.getMotivatedActorAffinityExpressionByIndex, actorIdx) as number;
+}
+
+function trapManaOf(core: Core, x: number, y: number): number {
+  return call(core.getStaticTrapManaReserveAt, x, y) as number;
+}
+
+function trapExistsAt(core: Core, x: number, y: number): boolean {
+  // armStaticTrapAt stores affinity > 0; 0 means no trap
+  return (call(core.getStaticTrapAffinityAt, x, y) as number) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// API presence
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityPullFromHazard: API surface", () => {
+  test("applyAffinityPullFromHazard is exported from createCore()", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).applyAffinityPullFromHazard).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Actor-vs-actor neutralization via applyAffinityDamage
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: actor-vs-actor neutralization (Pull + matching Emit)", () => {
+  test("Fire+Pull vs actor with Fire+Emit active → neutralizes; target mana drained to 0", () => {
+    const core = buildTwoActorWorld();
+    // Actor 1 has an active Fire+Emit affinity
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 2);
+
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+
+    expect(result).not.toBe(0);                  // accepted
+    expect(manaOf(core, 1)).toBe(0);              // target mana fully drained
+  });
+
+  test("actor target's active affinity expression is cleared after neutralization", () => {
+    const core = buildTwoActorWorld();
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 2);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+    // Sentinel value is 0 (no active expression)
+    expect(affinityExprOf(core, 1)).toBe(0);
+  });
+
+  test("Fire+Pull vs actor with Fire+Push active → also neutralizes (Push is also neutralizable)", () => {
+    const core = buildTwoActorWorld();
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Push, 3);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+    expect(result).not.toBe(0);
+    expect(manaOf(core, 1)).toBe(0);
+  });
+
+  test("mana transferred to attacker: min(targetMana, attackerManaCapacity)", () => {
+    // attacker has 2 of 10 mana (capacity = 8); target has 10 mana → transfer 8, discard 2
+    const core = buildTwoActorWorld(
+      [1, 1], [2, 1],
+      { attackerVitals: { manaCurrent: 2, mana: 10 } },
+    );
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 2);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+    // Attacker: 2 + min(10, 10-2=8) = 2 + 8 = 10 (capped at max)
+    expect(manaOf(core, 0)).toBe(10);
+    // Target: fully drained
+    expect(manaOf(core, 1)).toBe(0);
+  });
+
+  test("excess mana is discarded when transfer would exceed attacker max", () => {
+    // attacker max=10, current=6 → capacity=4; target has 10 mana → transfer only 4, discard 6
+    const core = buildTwoActorWorld(
+      [1, 1], [2, 1],
+      { attackerVitals: { manaCurrent: 6, mana: 10 } },
+    );
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 2);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+    expect(manaOf(core, 0)).toBe(10);  // 6 + 4, clamped to max
+    expect(manaOf(core, 1)).toBe(0);   // source always fully drained
+  });
+
+  test("neutralization does NOT drain target health — only mana is affected", () => {
+    const core = buildTwoActorWorld();
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 2);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+    // Health should be unchanged (neutralization doesn't deal matrix damage)
+    expect(call(core.getMotivatedActorVitalCurrentByIndex, 1, VitalKind.Health)).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-matching Pull falls back to matrix path
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: non-matching Pull uses matrix (no neutralization)", () => {
+  test("Fire+Pull vs actor with Water+Emit (different kind) → matrix path, no mana drain", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { defenderVitals: { mana: 10 } });
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Water, AffinityExpression.Emit, 2);
+
+    const beforeMana = manaOf(core, 1);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+    // Fire+Pull on the matrix drains Health (sign-reversed fire = negative Health)
+    // Target mana should NOT be drained (no neutralization)
+    expect(manaOf(core, 1)).toBe(beforeMana);
+    // Health IS reduced by the matrix (Fire pulls health: polarity -1, pull = sign-reversed = +1*2... wait)
+    // Fire polarity = -1, Pull expression = sign-reversed (isReversed=true) → sign = -(-1) = +1
+    // So fire+pull BUFFS health (opposite of fire+push which drains).
+    // But target starts at full health=10 → clamped to 10 (no visible change)
+    // The point is: mana was not drained via neutralization.
+  });
+
+  test("Fire+Pull vs actor with Fire+Draw active (Draw ≠ Emit|Push) → matrix path", () => {
+    const core = buildTwoActorWorld();
+    // Draw is not Emit or Push — should not trigger neutralization
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Draw, 2);
+    const beforeMana = manaOf(core, 1);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+    expect(manaOf(core, 1)).toBe(beforeMana); // no neutralization drain
+    // affinity expression NOT cleared (no neutralization)
+    expect(affinityExprOf(core, 1)).toBe(AffinityExpression.Draw);
+  });
+
+  test("Fire+Pull vs actor with no active affinity → matrix path (no neutralization)", () => {
+    const core = buildTwoActorWorld([1, 1], [2, 1], { defenderVitals: { mana: 10 } });
+    // Actor 1 has no active affinity set (expression == 0)
+    const beforeMana = manaOf(core, 1);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    );
+    expect(manaOf(core, 1)).toBe(beforeMana); // no mana drain from neutralization
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hazard neutralization via applyAffinityPullFromHazard
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityPullFromHazard: hazard neutralization", () => {
+  test("Fire+Pull vs Fire+Emit hazard → trap mana drained to 0, structure preserved, mana transferred to actor", () => {
+    // actor at (1,1), trap at (3,1), actor mana=2/10, trap mana=8
+    const core = buildTrapWorld(
+      [1, 1], [3, 1],
+      AffinityKind.Fire, AffinityExpression.Emit,
+      2, 8, // stacks=2, mana=8
+      10, 2, // actor maxMana=10, currentMana=2
+    );
+
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 3, 1, AffinityKind.Fire, 1,
+    );
+
+    expect(result).not.toBe(0);                   // accepted
+    expect(trapManaOf(core, 3, 1)).toBe(0);        // mana fully drained
+    expect(trapExistsAt(core, 3, 1)).toBe(true);   // trap structure preserved (can regen)
+    // Transfer: min(8, 10-2=8) = 8 → attacker mana = 2 + 8 = 10
+    expect(manaOf(core, 0)).toBe(10);
+  });
+
+  test("Fire+Pull vs Fire+Push hazard → also neutralizes (Push traps are neutralizable)", () => {
+    const core = buildTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Fire, AffinityExpression.Push,
+      2, 5,
+      10, 0,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(result).not.toBe(0);
+    expect(trapManaOf(core, 2, 1)).toBe(0);       // mana drained
+    expect(trapExistsAt(core, 2, 1)).toBe(true);  // structure preserved
+  });
+
+  test("mana excess is discarded when trap mana > attacker capacity", () => {
+    // actor: current=8, max=10 → capacity=2; trap mana=6 → transfer 2, discard 4
+    const core = buildTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Dark, AffinityExpression.Emit,
+      1, 6,
+      10, 8,
+    );
+    call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Dark, 1,
+    );
+    expect(manaOf(core, 0)).toBe(10); // 8 + min(6, 2) = 8 + 2 = 10
+  });
+
+  test("trap with zero mana (after drain) is rejected on second pull — nothing to neutralize", () => {
+    // armStaticTrapAt rejects manaReserve <= 0, so create a world with a valid trap
+    // then verify zero-mana path via mana already drained in a prior call
+    const core = buildTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Fire, AffinityExpression.Emit,
+      1, 1, // mana=1 (minimum valid arm)
+      10, 0,
+    );
+    // First pull drains the 1 mana; trap structure remains
+    call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(trapManaOf(core, 2, 1)).toBe(0);       // mana drained
+    expect(trapExistsAt(core, 2, 1)).toBe(true);  // structure present
+
+    // Second pull on the zero-mana trap should be rejected
+    const result2 = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(result2).toBe(0);
+  });
+
+  test("non-matching hazard affinity (Fire+Pull vs Water+Emit) → rejected (0)", () => {
+    const core = buildTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Water, AffinityExpression.Emit,
+      2, 8,
+      10, 2,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(result).toBe(0);
+    expect(trapExistsAt(core, 2, 1)).toBe(true);  // trap still armed
+    expect(trapManaOf(core, 2, 1)).toBe(8);        // mana untouched
+  });
+
+  test("no hazard at target cell → rejected (0)", () => {
+    const core = buildTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Fire, AffinityExpression.Emit,
+      2, 8,
+    );
+    // Pull at (4,1) which has no trap
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 4, 1, AffinityKind.Fire, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("invalid attacker index → rejected (0)", () => {
+    const core = buildTrapWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      99, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("invalid affinity kind → rejected (0)", () => {
+    const core = buildTrapWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, 99, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("zero stacks → rejected (0)", () => {
+    const core = buildTrapWorld([1, 1], [2, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 0,
+    );
+    expect(result).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Actor-vs-actor: rejection edge cases
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamage: neutralization rejection cases", () => {
+  test("target actor has matching affinity but attacker uses Push (not Pull) → no neutralization, matrix applies", () => {
+    const core = buildTwoActorWorld();
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 2);
+    // Push, not Pull → normal matrix path (drains health)
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    // Mana should be untouched (no neutralization)
+    expect(manaOf(core, 1)).toBe(10);
+    // Health should be reduced (matrix: fire+push = -2)
+    expect(call(core.getMotivatedActorVitalCurrentByIndex, 1, VitalKind.Health)).toBe(8);
+    // Target's affinity expression should still be Emit (not cleared)
+    expect(affinityExprOf(core, 1)).toBe(AffinityExpression.Emit);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #42 regression
+// ---------------------------------------------------------------------------
+
+describe("M3b: applyAttack PR #42 non-regression", () => {
+  test("applyAttack still reduces target Health and ignores affinity state", () => {
+    const core = buildTwoActorWorld();
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 2);
+    const result = call(
+      (core as Record<string, unknown>).applyAttack,
+      0, 1, 3,
+    );
+    expect(result).not.toBe(0);
+    expect(call(core.getMotivatedActorVitalCurrentByIndex, 1, VitalKind.Health)).toBe(7);
+    // mana unchanged — applyAttack does not touch affinity
+    expect(manaOf(core, 1)).toBe(10);
+    expect(affinityExprOf(core, 1)).toBe(AffinityExpression.Emit);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M3d regression — neutralised trap regens mana and comes back online
+// ---------------------------------------------------------------------------
+
+describe("M3d regression: neutralised trap mana regen via advanceTick", () => {
+  test("neutralised hazard with manaRegen=1 recovers mana over ticks", () => {
+    // Build a world with one actor and a Fire+Emit trap that has manaRegen=1
+    const core = createCore();
+    call(core.configureGrid, 7, 7);
+    for (let y = 1; y <= 5; y++) {
+      for (let x = 1; x <= 5; x++) {
+        call(core.setTileAt, x, y, 1);
+      }
+    }
+    call(core.addActorPlacement, 1, 1, 1);
+    call(core.applyActorPlacements);
+    call(core.setMotivatedActorVital, 0, VitalKind.Mana, 0, 10, 0);
+
+    // armStaticTrapAt with manaMax=4, manaRegen=1 (new M3d params at positions 10,11)
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 4,
+      0, 0, 0,   // durability: immortal
+      4, 1,      // manaMax=4, manaRegen=1
+    );
+
+    // Neutralise
+    call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(trapManaOf(core, 2, 1)).toBe(0);       // drained
+    expect(trapExistsAt(core, 2, 1)).toBe(true);  // structure intact
+
+    // Regen: needs 4 ticks at regen=1 to reach max=4
+    for (let t = 1; t <= 4; t++) {
+      call(core.advanceTick);
+      expect(trapManaOf(core, 2, 1)).toBe(t);
+    }
+    expect(trapManaOf(core, 2, 1)).toBe(4); // back to max
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: all 10 affinities — Pull vs matching Emit actor triggers neutralization
+// ---------------------------------------------------------------------------
+
+describe("permutations: all 10 kinds — Pull vs matching Emit actor neutralizes and clears expression", () => {
+  const ALL_KINDS = [
+    AffinityKind.Fire, AffinityKind.Water, AffinityKind.Earth, AffinityKind.Wind,
+    AffinityKind.Life, AffinityKind.Decay, AffinityKind.Corrode, AffinityKind.Fortify,
+    AffinityKind.Light, AffinityKind.Dark,
+  ];
+
+  test("neutralization triggers (return=1) and clears target expression for every AffinityKind", () => {
+    for (const kind of ALL_KINDS) {
+      const core = buildTwoActorWorld();
+      call(core.setMotivatedActorAffinity, 1, kind, AffinityExpression.Emit, 1);
+      const result = call(
+        (core as Record<string, unknown>).applyAffinityDamage,
+        0, 1, kind, AffinityExpression.Pull, 1,
+      ) as number;
+      expect(result).not.toBe(0);
+      expect(affinityExprOf(core, 1)).toBe(0); // expression cleared
+      expect(manaOf(core, 1)).toBe(0);         // mana drained
+    }
+  });
+
+  test("neutralization triggers for Push (not just Emit) as the target expression for every kind", () => {
+    for (const kind of ALL_KINDS) {
+      const core = buildTwoActorWorld();
+      call(core.setMotivatedActorAffinity, 1, kind, AffinityExpression.Push, 2);
+      const result = call(
+        (core as Record<string, unknown>).applyAffinityDamage,
+        0, 1, kind, AffinityExpression.Pull, 1,
+      ) as number;
+      expect(result).not.toBe(0);
+      expect(affinityExprOf(core, 1)).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: mismatched kind → normal matrix path, no mana drain
+// ---------------------------------------------------------------------------
+
+describe("permutations: Pull vs mismatched kind uses the matrix path, does not drain mana", () => {
+  test("for each kind K, Pull(K) vs target with Emit(K+1) does not neutralize", () => {
+    const KINDS = [
+      AffinityKind.Fire, AffinityKind.Water, AffinityKind.Earth, AffinityKind.Wind,
+      AffinityKind.Life, AffinityKind.Decay, AffinityKind.Corrode, AffinityKind.Fortify,
+      AffinityKind.Light, AffinityKind.Dark,
+    ];
+    for (let i = 0; i < KINDS.length; i++) {
+      const pullerKind = KINDS[i]!;
+      const targetKind = KINDS[(i + 1) % KINDS.length]!; // deliberately mismatched
+      const core = buildTwoActorWorld();
+      call(core.setMotivatedActorAffinity, 1, targetKind, AffinityExpression.Emit, 1);
+      call(
+        (core as Record<string, unknown>).applyAffinityDamage,
+        0, 1, pullerKind, AffinityExpression.Pull, 1,
+      );
+      // Expression must NOT be cleared — only neutralization (matching kind) clears it
+      // Note: some Pull affinities affect mana through the normal matrix path (e.g. Light+Pull
+      // drains mana), so we cannot assert manaOf unchanged — only the expression sentinel matters
+      expect(affinityExprOf(core, 1)).not.toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: minimal source mana — transfer=1, source goes to 0
+// ---------------------------------------------------------------------------
+
+describe("permutations: actor neutralization with minimal source mana (mana=1)", () => {
+  test("source mana=1: transfer=1, attacker gains 1, source goes to 0 (not negative)", () => {
+    const core = buildTwoActorWorld(
+      [1, 1], [2, 1],
+      { attackerVitals: { mana: 10, manaCurrent: 5 }, defenderVitals: { mana: 10, manaCurrent: 1 } },
+    );
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 1);
+    call((core as Record<string, unknown>).applyAffinityDamage, 0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1);
+    expect(manaOf(core, 0)).toBe(6); // 5 + 1
+    expect(manaOf(core, 1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: attacker already at max mana — transfer=0, neutralization still accepted
+// ---------------------------------------------------------------------------
+
+describe("permutations: attacker at max mana — transfer=0 but neutralization is still accepted", () => {
+  test("capacity=0: return=1, source mana drained to 0, attacker mana unchanged", () => {
+    const core = buildTwoActorWorld(
+      [1, 1], [2, 1],
+      { attackerVitals: { mana: 10, manaCurrent: 10 }, defenderVitals: { mana: 10, manaCurrent: 8 } },
+    );
+    call(core.setMotivatedActorAffinity, 1, AffinityKind.Fire, AffinityExpression.Emit, 1);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Pull, 1,
+    ) as number;
+    expect(result).not.toBe(0); // still accepted
+    expect(manaOf(core, 0)).toBe(10);  // attacker unchanged (already at max)
+    expect(manaOf(core, 1)).toBe(0);   // source drained regardless
+    expect(affinityExprOf(core, 1)).toBe(0); // expression cleared
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: applyAffinityPullFromHazard — all 10 kinds vs matching Emit trap
+// ---------------------------------------------------------------------------
+
+describe("permutations: applyAffinityPullFromHazard — all 10 AffinityKind values vs matching Emit trap", () => {
+  test("each kind: trap mana drained to 0, structure intact, mana transferred to attacker", () => {
+    const ALL_KINDS = [
+      AffinityKind.Fire, AffinityKind.Water, AffinityKind.Earth, AffinityKind.Wind,
+      AffinityKind.Life, AffinityKind.Decay, AffinityKind.Corrode, AffinityKind.Fortify,
+      AffinityKind.Light, AffinityKind.Dark,
+    ];
+    const TRAP_MANA = 4;
+    const ATTACKER_MANA_START = 2;
+    const ATTACKER_MANA_MAX = 10;
+
+    for (const kind of ALL_KINDS) {
+      const core = buildTrapWorld(
+        [1, 1], [3, 1], kind, AffinityExpression.Emit, 1, TRAP_MANA,
+        ATTACKER_MANA_MAX, ATTACKER_MANA_START,
+      );
+      const result = call(
+        (core as Record<string, unknown>).applyAffinityPullFromHazard,
+        0, 3, 1, kind, 1,
+      ) as number;
+      expect(result).not.toBe(0);                          // accepted
+      expect(trapManaOf(core, 3, 1)).toBe(0);             // mana drained
+      expect(trapExistsAt(core, 3, 1)).toBe(true);        // structure intact
+      expect(manaOf(core, 0)).toBe(ATTACKER_MANA_START + Math.min(TRAP_MANA, ATTACKER_MANA_MAX - ATTACKER_MANA_START));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: applyAffinityPullFromHazard — grid boundary cells (no off-by-one)
+// ---------------------------------------------------------------------------
+
+describe("permutations: applyAffinityPullFromHazard at grid boundary cells", () => {
+  test("trap at (1,1) — minimum corner of walkable area — is pulled successfully", () => {
+    const core = buildTrapWorld([2, 1], [1, 1], AffinityKind.Fire, AffinityExpression.Emit, 1, 5, 10, 2);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 1, 1, AffinityKind.Fire, 1,
+    ) as number;
+    expect(result).not.toBe(0);
+    expect(trapManaOf(core, 1, 1)).toBe(0);
+    expect(trapExistsAt(core, 1, 1)).toBe(true);
+  });
+
+  test("trap at (5,5) — maximum corner of walkable area — is pulled successfully", () => {
+    const core = buildTrapWorld([1, 1], [5, 5], AffinityKind.Dark, AffinityExpression.Emit, 1, 3, 10, 0);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 5, 5, AffinityKind.Dark, 1,
+    ) as number;
+    expect(result).not.toBe(0);
+    expect(trapManaOf(core, 5, 5)).toBe(0);
+    expect(trapExistsAt(core, 5, 5)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: sequential neutralization — two traps pulled in sequence
+// ---------------------------------------------------------------------------
+
+describe("permutations: sequential applyAffinityPullFromHazard on two traps accumulates mana", () => {
+  test("pulling two Fire traps in sequence: both drained, attacker gains from both (capped at max)", () => {
+    const core = createCore();
+    call(core.configureGrid, 7, 7);
+    for (let y = 1; y <= 5; y++) {
+      for (let x = 1; x <= 5; x++) call(core.setTileAt, x, y, 1);
+    }
+    call(core.addActorPlacement, 1, 1, 1);
+    call(core.applyActorPlacements);
+    call(core.setMotivatedActorVital, 0, VitalKind.Mana, 0, 10, 0);
+
+    call(core.armStaticTrapAt, 3, 1, AffinityKind.Fire, AffinityExpression.Emit, 1, 3);
+    call(core.armStaticTrapAt, 4, 1, AffinityKind.Fire, AffinityExpression.Emit, 1, 3);
+
+    call((core as Record<string, unknown>).applyAffinityPullFromHazard, 0, 3, 1, AffinityKind.Fire, 1);
+    expect(manaOf(core, 0)).toBe(3);
+    expect(trapManaOf(core, 3, 1)).toBe(0);
+    expect(trapExistsAt(core, 3, 1)).toBe(true);
+
+    call((core as Record<string, unknown>).applyAffinityPullFromHazard, 0, 4, 1, AffinityKind.Fire, 1);
+    expect(manaOf(core, 0)).toBe(6);
+    expect(trapManaOf(core, 4, 1)).toBe(0);
+    expect(trapExistsAt(core, 4, 1)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: stacks > 1 does not change transfer magnitude in applyAffinityPullFromHazard
+// ---------------------------------------------------------------------------
+
+describe("permutations: stacks parameter does not affect mana transfer magnitude in applyAffinityPullFromHazard", () => {
+  test("stacks=5 yields the same mana transfer as stacks=1 for the same trap", () => {
+    const TRAP_MANA = 6;
+    const ATTACKER_MAX = 10;
+
+    const core1 = buildTrapWorld([1, 1], [3, 1], AffinityKind.Water, AffinityExpression.Emit, 1, TRAP_MANA, ATTACKER_MAX, 0);
+    call((core1 as Record<string, unknown>).applyAffinityPullFromHazard, 0, 3, 1, AffinityKind.Water, 1);
+    const manaAfterStacks1 = manaOf(core1, 0);
+
+    const core5 = buildTrapWorld([1, 1], [3, 1], AffinityKind.Water, AffinityExpression.Emit, 1, TRAP_MANA, ATTACKER_MAX, 0);
+    call((core5 as Record<string, unknown>).applyAffinityPullFromHazard, 0, 3, 1, AffinityKind.Water, 5);
+    const manaAfterStacks5 = manaOf(core5, 0);
+
+    expect(manaAfterStacks1).toBe(manaAfterStacks5);
+    expect(manaAfterStacks5).toBe(TRAP_MANA); // full transfer fits
+  });
+});

--- a/tests/core-ts/affinity-vital-matrix.test.mts
+++ b/tests/core-ts/affinity-vital-matrix.test.mts
@@ -482,16 +482,211 @@ describe("affinity-vital matrix: stack scaling (linear for this milestone)", () 
   });
 });
 
-// ## TODO: Test Permutations
-//
-// 1. getAffinityVitalEffect across all 10 affinities × 4 expressions × 4 vitals × stacks ∈ {1, 2, 3, 5, 10}
-//    — assert no integer overflow within INT32 bounds
-// 2. Sign-reversal property holds at every stack count (push(s) = -pull(s) for all valid s, same vital)
-// 3. Polarity invariant: for each affinity, the SET of (expression, vital) cells with sign matches the affinity's polarity
-//    table exactly (push/emit share sign, pull/draw share opposite sign)
-// 4. Opposite-affinity pairs (Fire↔Water, Earth↔Wind, Life↔Decay, Corrode↔Fortify, Light↔Dark) produce
-//    matrix entries with opposite polarities on their shared/related primary vital where applicable
-// 5. scaleAffinityVitalEffect with extremely large stacks (e.g. 1_000_000) does not throw and returns a finite integer
-// 6. Calling getAffinityVitalEffectBase twice with the same args is referentially transparent (no hidden state)
-// 7. Helpers are not exposed via createCore() unless an api-surface test explicitly approves the addition
-//    (M3 may add them to CORE_API_KEYS — until then, they live only on the affinity.ts module)
+// ---------------------------------------------------------------------------
+// Permutations: no integer overflow across full matrix × stacks
+// ---------------------------------------------------------------------------
+
+describe("permutations: no integer overflow across full matrix × stacks", () => {
+  test("all 160 cells × stacks in {1,2,3,5,10} produce integers within INT32 bounds", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const INT32_MAX = 2 ** 31 - 1;
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const expr of ALL_EXPRESSIONS) {
+        for (const vital of ALL_VITALS) {
+          for (const stacks of [1, 2, 3, 5, 10]) {
+            const effect = call(getAffinityVitalEffect, kind, expr, vital, stacks) as number;
+            expect(Number.isInteger(effect)).toBe(true);
+            expect(Math.abs(effect)).toBeLessThanOrEqual(INT32_MAX);
+          }
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: sign-reversal — push(s) = −pull(s), emit(s) = −draw(s)
+// ---------------------------------------------------------------------------
+
+describe("permutations: sign-reversal property across all (kind, vital, stacks)", () => {
+  test("push(s) = −pull(s) for all (kind, vital) pairs at stacks ∈ {1,2,3,5}", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const vital of ALL_VITALS) {
+        for (const stacks of [1, 2, 3, 5]) {
+          const push = call(getAffinityVitalEffect, kind, AffinityExpression.Push, vital, stacks) as number;
+          const pull = call(getAffinityVitalEffect, kind, AffinityExpression.Pull, vital, stacks) as number;
+          expect(push + pull).toBe(0); // +0 vs -0 safe: avoids Object.is edge case on zero cells
+        }
+      }
+    }
+  });
+
+  test("emit(s) = −draw(s) for all (kind, vital) pairs at stacks ∈ {1,2,3,5}", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const vital of ALL_VITALS) {
+        for (const stacks of [1, 2, 3, 5]) {
+          const emit = call(getAffinityVitalEffect, kind, AffinityExpression.Emit, vital, stacks) as number;
+          const draw = call(getAffinityVitalEffect, kind, AffinityExpression.Draw, vital, stacks) as number;
+          expect(emit + draw).toBe(0); // +0 vs -0 safe: avoids Object.is edge case on zero cells
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: polarity invariant on primary vitals
+// ---------------------------------------------------------------------------
+
+describe("permutations: polarity invariant — push/emit carry polarity sign; pull/draw carry opposite", () => {
+  test("push and emit on the primary vital have the affinity's polarity sign for all 10 kinds", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      const { vital, polarity } = PRIMARY[kind as keyof typeof PRIMARY];
+      const push = call(getAffinityVitalEffect, kind, AffinityExpression.Push, vital, 1) as number;
+      const emit = call(getAffinityVitalEffect, kind, AffinityExpression.Emit, vital, 1) as number;
+      expect(Math.sign(push)).toBe(polarity);
+      expect(Math.sign(emit)).toBe(polarity);
+    }
+  });
+
+  test("pull and draw on the primary vital carry the opposite polarity sign for all 10 kinds", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      const { vital, polarity } = PRIMARY[kind as keyof typeof PRIMARY];
+      const pull = call(getAffinityVitalEffect, kind, AffinityExpression.Pull, vital, 1) as number;
+      const draw = call(getAffinityVitalEffect, kind, AffinityExpression.Draw, vital, 1) as number;
+      expect(Math.sign(pull)).toBe(-polarity);
+      expect(Math.sign(draw)).toBe(-polarity);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: opposite-affinity pairs produce opposite polarities on shared vitals
+// ---------------------------------------------------------------------------
+
+describe("permutations: opposite-affinity pairs have opposite push effects on their shared vital", () => {
+  test("Fire (−Health) vs Water (+Health): push(1) effects are negatives of each other", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const firePush  = call(getAffinityVitalEffect, AffinityKind.Fire,  AffinityExpression.Push, VitalKind.Health, 1) as number;
+    const waterPush = call(getAffinityVitalEffect, AffinityKind.Water, AffinityExpression.Push, VitalKind.Health, 1) as number;
+    expect(firePush).toBe(-waterPush);
+    expect(firePush).not.toBe(0);
+  });
+
+  test("Life (+Health) vs Decay (−Health): push(1) effects are negatives of each other", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const lifePush  = call(getAffinityVitalEffect, AffinityKind.Life,  AffinityExpression.Push, VitalKind.Health, 1) as number;
+    const decayPush = call(getAffinityVitalEffect, AffinityKind.Decay, AffinityExpression.Push, VitalKind.Health, 1) as number;
+    expect(lifePush).toBe(-decayPush);
+    expect(lifePush).not.toBe(0);
+  });
+
+  test("Corrode (−Durability) vs Fortify (+Durability): push(1) effects are negatives of each other", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const corrodePush = call(getAffinityVitalEffect, AffinityKind.Corrode, AffinityExpression.Push, VitalKind.Durability, 1) as number;
+    const fortifyPush = call(getAffinityVitalEffect, AffinityKind.Fortify, AffinityExpression.Push, VitalKind.Durability, 1) as number;
+    expect(corrodePush).toBe(-fortifyPush);
+    expect(corrodePush).not.toBe(0);
+  });
+
+  test("Light (+Mana) vs Dark (−Mana): push(1) effects are negatives of each other", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const lightPush = call(getAffinityVitalEffect, AffinityKind.Light, AffinityExpression.Push, VitalKind.Mana, 1) as number;
+    const darkPush  = call(getAffinityVitalEffect, AffinityKind.Dark,  AffinityExpression.Push, VitalKind.Mana, 1) as number;
+    expect(lightPush).toBe(-darkPush);
+    expect(lightPush).not.toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: large stacks safety
+// ---------------------------------------------------------------------------
+
+describe("permutations: large stacks do not throw and return finite integers", () => {
+  test("scaleAffinityVitalEffect(base, 1_000_000) returns a finite integer for all base values in {−2,−1,0,1,2}", async () => {
+    const { scaleAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const base of [-2, -1, 0, 1, 2]) {
+      const result = call(scaleAffinityVitalEffect, base, 1_000_000) as number;
+      expect(Number.isFinite(result)).toBe(true);
+      expect(Number.isInteger(result)).toBe(true);
+    }
+  });
+
+  test("getAffinityVitalEffect(kind, expr, vital, 1_000_000) returns a finite integer on all 160 cells", async () => {
+    const { getAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const expr of ALL_EXPRESSIONS) {
+        for (const vital of ALL_VITALS) {
+          const result = call(getAffinityVitalEffect, kind, expr, vital, 1_000_000) as number;
+          expect(Number.isFinite(result)).toBe(true);
+          expect(Number.isInteger(result)).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: referential transparency (no hidden state)
+// ---------------------------------------------------------------------------
+
+describe("permutations: getAffinityVitalEffectBase is referentially transparent", () => {
+  test("calling with the same (kind, expr, vital) twice returns the same value across all 160 cells", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const expr of ALL_EXPRESSIONS) {
+        for (const vital of ALL_VITALS) {
+          const first  = call(getAffinityVitalEffectBase, kind, expr, vital);
+          const second = call(getAffinityVitalEffectBase, kind, expr, vital);
+          expect(first).toBe(second);
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: helpers remain outside createCore() API surface
+// ---------------------------------------------------------------------------
+
+describe("permutations: affinity helpers are not exposed on createCore() return value", () => {
+  test("getAffinityVitalEffectBase is not present on the createCore() object", async () => {
+    const { createCore } = await import("../../packages/core-ts/src/index.ts");
+    const core = createCore();
+    expect((core as Record<string, unknown>).getAffinityVitalEffectBase).toBeUndefined();
+  });
+
+  test("scaleAffinityVitalEffect is not present on the createCore() object", async () => {
+    const { createCore } = await import("../../packages/core-ts/src/index.ts");
+    const core = createCore();
+    expect((core as Record<string, unknown>).scaleAffinityVitalEffect).toBeUndefined();
+  });
+});

--- a/tests/core-ts/affinity-vital-matrix.test.mts
+++ b/tests/core-ts/affinity-vital-matrix.test.mts
@@ -1,0 +1,497 @@
+/**
+ * M1 — Affinity × Expression × Vital matrix: failing tests
+ *
+ * These tests specify the shape and contents of a complete 10 × 4 × 4 matrix
+ * mapping (AffinityKind, AffinityExpression, VitalKind) → signed integer
+ * base magnitude, plus the pure scaling helpers that drive `effect = base * stacks`.
+ *
+ * Tests MUST FAIL until M2 implements:
+ *   - getAffinityVitalEffectBase(kind, expression, vital): signed base magnitude (can be 0)
+ *   - scaleAffinityVitalEffect(base, stacks): formula multiplier (linear for this milestone)
+ *   - getAffinityVitalEffect(kind, expression, vital, stacks): convenience = scale(base, stacks)
+ *
+ * Implementation matrix (from M1 contract, Codex defaults):
+ *   - Base magnitudes: push/pull = 2, emit/draw = 1
+ *   - Each affinity has 4 non-zero cells (its primary vital × 4 expressions)
+ *   - All other cells = explicit 0
+ *   - Per-affinity polarity (positive sign = buff, negative sign = drain):
+ *       Fire    → -Health (drain)        Decay   → -Health (drain)
+ *       Water   → +Health (buff)         Life    → +Health (buff)
+ *       Wind    → -Stamina (drain)       Earth   → +Durability (buff)
+ *       Corrode → -Durability (drain)    Fortify → +Durability (buff)
+ *       Dark    → -Mana (drain)          Light   → +Mana (buff)
+ *   - Push and Emit carry the polarity sign on the primary vital.
+ *   - Pull and Draw carry the OPPOSITE sign on the same vital (sign-reversal pair).
+ *   - Stacks scale linearly: effect = base * stacks.
+ *
+ * Architecture: core-ts only — no runtime, no IO, no clocks.
+ */
+import { describe, expect, test } from "vitest";
+
+import {
+  AffinityExpression,
+  AffinityKind,
+} from "../../packages/core-ts/src/state/affinity.ts";
+import { VitalKind } from "../../packages/core-ts/src/state/vitals.ts";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AFFINITY_KIND_COUNT = 10;
+const AFFINITY_EXPRESSION_COUNT = 4;
+const VITAL_COUNT = 4;
+
+const ALL_AFFINITY_KINDS = Object.values(AffinityKind);
+const ALL_EXPRESSIONS = Object.values(AffinityExpression);
+const ALL_VITALS = Object.values(VitalKind);
+
+// Primary vital + polarity per affinity (push/emit carry this sign).
+// pull/draw invert the sign on the same vital.
+const PRIMARY = {
+  [AffinityKind.Fire]:    { vital: VitalKind.Health,     polarity: -1 },
+  [AffinityKind.Water]:   { vital: VitalKind.Health,     polarity: +1 },
+  [AffinityKind.Earth]:   { vital: VitalKind.Durability, polarity: +1 },
+  [AffinityKind.Wind]:    { vital: VitalKind.Stamina,    polarity: -1 },
+  [AffinityKind.Life]:    { vital: VitalKind.Health,     polarity: +1 },
+  [AffinityKind.Decay]:   { vital: VitalKind.Health,     polarity: -1 },
+  [AffinityKind.Corrode]: { vital: VitalKind.Durability, polarity: -1 },
+  [AffinityKind.Fortify]: { vital: VitalKind.Durability, polarity: +1 },
+  [AffinityKind.Light]:   { vital: VitalKind.Mana,       polarity: +1 },
+  [AffinityKind.Dark]:    { vital: VitalKind.Mana,       polarity: -1 },
+} as const;
+
+const BASE_PUSH_PULL = 2; // single-target discrete intensity
+const BASE_EMIT_DRAW = 1; // diffuse area per-target intensity
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function call(fn: unknown, ...args: unknown[]): unknown {
+  if (typeof fn !== "function") {
+    throw new Error("expected callable export — M2 must implement this");
+  }
+  return fn(...args);
+}
+
+/** Expected base for any (kind, expression, vital) cell. 0 if not the primary vital. */
+function expectedBase(kind: number, expression: number, vital: number): number {
+  const primary = PRIMARY[kind as keyof typeof PRIMARY];
+  if (!primary || primary.vital !== vital) return 0;
+  const magnitude = (expression === AffinityExpression.Push || expression === AffinityExpression.Pull)
+    ? BASE_PUSH_PULL
+    : BASE_EMIT_DRAW;
+  const isReversed = expression === AffinityExpression.Pull || expression === AffinityExpression.Draw;
+  const sign = isReversed ? -primary.polarity : primary.polarity;
+  return sign * magnitude;
+}
+
+// ---------------------------------------------------------------------------
+// API presence (drives M2 implementation)
+// ---------------------------------------------------------------------------
+
+describe("affinity-vital matrix: API surface", () => {
+  test("getAffinityVitalEffectBase is exported from state/affinity.ts", async () => {
+    const mod = await import("../../packages/core-ts/src/state/affinity.ts");
+    expect(typeof (mod as Record<string, unknown>).getAffinityVitalEffectBase).toBe("function");
+  });
+
+  test("scaleAffinityVitalEffect is exported from state/affinity.ts", async () => {
+    const mod = await import("../../packages/core-ts/src/state/affinity.ts");
+    expect(typeof (mod as Record<string, unknown>).scaleAffinityVitalEffect).toBe("function");
+  });
+
+  test("getAffinityVitalEffect is exported from state/affinity.ts", async () => {
+    const mod = await import("../../packages/core-ts/src/state/affinity.ts");
+    expect(typeof (mod as Record<string, unknown>).getAffinityVitalEffect).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Matrix shape — 160 addressable cells
+// ---------------------------------------------------------------------------
+
+describe("affinity-vital matrix: shape", () => {
+  test("matrix is 10 affinities × 4 expressions × 4 vitals = 160 cells", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    let count = 0;
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const expr of ALL_EXPRESSIONS) {
+        for (const vital of ALL_VITALS) {
+          const v = call(getAffinityVitalEffectBase, kind, expr, vital);
+          expect(typeof v).toBe("number");
+          count++;
+        }
+      }
+    }
+    expect(count).toBe(AFFINITY_KIND_COUNT * AFFINITY_EXPRESSION_COUNT * VITAL_COUNT);
+    expect(count).toBe(160);
+  });
+
+  test("every (kind, expression, vital) cell returns an integer (0 for no-effect)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const expr of ALL_EXPRESSIONS) {
+        for (const vital of ALL_VITALS) {
+          const v = call(getAffinityVitalEffectBase, kind, expr, vital) as number;
+          expect(Number.isInteger(v)).toBe(true);
+        }
+      }
+    }
+  });
+
+  test("invalid affinity kind returns 0 (out-of-band sentinel)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    expect(call(getAffinityVitalEffectBase, 0, AffinityExpression.Push, VitalKind.Health)).toBe(0);
+    expect(call(getAffinityVitalEffectBase, 99, AffinityExpression.Push, VitalKind.Health)).toBe(0);
+    expect(call(getAffinityVitalEffectBase, -1, AffinityExpression.Push, VitalKind.Health)).toBe(0);
+  });
+
+  test("invalid expression returns 0", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    expect(call(getAffinityVitalEffectBase, AffinityKind.Fire, 0, VitalKind.Health)).toBe(0);
+    expect(call(getAffinityVitalEffectBase, AffinityKind.Fire, 99, VitalKind.Health)).toBe(0);
+  });
+
+  test("invalid vital returns 0", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    expect(call(getAffinityVitalEffectBase, AffinityKind.Fire, AffinityExpression.Push, 99)).toBe(0);
+    expect(call(getAffinityVitalEffectBase, AffinityKind.Fire, AffinityExpression.Push, -1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "No effect" matrix cells — explicit 0 (not null/undefined/omitted)
+// ---------------------------------------------------------------------------
+
+describe("affinity-vital matrix: no-effect cells stored as explicit 0", () => {
+  test("decay on durability is 0 (worked example: decay must not affect durability)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const expr of ALL_EXPRESSIONS) {
+      const v = call(getAffinityVitalEffectBase, AffinityKind.Decay, expr, VitalKind.Durability);
+      expect(v).toBe(0);
+    }
+  });
+
+  test("fire on mana is 0 (not in primary mapping)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const expr of ALL_EXPRESSIONS) {
+      const v = call(getAffinityVitalEffectBase, AffinityKind.Fire, expr, VitalKind.Mana);
+      expect(v).toBe(0);
+    }
+  });
+
+  test("for any affinity, exactly one vital (its primary) is non-zero across all expressions", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      const nonZeroVitals = new Set<number>();
+      for (const vital of ALL_VITALS) {
+        for (const expr of ALL_EXPRESSIONS) {
+          if ((call(getAffinityVitalEffectBase, kind, expr, vital) as number) !== 0) {
+            nonZeroVitals.add(vital);
+          }
+        }
+      }
+      expect(nonZeroVitals.size).toBe(1);
+      const expected = PRIMARY[kind as keyof typeof PRIMARY]?.vital;
+      expect([...nonZeroVitals][0]).toBe(expected);
+    }
+  });
+
+  test("aggregate: exactly 40 of 160 cells are non-zero (10 affinities × 4 expressions each on primary vital)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    let nonZero = 0;
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const expr of ALL_EXPRESSIONS) {
+        for (const vital of ALL_VITALS) {
+          if ((call(getAffinityVitalEffectBase, kind, expr, vital) as number) !== 0) {
+            nonZero++;
+          }
+        }
+      }
+    }
+    expect(nonZero).toBe(40);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worked examples from the M1 contract
+// ---------------------------------------------------------------------------
+
+describe("affinity-vital matrix: worked examples from M1 contract", () => {
+  test("decay+push drains health (negative on Health)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const v = call(getAffinityVitalEffectBase, AffinityKind.Decay, AffinityExpression.Push, VitalKind.Health) as number;
+    expect(v).toBeLessThan(0);
+    expect(v).toBe(-BASE_PUSH_PULL);
+  });
+
+  test("corrode+push drains durability (negative on Durability)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const v = call(getAffinityVitalEffectBase, AffinityKind.Corrode, AffinityExpression.Push, VitalKind.Durability) as number;
+    expect(v).toBe(-BASE_PUSH_PULL);
+  });
+
+  test("fortify+push buffs durability (positive on Durability)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const v = call(getAffinityVitalEffectBase, AffinityKind.Fortify, AffinityExpression.Push, VitalKind.Durability) as number;
+    expect(v).toBe(+BASE_PUSH_PULL);
+  });
+
+  test("life+push buffs health, life+pull drains health (equal magnitude, opposite sign)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const push = call(getAffinityVitalEffectBase, AffinityKind.Life, AffinityExpression.Push, VitalKind.Health) as number;
+    const pull = call(getAffinityVitalEffectBase, AffinityKind.Life, AffinityExpression.Pull, VitalKind.Health) as number;
+    expect(push).toBe(+BASE_PUSH_PULL);
+    expect(pull).toBe(-BASE_PUSH_PULL);
+    expect(push).toBe(-pull);
+  });
+
+  test("life+emit is a group ambient heal (positive on Health, diffuse magnitude)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const v = call(getAffinityVitalEffectBase, AffinityKind.Life, AffinityExpression.Emit, VitalKind.Health) as number;
+    expect(v).toBe(+BASE_EMIT_DRAW);
+  });
+
+  test("wind+push affects stamina (negative on Stamina, area-denial intent)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const v = call(getAffinityVitalEffectBase, AffinityKind.Wind, AffinityExpression.Push, VitalKind.Stamina) as number;
+    expect(v).toBe(-BASE_PUSH_PULL);
+  });
+
+  test("earth+push and earth+emit are both durability buffs", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const push = call(getAffinityVitalEffectBase, AffinityKind.Earth, AffinityExpression.Push, VitalKind.Durability) as number;
+    const emit = call(getAffinityVitalEffectBase, AffinityKind.Earth, AffinityExpression.Emit, VitalKind.Durability) as number;
+    expect(push).toBe(+BASE_PUSH_PULL);
+    expect(emit).toBe(+BASE_EMIT_DRAW);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sign-reversal pattern — push↔pull and emit↔draw on the same vital
+// ---------------------------------------------------------------------------
+
+describe("affinity-vital matrix: sign-reversal pairs", () => {
+  test("push and pull always have opposite signs and equal magnitude on the primary vital", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      const vital = PRIMARY[kind as keyof typeof PRIMARY].vital;
+      const push = call(getAffinityVitalEffectBase, kind, AffinityExpression.Push, vital) as number;
+      const pull = call(getAffinityVitalEffectBase, kind, AffinityExpression.Pull, vital) as number;
+      expect(push).toBe(-pull);
+      expect(Math.abs(push)).toBe(BASE_PUSH_PULL);
+    }
+  });
+
+  test("emit and draw always have opposite signs and equal magnitude on the primary vital", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      const vital = PRIMARY[kind as keyof typeof PRIMARY].vital;
+      const emit = call(getAffinityVitalEffectBase, kind, AffinityExpression.Emit, vital) as number;
+      const draw = call(getAffinityVitalEffectBase, kind, AffinityExpression.Draw, vital) as number;
+      expect(emit).toBe(-draw);
+      expect(Math.abs(emit)).toBe(BASE_EMIT_DRAW);
+    }
+  });
+
+  test("push/emit share polarity sign on the primary vital (both reflect the affinity's intrinsic polarity)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      const vital = PRIMARY[kind as keyof typeof PRIMARY].vital;
+      const push = call(getAffinityVitalEffectBase, kind, AffinityExpression.Push, vital) as number;
+      const emit = call(getAffinityVitalEffectBase, kind, AffinityExpression.Emit, vital) as number;
+      expect(Math.sign(push)).toBe(Math.sign(emit));
+    }
+  });
+
+  test("emit per-target intensity is strictly lower than push for the same affinity (diffuse trade-off)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      const vital = PRIMARY[kind as keyof typeof PRIMARY].vital;
+      const push = call(getAffinityVitalEffectBase, kind, AffinityExpression.Push, vital) as number;
+      const emit = call(getAffinityVitalEffectBase, kind, AffinityExpression.Emit, vital) as number;
+      expect(Math.abs(emit)).toBeLessThan(Math.abs(push));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Every-vital drain + buff coverage
+// ---------------------------------------------------------------------------
+
+describe("affinity-vital matrix: every vital is both drainable and buffable", () => {
+  test("each vital has at least one (kind, expression) pair that drains (negative effect)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const vital of ALL_VITALS) {
+      let found = false;
+      outer: for (const kind of ALL_AFFINITY_KINDS) {
+        for (const expr of ALL_EXPRESSIONS) {
+          if ((call(getAffinityVitalEffectBase, kind, expr, vital) as number) < 0) {
+            found = true;
+            break outer;
+          }
+        }
+      }
+      expect(found, `vital ${vital} must have at least one draining pair`).toBe(true);
+    }
+  });
+
+  test("each vital has at least one (kind, expression) pair that buffs (positive effect)", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const vital of ALL_VITALS) {
+      let found = false;
+      outer: for (const kind of ALL_AFFINITY_KINDS) {
+        for (const expr of ALL_EXPRESSIONS) {
+          if ((call(getAffinityVitalEffectBase, kind, expr, vital) as number) > 0) {
+            found = true;
+            break outer;
+          }
+        }
+      }
+      expect(found, `vital ${vital} must have at least one buffing pair`).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Matrix conforms to expected per-cell values (exhaustive ground truth)
+// ---------------------------------------------------------------------------
+
+describe("affinity-vital matrix: exhaustive ground-truth verification", () => {
+  test("every cell matches the polarity-driven expectedBase()", async () => {
+    const { getAffinityVitalEffectBase } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    const mismatches: string[] = [];
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const expr of ALL_EXPRESSIONS) {
+        for (const vital of ALL_VITALS) {
+          const actual = call(getAffinityVitalEffectBase, kind, expr, vital) as number;
+          const expected = expectedBase(kind, expr, vital);
+          if (actual !== expected) {
+            mismatches.push(`(kind=${kind}, expr=${expr}, vital=${vital}): expected ${expected}, got ${actual}`);
+          }
+        }
+      }
+    }
+    expect(mismatches, `matrix has ${mismatches.length} mismatched cells:\n${mismatches.slice(0, 5).join("\n")}`).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stack scaling helpers
+// ---------------------------------------------------------------------------
+
+describe("affinity-vital matrix: stack scaling (linear for this milestone)", () => {
+  test("scaleAffinityVitalEffect(base, stacks) returns base * stacks for positive stacks", async () => {
+    const { scaleAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    expect(call(scaleAffinityVitalEffect, 2, 1)).toBe(2);
+    expect(call(scaleAffinityVitalEffect, 2, 3)).toBe(6);
+    expect(call(scaleAffinityVitalEffect, 1, 5)).toBe(5);
+    expect(call(scaleAffinityVitalEffect, -2, 4)).toBe(-8);
+  });
+
+  test("scaleAffinityVitalEffect with stacks=0 returns 0", async () => {
+    const { scaleAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    expect(call(scaleAffinityVitalEffect, 2, 0)).toBe(0);
+    expect(call(scaleAffinityVitalEffect, -2, 0)).toBe(0);
+  });
+
+  test("scaleAffinityVitalEffect with base=0 always returns 0 regardless of stacks", async () => {
+    const { scaleAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    expect(call(scaleAffinityVitalEffect, 0, 0)).toBe(0);
+    expect(call(scaleAffinityVitalEffect, 0, 5)).toBe(0);
+    expect(call(scaleAffinityVitalEffect, 0, 100)).toBe(0);
+  });
+
+  test("scaleAffinityVitalEffect rejects negative stacks (returns 0)", async () => {
+    const { scaleAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    expect(call(scaleAffinityVitalEffect, 2, -1)).toBe(0);
+    expect(call(scaleAffinityVitalEffect, 2, -5)).toBe(0);
+  });
+
+  test("getAffinityVitalEffect is the composition: scale(getBase(...), stacks)", async () => {
+    const { getAffinityVitalEffect, getAffinityVitalEffectBase, scaleAffinityVitalEffect } = await import(
+      "../../packages/core-ts/src/state/affinity.ts"
+    );
+    for (const kind of ALL_AFFINITY_KINDS) {
+      for (const expr of ALL_EXPRESSIONS) {
+        for (const vital of ALL_VITALS) {
+          for (const stacks of [0, 1, 2, 5]) {
+            const composed = call(scaleAffinityVitalEffect, call(getAffinityVitalEffectBase, kind, expr, vital), stacks);
+            const direct = call(getAffinityVitalEffect, kind, expr, vital, stacks);
+            expect(direct).toBe(composed);
+          }
+        }
+      }
+    }
+  });
+});
+
+// ## TODO: Test Permutations
+//
+// 1. getAffinityVitalEffect across all 10 affinities × 4 expressions × 4 vitals × stacks ∈ {1, 2, 3, 5, 10}
+//    — assert no integer overflow within INT32 bounds
+// 2. Sign-reversal property holds at every stack count (push(s) = -pull(s) for all valid s, same vital)
+// 3. Polarity invariant: for each affinity, the SET of (expression, vital) cells with sign matches the affinity's polarity
+//    table exactly (push/emit share sign, pull/draw share opposite sign)
+// 4. Opposite-affinity pairs (Fire↔Water, Earth↔Wind, Life↔Decay, Corrode↔Fortify, Light↔Dark) produce
+//    matrix entries with opposite polarities on their shared/related primary vital where applicable
+// 5. scaleAffinityVitalEffect with extremely large stacks (e.g. 1_000_000) does not throw and returns a finite integer
+// 6. Calling getAffinityVitalEffectBase twice with the same args is referentially transparent (no hidden state)
+// 7. Helpers are not exposed via createCore() unless an api-surface test explicitly approves the addition
+//    (M3 may add them to CORE_API_KEYS — until then, they live only on the affinity.ts module)

--- a/tests/core-ts/hazard-durability.test.mts
+++ b/tests/core-ts/hazard-durability.test.mts
@@ -1,0 +1,789 @@
+/**
+ * M3c — Hazard Durability + Destruction: failing tests
+ *
+ * Static traps gain a durability vital (current / max / regen).
+ * Durability-routing affinities (Earth, Corrode, Fortify) applied via
+ * `applyAffinityDamageToHazard` drain or buff hazard durability.
+ * When durability reaches 0 the trap is destroyed (disarmed).
+ *
+ * Design choices encoded here:
+ *   - `armStaticTrapAt` gains three optional trailing params for durability:
+ *       armStaticTrapAt(x, y, kind, expr, stacks, mana, durCurrent?, durMax?, durRegen?)
+ *   - durabilityMax == 0 → "immortal" trap; durability damage is rejected (0)
+ *   - `applyAffinityDamageToHazard(attackerIndex, hazardX, hazardY, kind, expr, stacks)`
+ *       routes only affinities that target VitalKind.Durability; others return 0
+ *   - Push/Pull enforce Chebyshev range ≤ stacks from attacker to (hazardX, hazardY)
+ *
+ * Tests MUST FAIL until M3c implements:
+ *   1. Per-trap durability arrays in `packages/core-ts/src/state/world.ts`
+ *   2. `armStaticTrapAt` extended with optional durability params
+ *   3. Getters: `getStaticTrapDurabilityAt`, `getStaticTrapDurabilityMaxAt`,
+ *      `getStaticTrapDurabilityRegenAt`
+ *   4. `applyAffinityDamageToHazard` in `packages/core-ts/src/rules/affinity-damage.ts`
+ *   5. All new symbols wired into `createCore()` with `CORE_API_KEYS` alphabetical
+ */
+import { describe, expect, test } from "vitest";
+import { createCore } from "../../packages/core-ts/src/index.ts";
+import {
+  AffinityExpression,
+  AffinityKind,
+} from "../../packages/core-ts/src/state/affinity.ts";
+import { VitalKind } from "../../packages/core-ts/src/state/vitals.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function call(fn: unknown, ...args: unknown[]): unknown {
+  if (typeof fn !== "function") {
+    throw new Error("expected callable core export — M3c must wire this");
+  }
+  return fn(...args);
+}
+
+type Core = ReturnType<typeof createCore>;
+
+/** 7×7 floor grid with a single actor at actorXY. */
+function buildActorWorld(
+  actorXY: [number, number] = [1, 1],
+  actorManaMax = 10,
+  actorManaCurrent = 10,
+): Core {
+  const core = createCore();
+  call(core.configureGrid, 7, 7);
+  for (let y = 1; y <= 5; y++) {
+    for (let x = 1; x <= 5; x++) {
+      call(core.setTileAt, x, y, 1);
+    }
+  }
+  call(core.addActorPlacement, 1, ...actorXY);
+  call(core.applyActorPlacements);
+  call(core.setMotivatedActorVital, 0, VitalKind.Health,     10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Mana,       actorManaCurrent, actorManaMax, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Stamina,    10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Durability,  5,  5, 0);
+  return core;
+}
+
+/** 7×7 world with actor at actorXY and a trap at trapXY with given durability config. */
+function buildActorTrapWorld(
+  actorXY: [number, number],
+  trapXY: [number, number],
+  trapKind: number,
+  trapExpr: number,
+  trapStacks: number,
+  trapMana: number,
+  durCurrent: number,
+  durMax: number,
+  durRegen: number,
+): Core {
+  const core = buildActorWorld(actorXY);
+  call(
+    core.armStaticTrapAt,
+    ...trapXY, trapKind, trapExpr, trapStacks, trapMana,
+    durCurrent, durMax, durRegen,
+  );
+  return core;
+}
+
+/** Also builds two actor world with a trap (for regression testing). */
+function buildTwoActorTrapWorld(
+  attackerXY: [number, number] = [1, 1],
+  defenderXY: [number, number] = [2, 1],
+  trapXY: [number, number] = [3, 1],
+): Core {
+  const core = createCore();
+  call(core.configureGrid, 7, 7);
+  for (let y = 1; y <= 5; y++) {
+    for (let x = 1; x <= 5; x++) {
+      call(core.setTileAt, x, y, 1);
+    }
+  }
+  call(core.addActorPlacement, 1, ...attackerXY);
+  call(core.addActorPlacement, 2, ...defenderXY);
+  call(core.applyActorPlacements);
+  for (const idx of [0, 1]) {
+    call(core.setMotivatedActorVital, idx, VitalKind.Health,     10, 10, 0);
+    call(core.setMotivatedActorVital, idx, VitalKind.Mana,       10, 10, 0);
+    call(core.setMotivatedActorVital, idx, VitalKind.Stamina,    10, 10, 0);
+    call(core.setMotivatedActorVital, idx, VitalKind.Durability,  5,  5, 0);
+  }
+  // Trap with durability 6/6
+  call(core.armStaticTrapAt, ...trapXY,
+    AffinityKind.Corrode, AffinityExpression.Push, 1, 5,
+    6, 6, 0,
+  );
+  return core;
+}
+
+function durOf(core: Core, x: number, y: number): number {
+  return call(core.getStaticTrapDurabilityAt, x, y) as number;
+}
+
+function durMaxOf(core: Core, x: number, y: number): number {
+  return call(core.getStaticTrapDurabilityMaxAt, x, y) as number;
+}
+
+function durRegenOf(core: Core, x: number, y: number): number {
+  return call(core.getStaticTrapDurabilityRegenAt, x, y) as number;
+}
+
+function trapExists(core: Core, x: number, y: number): boolean {
+  return (call(core.getStaticTrapAffinityAt, x, y) as number) > 0;
+}
+
+function actorDurOf(core: Core, idx: number): number {
+  return call(core.getMotivatedActorVitalCurrentByIndex, idx, VitalKind.Durability) as number;
+}
+
+// ---------------------------------------------------------------------------
+// API presence
+// ---------------------------------------------------------------------------
+
+describe("M3c API surface", () => {
+  test("getStaticTrapDurabilityAt is exported from createCore()", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).getStaticTrapDurabilityAt).toBe("function");
+  });
+
+  test("getStaticTrapDurabilityMaxAt is exported from createCore()", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).getStaticTrapDurabilityMaxAt).toBe("function");
+  });
+
+  test("getStaticTrapDurabilityRegenAt is exported from createCore()", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).getStaticTrapDurabilityRegenAt).toBe("function");
+  });
+
+  test("applyAffinityDamageToHazard is exported from createCore()", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).applyAffinityDamageToHazard).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Spawn-time durability configuration
+// ---------------------------------------------------------------------------
+
+describe("armStaticTrapAt: durability configuration", () => {
+  test("arm with (5, 5, 0) → getters return correct values", () => {
+    const core = buildActorWorld([1, 1]);
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      5, 5, 0,
+    );
+    expect(durOf(core, 2, 1)).toBe(5);
+    expect(durMaxOf(core, 2, 1)).toBe(5);
+    expect(durRegenOf(core, 2, 1)).toBe(0);
+  });
+
+  test("arm with (3, 10, 1) → getters return correct values", () => {
+    const core = buildActorWorld([1, 1]);
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 2, 4,
+      3, 10, 1,
+    );
+    expect(durOf(core, 2, 1)).toBe(3);
+    expect(durMaxOf(core, 2, 1)).toBe(10);
+    expect(durRegenOf(core, 2, 1)).toBe(1);
+  });
+
+  test("arm with (0, 0, 0) → immortal trap; getters return 0/0/0", () => {
+    const core = buildActorWorld([1, 1]);
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 3,
+      0, 0, 0,
+    );
+    expect(durOf(core, 2, 1)).toBe(0);
+    expect(durMaxOf(core, 2, 1)).toBe(0);
+    expect(durRegenOf(core, 2, 1)).toBe(0);
+  });
+
+  test("arm without durability params (legacy 6-arg call) → durability defaults to 0/0/0", () => {
+    const core = buildActorWorld([1, 1]);
+    // Original 6-arg call — must still work (no breaking change)
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+    );
+    expect(durOf(core, 2, 1)).toBe(0);
+    expect(durMaxOf(core, 2, 1)).toBe(0);
+  });
+
+  test("getStaticTrapDurabilityAt returns 0 for a cell with no trap", () => {
+    const core = buildActorWorld([1, 1]);
+    expect(durOf(core, 4, 4)).toBe(0);
+  });
+
+  test("disarm clears durability getters", () => {
+    const core = buildActorWorld([1, 1]);
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      8, 8, 1,
+    );
+    call(core.disarmStaticTrapAt, 2, 1);
+    expect(durOf(core, 2, 1)).toBe(0);
+    expect(durMaxOf(core, 2, 1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyAffinityDamageToHazard: durability routing
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamageToHazard: durability drain (Corrode+Push)", () => {
+  test("Corrode+Push at stacks=1 drains hazard durability by 2", () => {
+    // actor at (1,1), trap at (2,1), durability 6/6, Corrode push range=1
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      6, 6, 0,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(result).not.toBe(0);
+    expect(durOf(core, 2, 1)).toBe(4); // 6 - 2
+  });
+
+  test("Corrode+Push at stacks=2 drains durability by 4", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      10, 10, 0,
+    );
+    call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 2,
+    );
+    expect(durOf(core, 2, 1)).toBe(6); // 10 - 4
+  });
+
+  test("Corrode+Pull BUFFS hazard durability (sign-reversed)", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      3, 10, 0,
+    );
+    call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Pull, 1,
+    );
+    expect(durOf(core, 2, 1)).toBe(5); // 3 + 2
+  });
+
+  test("Fortify+Push buffs hazard durability by 2 per stack", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      2, 10, 0,
+    );
+    call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Fortify, AffinityExpression.Push, 1,
+    );
+    expect(durOf(core, 2, 1)).toBe(4); // 2 + 2
+  });
+
+  test("buff clamps at durabilityMax", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      9, 10, 0,
+    );
+    call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Fortify, AffinityExpression.Push, 5, // +10 vs max 10
+    );
+    expect(durOf(core, 2, 1)).toBe(10); // clamped at max
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Destruction rule
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamageToHazard: destruction (durability reaches 0)", () => {
+  test("lethal Corrode+Push destroys the trap (durability to 0 → disarmed)", () => {
+    // trap durability 3/3, Corrode+Push stacks=2 → -4 → clamp to 0 → destroyed
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      3, 3, 0,
+    );
+    call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 2,
+    );
+    expect(trapExists(core, 2, 1)).toBe(false); // trap disarmed
+  });
+
+  test("after destruction, durability getters return 0", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      2, 2, 0,
+    );
+    call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 2,
+    );
+    expect(durOf(core, 2, 1)).toBe(0);
+    expect(durMaxOf(core, 2, 1)).toBe(0);
+  });
+
+  test("subsequent operation against destroyed cell is rejected (0)", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      1, 1, 0,
+    );
+    // First hit destroys
+    call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    // Second hit should be rejected
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+  });
+
+  test("non-lethal hit leaves trap armed", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      5, 5, 0,
+    );
+    call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1, // -2 → durability 3
+    );
+    expect(trapExists(core, 2, 1)).toBe(true);
+    expect(durOf(core, 2, 1)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Immortal trap (durabilityMax == 0)
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamageToHazard: immortal trap (durabilityMax == 0)", () => {
+  test("Corrode+Push against immortal trap (max=0) is rejected (0)", () => {
+    // arm with (0,0,0) durability — immortal
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 5,
+      0, 0, 0,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+    expect(trapExists(core, 2, 1)).toBe(true); // still armed
+  });
+
+  test("legacy-armed trap (no durability params) is also immortal", () => {
+    const core = buildActorWorld([1, 1]);
+    call(core.armStaticTrapAt, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1, 5);
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+    expect(trapExists(core, 2, 1)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Range semantics (Push/Pull)
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamageToHazard: range semantics", () => {
+  test("Push at stacks=1 accepted when trap is 1 tile away (Chebyshev = 1)", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 5,
+      4, 4, 0,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(result).not.toBe(0);
+  });
+
+  test("Push at stacks=1 rejected when trap is 2 tiles away", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [3, 1],
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 5,
+      4, 4, 0,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 3, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+    expect(durOf(core, 3, 1)).toBe(4); // unchanged
+  });
+
+  test("Emit has no range constraint", () => {
+    // actor at (1,1), trap at (5,5), Chebyshev = 4, Emit ignores range
+    const core = buildActorTrapWorld(
+      [1, 1], [5, 5],
+      AffinityKind.Corrode, AffinityExpression.Emit, 1, 5,
+      6, 6, 0,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 5, 5, AffinityKind.Corrode, AffinityExpression.Emit, 1,
+    );
+    expect(result).not.toBe(0);
+    expect(durOf(core, 5, 5)).toBe(5); // 6 - 1 (emit base = 1)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routing isolation
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamageToHazard: routing isolation", () => {
+  test("Fire+Push (routes to Health) targeting hazard is rejected (0) — hazards have no Health", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      4, 4, 0,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    expect(result).toBe(0);
+    expect(durOf(core, 2, 1)).toBe(4); // unchanged
+  });
+
+  test("applyAffinityDamage (actor target) Corrode+Push still drains actor durability, not hazard", () => {
+    const core = buildTwoActorTrapWorld([1, 1], [2, 1], [3, 1]);
+    const trapDurBefore = durOf(core, 3, 1);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    // Actor 1's durability is drained
+    expect(actorDurOf(core, 1)).toBe(3); // 5 - 2
+    // Trap durability is untouched
+    expect(durOf(core, 3, 1)).toBe(trapDurBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection cases
+// ---------------------------------------------------------------------------
+
+describe("applyAffinityDamageToHazard: rejection cases", () => {
+  test("invalid attacker index → 0", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1], AffinityKind.Corrode, AffinityExpression.Push, 1, 5, 6, 6, 0,
+    );
+    expect(call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      99, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    )).toBe(0);
+  });
+
+  test("invalid affinity kind → 0", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1], AffinityKind.Corrode, AffinityExpression.Push, 1, 5, 6, 6, 0,
+    );
+    expect(call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, 99, AffinityExpression.Push, 1,
+    )).toBe(0);
+  });
+
+  test("invalid expression → 0", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1], AffinityKind.Corrode, AffinityExpression.Push, 1, 5, 6, 6, 0,
+    );
+    expect(call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, 99, 1,
+    )).toBe(0);
+  });
+
+  test("zero stacks → 0", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1], AffinityKind.Corrode, AffinityExpression.Push, 1, 5, 6, 6, 0,
+    );
+    expect(call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 0,
+    )).toBe(0);
+  });
+
+  test("no trap at target cell → 0", () => {
+    const core = buildActorWorld([1, 1]);
+    expect(call(
+      (core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 3, 3, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    )).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #42 + M3b regression
+// ---------------------------------------------------------------------------
+
+describe("M3c: prior milestone non-regression", () => {
+  test("applyAttack still works and is unaffected by hazard durability changes", () => {
+    const core = buildTwoActorTrapWorld([1, 1], [2, 1], [3, 1]);
+    const result = call(
+      (core as Record<string, unknown>).applyAttack,
+      0, 1, 3,
+    );
+    expect(result).not.toBe(0);
+    expect(call(core.getMotivatedActorVitalCurrentByIndex, 1, VitalKind.Health)).toBe(7);
+  });
+
+  test("applyAffinityDamage (actor target) still passes all existing matrix routing", () => {
+    const core = buildTwoActorTrapWorld([1, 1], [2, 1], [3, 1]);
+    call(
+      (core as Record<string, unknown>).applyAffinityDamage,
+      0, 1, AffinityKind.Fire, AffinityExpression.Push, 1,
+    );
+    expect(call(core.getMotivatedActorVitalCurrentByIndex, 1, VitalKind.Health)).toBe(8); // -2
+  });
+
+  test("applyAffinityPullFromHazard (M3b) drains trap mana to 0, structure preserved", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 6,
+      0, 0, 0,
+    );
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(result).not.toBe(0);
+    expect(call(core.getStaticTrapManaReserveAt, 2, 1)).toBe(0); // mana drained
+    expect(trapExists(core, 2, 1)).toBe(true);                   // structure intact
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M3d regression — durability regen and destroyed-is-terminal
+// ---------------------------------------------------------------------------
+
+describe("M3d regression: trap durability regen via advanceTick", () => {
+  test("partially damaged trap with durRegen=1 heals back each tick", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 5,
+      3, 8, 1, // durCurrent=3, durMax=8, durRegen=1
+    );
+    // One tick → durability 3 + 1 = 4
+    call(core.advanceTick);
+    expect(durOf(core, 2, 1)).toBe(4);
+    // Another tick → 5
+    call(core.advanceTick);
+    expect(durOf(core, 2, 1)).toBe(5);
+  });
+
+  test("destroyed trap (durability → 0) stays destroyed across many ticks", () => {
+    const core = buildActorTrapWorld(
+      [1, 1], [2, 1],
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 5,
+      1, 1, 2, // durability: current=1, max=1, regen=2 (would regen if not terminal)
+    );
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(trapExists(core, 2, 1)).toBe(false);
+    for (let i = 0; i < 5; i++) call(core.advanceTick);
+    expect(trapExists(core, 2, 1)).toBe(false);
+    expect(durOf(core, 2, 1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: all 3 durability affinities × 4 expressions — routing and sign
+// ---------------------------------------------------------------------------
+
+describe("permutations: all 3 durability affinities × 4 expressions route correctly to trap durability", () => {
+  // Durability polarity: Earth=+1, Corrode=−1, Fortify=+1
+  const DUR_ROUTE = [
+    { kind: AffinityKind.Earth,   polarity: +1 },
+    { kind: AffinityKind.Corrode, polarity: -1 },
+    { kind: AffinityKind.Fortify, polarity: +1 },
+  ];
+  const ALL_EXPRS = [
+    AffinityExpression.Push, AffinityExpression.Pull,
+    AffinityExpression.Emit, AffinityExpression.Draw,
+  ];
+
+  test("each (durability-affinity × expression) changes trap durability by the matrix-predicted amount", () => {
+    // Actor at (1,1), trap at (2,1); distance=1 satisfies Push/Pull range for stacks=1
+    const DUR_START = 5;
+    const DUR_MAX = 10;
+
+    for (const { kind, polarity } of DUR_ROUTE) {
+      for (const expr of ALL_EXPRS) {
+        const core = buildActorTrapWorld([1, 1], [2, 1], kind, AffinityExpression.Emit, 1, 4, DUR_START, DUR_MAX, 0);
+        const base = (expr === AffinityExpression.Push || expr === AffinityExpression.Pull) ? 2 : 1;
+        const sign = (expr === AffinityExpression.Pull || expr === AffinityExpression.Draw) ? -polarity : polarity;
+        const effect = sign * base;
+        const expectedDur = Math.max(0, Math.min(DUR_MAX, DUR_START + effect));
+
+        const result = call(
+          (core as Record<string, unknown>).applyAffinityDamageToHazard,
+          0, 2, 1, kind, expr, 1,
+        ) as number;
+
+        if (expectedDur === 0) {
+          // Destruction case: trap no longer exists
+          expect(result).not.toBe(0);
+          expect(trapExists(core, 2, 1)).toBe(false);
+        } else {
+          expect(result).not.toBe(0);
+          expect(durOf(core, 2, 1)).toBe(expectedDur);
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: step-by-step drain to exactly 0 — destruction on the final hit
+// ---------------------------------------------------------------------------
+
+describe("permutations: drain sequence — destruction happens on the hit that reaches 0, not before", () => {
+  test("Corrode+Push: durability 6 → 4 → 2 → destroyed on third hit (not on the second)", () => {
+    const core = buildActorTrapWorld([1, 1], [2, 1], AffinityKind.Corrode, AffinityExpression.Emit, 1, 4, 6, 6, 0);
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1);
+    expect(trapExists(core, 2, 1)).toBe(true);
+    expect(durOf(core, 2, 1)).toBe(4);
+
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1);
+    expect(trapExists(core, 2, 1)).toBe(true);
+    expect(durOf(core, 2, 1)).toBe(2);
+
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1);
+    expect(trapExists(core, 2, 1)).toBe(false); // destroyed on the third hit
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: buff after partial damage does not exceed durabilityMax
+// ---------------------------------------------------------------------------
+
+describe("permutations: Fortify+Push repairs durability but clamps at durabilityMax", () => {
+  test("partial Corrode drain then Fortify repair — durability clamped at max, does not overflow", () => {
+    // Start dur 6/8; Corrode-2 → 4; then Fortify+Push×3 buffs by +6 → clamped at 8
+    const core = buildActorTrapWorld([1, 1], [2, 1], AffinityKind.Corrode, AffinityExpression.Emit, 1, 4, 6, 8, 0);
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1);
+    expect(durOf(core, 2, 1)).toBe(4);
+
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 2, 1, AffinityKind.Fortify, AffinityExpression.Push, 3);
+    expect(durOf(core, 2, 1)).toBe(8); // clamped at max
+    expect(durMaxOf(core, 2, 1)).toBe(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: stacks=1..5 → magnitude scales linearly (base × stacks)
+// ---------------------------------------------------------------------------
+
+describe("permutations: magnitude scales linearly with stacks for durability affinities", () => {
+  for (const stacks of [1, 2, 3, 4, 5]) {
+    test(`Earth+Emit at stacks=${stacks} increases trap durability by ${stacks}`, () => {
+      const DUR_START = 5;
+      const DUR_MAX = 20; // large enough to never clamp for stacks=1..5
+      const core = buildActorTrapWorld([1, 1], [2, 1], AffinityKind.Earth, AffinityExpression.Emit, 1, 4, DUR_START, DUR_MAX, 0);
+      call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 2, 1, AffinityKind.Earth, AffinityExpression.Emit, stacks);
+      expect(durOf(core, 2, 1)).toBe(DUR_START + stacks); // Emit base=1 × stacks
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: non-durability affinities return 0 and leave trap unchanged
+// ---------------------------------------------------------------------------
+
+describe("permutations: non-durability affinities return 0 and do not affect trap durability", () => {
+  const NON_DUR_KINDS = [
+    AffinityKind.Fire, AffinityKind.Water, AffinityKind.Wind,
+    AffinityKind.Life, AffinityKind.Decay, AffinityKind.Light, AffinityKind.Dark,
+  ];
+
+  test("all 7 non-durability affinities return 0 from applyAffinityDamageToHazard with Push", () => {
+    for (const kind of NON_DUR_KINDS) {
+      const core = buildActorTrapWorld([1, 1], [2, 1], AffinityKind.Corrode, AffinityExpression.Emit, 1, 4, 6, 6, 0);
+      const durBefore = durOf(core, 2, 1);
+      const result = call(
+        (core as Record<string, unknown>).applyAffinityDamageToHazard,
+        0, 2, 1, kind, AffinityExpression.Push, 1,
+      ) as number;
+      expect(result).toBe(0);
+      expect(durOf(core, 2, 1)).toBe(durBefore); // unchanged
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: grid corner cells — no off-by-one in getters or damage
+// ---------------------------------------------------------------------------
+
+describe("permutations: applyAffinityDamageToHazard and getters work at grid boundary cells", () => {
+  test("trap at (1,1) — minimum walkable corner — is hit and durability changes correctly", () => {
+    const core = buildActorWorld([2, 1]);
+    call(core.armStaticTrapAt, 1, 1, AffinityKind.Corrode, AffinityExpression.Emit, 1, 4, 6, 6, 0);
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 1, 1, AffinityKind.Corrode, AffinityExpression.Push, 1);
+    expect(durOf(core, 1, 1)).toBe(4);
+  });
+
+  test("trap at (5,5) — maximum walkable corner — is hit and durability changes correctly", () => {
+    const core = buildActorWorld([1, 1]);
+    // Use Emit (no range constraint) since actor at (1,1) is 4 tiles from (5,5)
+    call(core.armStaticTrapAt, 5, 5, AffinityKind.Earth, AffinityExpression.Emit, 1, 4, 3, 10, 0);
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 5, 5, AffinityKind.Earth, AffinityExpression.Emit, 1);
+    expect(durOf(core, 5, 5)).toBe(4); // Earth+Emit+stacks=1: effect=+1, 3+1=4
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: re-arm after destruction resets durability to new values
+// ---------------------------------------------------------------------------
+
+describe("permutations: re-arming a destroyed trap starts with the newly-specified durability", () => {
+  test("trap destroyed by Corrode drain; re-armed on same cell with new durability=8/8 resets cleanly", () => {
+    const core = buildActorTrapWorld([1, 1], [2, 1], AffinityKind.Corrode, AffinityExpression.Emit, 1, 4, 2, 2, 0);
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1);
+    expect(trapExists(core, 2, 1)).toBe(false);
+
+    call(core.armStaticTrapAt, 2, 1, AffinityKind.Earth, AffinityExpression.Emit, 1, 4, 8, 8, 0);
+    expect(trapExists(core, 2, 1)).toBe(true);
+    expect(durOf(core, 2, 1)).toBe(8);
+    expect(durMaxOf(core, 2, 1)).toBe(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: multiple traps on the grid — only the targeted cell is affected
+// ---------------------------------------------------------------------------
+
+describe("permutations: applyAffinityDamageToHazard only modifies the targeted trap cell", () => {
+  test("damaging trap at (2,1) does not change durability of trap at (4,1)", () => {
+    const core = buildActorWorld([1, 1]);
+    call(core.armStaticTrapAt, 2, 1, AffinityKind.Corrode, AffinityExpression.Emit, 1, 4, 8, 8, 0);
+    call(core.armStaticTrapAt, 4, 1, AffinityKind.Corrode, AffinityExpression.Emit, 1, 4, 8, 8, 0);
+
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard, 0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1);
+
+    expect(durOf(core, 2, 1)).toBe(6); // targeted: drained by 2
+    expect(durOf(core, 4, 1)).toBe(8); // bystander: unchanged
+  });
+});

--- a/tests/core-ts/hazard-regen.test.mts
+++ b/tests/core-ts/hazard-regen.test.mts
@@ -1,0 +1,630 @@
+/**
+ * M3d — Hazard Regen Ticks (Mana + Durability): failing tests
+ *
+ * `advanceTick` must advance each non-destroyed trap's mana and durability
+ * by their per-trap regen rates (clamped to their respective maxima).
+ *
+ * Key design choices encoded here:
+ *   - `armStaticTrapAt` gains two more optional trailing params (after durability):
+ *       armStaticTrapAt(x, y, kind, expr, stacks, mana,
+ *                       durCurrent?, durMax?, durRegen?,
+ *                       manaMax?, manaRegen?)
+ *     manaMax defaults to manaReserve (initial current); manaRegen defaults to 0.
+ *   - `getStaticTrapManaMaxAt(x, y)` / `getStaticTrapManaRegenAt(x, y)` are new exports.
+ *   - Destruction (durability → 0) is terminal; destroyed cells do NOT regen.
+ *   - Neutralised traps (mana drained to 0 by M3b pull, trap structure intact)
+ *     regen mana back to max over ceil(max / regen) ticks.
+ *   - Regen of 0 means no advancement on any tick.
+ *   - Actor vital regen is unaffected by these changes.
+ *
+ * Tests MUST FAIL until M3d implements:
+ *   1. `staticTrapManaMaxByCell` + `staticTrapManaRegenByCell` arrays in world.ts
+ *   2. `armStaticTrapAt` extended with optional manaMax / manaRegen params
+ *   3. `getStaticTrapManaMaxAt` / `getStaticTrapManaRegenAt` getters + CORE_API_KEYS
+ *   4. Per-trap regen loop appended to `applyTickRegen()` in world.ts
+ *   5. `applyAffinityPullFromHazard` changed to drain mana to 0 (not full disarm)
+ */
+import { describe, expect, test } from "vitest";
+import { createCore } from "../../packages/core-ts/src/index.ts";
+import {
+  AffinityExpression,
+  AffinityKind,
+} from "../../packages/core-ts/src/state/affinity.ts";
+import { VitalKind } from "../../packages/core-ts/src/state/vitals.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function call(fn: unknown, ...args: unknown[]): unknown {
+  if (typeof fn !== "function") {
+    throw new Error("expected callable core export — M3d must wire this");
+  }
+  return fn(...args);
+}
+
+type Core = ReturnType<typeof createCore>;
+
+/** 7×7 floor grid with one actor at (1,1). */
+function buildWorld(): Core {
+  const core = createCore();
+  call(core.configureGrid, 7, 7);
+  for (let y = 1; y <= 5; y++) {
+    for (let x = 1; x <= 5; x++) {
+      call(core.setTileAt, x, y, 1);
+    }
+  }
+  call(core.addActorPlacement, 1, 1, 1);
+  call(core.applyActorPlacements);
+  call(core.setMotivatedActorVital, 0, VitalKind.Health,     10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Mana,       10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Stamina,    10, 10, 0);
+  call(core.setMotivatedActorVital, 0, VitalKind.Durability,  5,  5, 0);
+  return core;
+}
+
+function tick(core: Core, n = 1): void {
+  for (let i = 0; i < n; i++) call(core.advanceTick);
+}
+
+function trapMana(core: Core, x: number, y: number): number {
+  return call(core.getStaticTrapManaReserveAt, x, y) as number;
+}
+
+function trapManaMax(core: Core, x: number, y: number): number {
+  return call(core.getStaticTrapManaMaxAt, x, y) as number;
+}
+
+function trapManaRegen(core: Core, x: number, y: number): number {
+  return call(core.getStaticTrapManaRegenAt, x, y) as number;
+}
+
+function trapDur(core: Core, x: number, y: number): number {
+  return call(core.getStaticTrapDurabilityAt, x, y) as number;
+}
+
+function trapExists(core: Core, x: number, y: number): boolean {
+  return (call(core.getStaticTrapAffinityAt, x, y) as number) > 0;
+}
+
+function actorMana(core: Core): number {
+  return call(core.getMotivatedActorVitalCurrentByIndex, 0, VitalKind.Mana) as number;
+}
+
+// ---------------------------------------------------------------------------
+// API presence
+// ---------------------------------------------------------------------------
+
+describe("M3d API surface", () => {
+  test("getStaticTrapManaMaxAt is exported", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).getStaticTrapManaMaxAt).toBe("function");
+  });
+
+  test("getStaticTrapManaRegenAt is exported", () => {
+    const core = createCore();
+    expect(typeof (core as Record<string, unknown>).getStaticTrapManaRegenAt).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// armStaticTrapAt: mana max / regen params
+// ---------------------------------------------------------------------------
+
+describe("armStaticTrapAt: mana max and regen configuration", () => {
+  test("manaMax defaults to manaReserve when omitted (6-arg legacy call)", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1, AffinityKind.Fire, AffinityExpression.Emit, 1, 6);
+    expect(trapManaMax(core, 2, 1)).toBe(6);
+    expect(trapManaRegen(core, 2, 1)).toBe(0);
+  });
+
+  test("explicit manaMax and manaRegen stored and read back", () => {
+    const core = buildWorld();
+    // armStaticTrapAt(x,y, kind,expr,stacks,mana, durCur,durMax,durRegen, manaMax,manaRegen)
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 3,
+      0, 0, 0,   // durability: immortal
+      8, 2,      // manaMax=8, manaRegen=2
+    );
+    expect(trapManaMax(core, 2, 1)).toBe(8);
+    expect(trapManaRegen(core, 2, 1)).toBe(2);
+    expect(trapMana(core, 2, 1)).toBe(3); // current starts at manaReserve (3)
+  });
+
+  test("manaMax defaults to manaReserve when only durability params given", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      4, 4, 1,   // durability
+      // no manaMax/manaRegen → default manaMax=5, manaRegen=0
+    );
+    expect(trapManaMax(core, 2, 1)).toBe(5);
+    expect(trapManaRegen(core, 2, 1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mana regen on advanceTick
+// ---------------------------------------------------------------------------
+
+describe("advanceTick: trap mana regen", () => {
+  test("mana advances by regen each tick (regen=1, from 3 to 4 after 1 tick)", () => {
+    const core = buildWorld();
+    // current=3, max=6, regen=1
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 3,
+      0, 0, 0, 6, 1,
+    );
+    tick(core);
+    expect(trapMana(core, 2, 1)).toBe(4);
+  });
+
+  test("mana advances by regen=2 per tick", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 2,
+      0, 0, 0, 10, 2,
+    );
+    tick(core);
+    expect(trapMana(core, 2, 1)).toBe(4);
+    tick(core);
+    expect(trapMana(core, 2, 1)).toBe(6);
+  });
+
+  test("mana clamps at manaMax — does not exceed", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      0, 0, 0, 6, 2,
+    );
+    tick(core, 5); // 5+2+2+2+2+2 → would be 15 but clamped at 6
+    expect(trapMana(core, 2, 1)).toBe(6);
+  });
+
+  test("regen=0 means no advancement across many ticks", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 4,
+      0, 0, 0, 10, 0,
+    );
+    tick(core, 10);
+    expect(trapMana(core, 2, 1)).toBe(4); // unchanged
+  });
+
+  test("trap already at max (mana==manaMax) does not increase further", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      0, 0, 0, 5, 1,
+    );
+    tick(core, 3);
+    expect(trapMana(core, 2, 1)).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Durability regen on advanceTick
+// ---------------------------------------------------------------------------
+
+describe("advanceTick: trap durability regen", () => {
+  test("durability advances by durRegen each tick", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 4,
+      2, 8, 1,   // durCurrent=2, durMax=8, durRegen=1
+    );
+    tick(core);
+    expect(trapDur(core, 2, 1)).toBe(3);
+  });
+
+  test("durability clamps at durMax", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 4,
+      6, 8, 3,   // regen=3, max=8 → reaches 8 in 1 tick (6+3=9→8)
+    );
+    tick(core);
+    expect(trapDur(core, 2, 1)).toBe(8);
+  });
+
+  test("durRegen=0 → durability unchanged", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 4,
+      3, 8, 0,
+    );
+    tick(core, 5);
+    expect(trapDur(core, 2, 1)).toBe(3); // unchanged
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Destroyed traps do NOT regen (terminal)
+// ---------------------------------------------------------------------------
+
+describe("advanceTick: destroyed trap stays gone", () => {
+  test("trap destroyed via applyAffinityDamageToHazard does not regen mana or durability", () => {
+    const core = buildWorld();
+    // durability 1/1, regen=1 — after destruction, regen must not bring it back
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 5,
+      1, 1, 1,   // durability: current=1, max=1, regen=1
+      5, 1,      // mana: max=5, regen=1
+    );
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(trapExists(core, 2, 1)).toBe(false); // destroyed
+
+    tick(core, 5);
+    // Trap must not reappear
+    expect(trapExists(core, 2, 1)).toBe(false);
+    expect(trapMana(core, 2, 1)).toBe(0);
+    expect(trapDur(core, 2, 1)).toBe(0);
+  });
+
+  test("destroyed cell returns 0 from all trap getters across ticks", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 4,
+      1, 1, 2, 4, 2,
+    );
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    tick(core, 10);
+    expect(trapManaMax(core, 2, 1)).toBe(0);
+    expect(trapManaRegen(core, 2, 1)).toBe(0);
+    expect(call(core.getStaticTrapDurabilityMaxAt, 2, 1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Neutralised trap (M3b) regens mana and comes back online
+// ---------------------------------------------------------------------------
+
+describe("advanceTick: neutralised trap regens mana", () => {
+  test("after M3b pull, mana=0 trap regens back to max over ceil(max/regen) ticks", () => {
+    const core = buildWorld();
+    // mana current=5, max=5, regen=1 → needs 5 ticks from 0 to reach 5
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      0, 0, 0,   // immortal (no durability)
+      5, 1,      // manaMax=5, manaRegen=1
+    );
+    // Neutralise: drain mana to 0, trap structure preserved
+    call((core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(trapMana(core, 2, 1)).toBe(0);      // drained
+    expect(trapExists(core, 2, 1)).toBe(true); // structure intact
+
+    tick(core, 5);
+    expect(trapMana(core, 2, 1)).toBe(5);      // fully regenerated
+  });
+
+  test("second pull is accepted once mana regens back above 0", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 4,
+      0, 0, 0, 4, 2,
+    );
+    call((core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    // Partially regen (1 tick, regen=2 → mana=2)
+    tick(core);
+    expect(trapMana(core, 2, 1)).toBe(2);
+
+    // Attacker mana back to 0 first so we can see transfer
+    call(core.setMotivatedActorVital, 0, VitalKind.Mana, 0, 10, 0);
+
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(result).not.toBe(0); // second pull accepted
+    expect(actorMana(core)).toBe(2); // 0 + min(2, 10) = 2
+  });
+
+  test("pull on still-drained trap (mana=0) is rejected (0)", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      0, 0, 0, 5, 0, // regen=0 so mana stays 0 after pull
+    );
+    call((core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    tick(core, 3); // no regen
+    const result = call(
+      (core as Record<string, unknown>).applyAffinityPullFromHazard,
+      0, 2, 1, AffinityKind.Fire, 1,
+    );
+    expect(result).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-trap independence
+// ---------------------------------------------------------------------------
+
+describe("advanceTick: multiple traps regen independently", () => {
+  test("two traps with different regen values each advance correctly per tick", () => {
+    const core = buildWorld();
+    // Trap A at (2,1): mana current=1, max=10, regen=1
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 1,
+      0, 0, 0, 10, 1,
+    );
+    // Trap B at (3,1): mana current=1, max=10, regen=3
+    call(core.armStaticTrapAt, 3, 1,
+      AffinityKind.Dark, AffinityExpression.Push, 1, 1,
+      0, 0, 0, 10, 3,
+    );
+    tick(core);
+    expect(trapMana(core, 2, 1)).toBe(2);  // 1 + 1
+    expect(trapMana(core, 3, 1)).toBe(4);  // 1 + 3
+  });
+
+  test("one trap destroyed, other continues to regen normally", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 4,
+      1, 1, 0,   // durability: will be destroyed
+      4, 1,
+    );
+    call(core.armStaticTrapAt, 3, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 2,
+      0, 0, 0, 6, 2,
+    );
+    // Destroy trap A
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    tick(core, 2);
+    // Trap A gone, trap B regens normally
+    expect(trapExists(core, 2, 1)).toBe(false);
+    expect(trapMana(core, 3, 1)).toBe(6); // 2 + 2 + 2 = 6 (clamped at max)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Actor regen unaffected
+// ---------------------------------------------------------------------------
+
+describe("advanceTick: actor vital regen unaffected by trap regen changes", () => {
+  test("actor mana regen still works normally alongside trap regen", () => {
+    const core = buildWorld();
+    // Give actor a mana regen of 2
+    call(core.setMotivatedActorVital, 0, VitalKind.Mana, 6, 10, 2);
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 3,
+      0, 0, 0, 8, 1,
+    );
+    tick(core);
+    expect(actorMana(core)).toBe(8);         // 6 + 2
+    expect(trapMana(core, 2, 1)).toBe(4);    // 3 + 1
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #42 regression
+// ---------------------------------------------------------------------------
+
+describe("M3d: applyAttack non-regression", () => {
+  test("applyAttack still works and is unaffected by trap regen tick changes", () => {
+    const core = buildWorld();
+    call(core.addActorPlacement, 2, 2, 1);
+    // Can't addActorPlacement after applyActorPlacements — rebuild with 2 actors
+    const core2 = createCore();
+    call(core2.configureGrid, 7, 7);
+    for (let y = 1; y <= 5; y++) {
+      for (let x = 1; x <= 5; x++) {
+        call(core2.setTileAt, x, y, 1);
+      }
+    }
+    call(core2.addActorPlacement, 1, 1, 1);
+    call(core2.addActorPlacement, 2, 2, 1);
+    call(core2.applyActorPlacements);
+    call(core2.setMotivatedActorVital, 0, VitalKind.Health, 10, 10, 0);
+    call(core2.setMotivatedActorVital, 1, VitalKind.Health, 10, 10, 0);
+    call(core2.armStaticTrapAt, 3, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 5,
+      0, 0, 0, 5, 1,
+    );
+    const result = call((core2 as Record<string, unknown>).applyAttack, 0, 1, 3);
+    expect(result).not.toBe(0);
+    expect(call(core2.getMotivatedActorVitalCurrentByIndex, 1, VitalKind.Health)).toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: all 10 AffinityKind traps with manaRegen=1 reach manaMax
+// ---------------------------------------------------------------------------
+
+describe("permutations: all 10 AffinityKind traps with manaRegen=1 reach manaMax after max ticks", () => {
+  const ALL_KINDS = [
+    AffinityKind.Fire, AffinityKind.Water, AffinityKind.Earth, AffinityKind.Wind,
+    AffinityKind.Life, AffinityKind.Decay, AffinityKind.Corrode, AffinityKind.Fortify,
+    AffinityKind.Light, AffinityKind.Dark,
+  ];
+
+  test("each kind: trap starts at mana=1, manaMax=4, regen=1 → reaches 4 after 3 more ticks", () => {
+    // Use a 7×7 grid; place each trap at a unique cell in rows y=1 and y=2
+    const POSITIONS: [number, number][] = [
+      [1,1],[2,1],[3,1],[4,1],[5,1],
+      [1,2],[2,2],[3,2],[4,2],[5,2],
+    ];
+    const MANA_START = 1;
+    const MANA_MAX = 4;
+    const core = buildWorld();
+
+    for (let i = 0; i < ALL_KINDS.length; i++) {
+      const [x, y] = POSITIONS[i]!;
+      const kind = ALL_KINDS[i]!;
+      // armStaticTrapAt requires manaReserve > 0; start at 1, regen fills to max
+      call(core.armStaticTrapAt, x, y, kind, AffinityExpression.Emit, 1, MANA_START,
+        0, 0, 0,           // durability: immortal
+        MANA_MAX, 1,       // manaMax=4, manaRegen=1
+      );
+    }
+
+    tick(core, MANA_MAX - MANA_START); // 3 ticks → 1+3 = 4
+
+    for (let i = 0; i < ALL_KINDS.length; i++) {
+      const [x, y] = POSITIONS[i]!;
+      expect(trapMana(core, x, y)).toBe(MANA_MAX);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: manaRegen > manaMax — single tick clamps at max
+// ---------------------------------------------------------------------------
+
+describe("permutations: manaRegen > manaMax — single tick clamps at max", () => {
+  test("regen=10, manaMax=3: one tick clamps at max (starting from 1)", () => {
+    const core = buildWorld();
+    // manaReserve must be > 0; start at 1, regen=10 overshoots and clamps at max=3
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 1,
+      0, 0, 0,     // immortal
+      3, 10,       // manaMax=3, manaRegen=10
+    );
+    tick(core);
+    expect(trapMana(core, 2, 1)).toBe(3); // min(3, 1+10) = 3
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: durRegen exact recovery — ceil((max-current)/regen) ticks
+// ---------------------------------------------------------------------------
+
+describe("permutations: durability reaches durMax in exactly the expected number of ticks", () => {
+  test("durCurrent=2, durMax=6, durRegen=2 → reaches 6 after exactly 2 ticks", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 4,
+      2, 6, 2, // durCurrent=2, durMax=6, durRegen=2
+    );
+    tick(core);
+    expect(trapDur(core, 2, 1)).toBe(4); // +2
+    tick(core);
+    expect(trapDur(core, 2, 1)).toBe(6); // +2 → max
+    tick(core);
+    expect(trapDur(core, 2, 1)).toBe(6); // clamped
+  });
+
+  test("durCurrent=1, durMax=5, durRegen=1 → reaches 5 after exactly 4 ticks", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Earth, AffinityExpression.Emit, 1, 4,
+      1, 5, 1,
+    );
+    tick(core, 4);
+    expect(trapDur(core, 2, 1)).toBe(5);
+    tick(core);
+    expect(trapDur(core, 2, 1)).toBe(5); // clamped, does not exceed
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: combined mana + durability regen advances both in a single tick
+// ---------------------------------------------------------------------------
+
+describe("permutations: combined mana and durability regen both advance in a single advanceTick", () => {
+  test("trap with manaRegen=2 and durRegen=3: single tick advances both independently", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Earth, AffinityExpression.Emit, 1, 1,
+      2, 10, 3,    // durCurrent=2, durMax=10, durRegen=3
+      8, 2,        // manaMax=8, manaRegen=2
+    );
+    tick(core);
+    expect(trapMana(core, 2, 1)).toBe(3);  // 1 + 2
+    expect(trapDur(core, 2, 1)).toBe(5);   // 2 + 3
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: trap with regen=0 for both — no mutation after multiple ticks
+// ---------------------------------------------------------------------------
+
+describe("permutations: regen=0 means no mutation on either mana or durability arrays across many ticks", () => {
+  test("manaRegen=0 AND durRegen=0: both values unchanged after 10 ticks", () => {
+    const core = buildWorld();
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Fire, AffinityExpression.Emit, 1, 3,
+      2, 8, 0,    // durability: current=2, max=8, regen=0
+      7, 0,       // mana: max=7, regen=0
+    );
+    tick(core, 10);
+    expect(trapMana(core, 2, 1)).toBe(3); // unchanged
+    expect(trapDur(core, 2, 1)).toBe(2);  // unchanged
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: multiple traps on the same grid all regen independently
+// ---------------------------------------------------------------------------
+
+describe("permutations: multiple traps regen independently — each advances by its own regen rate", () => {
+  test("five traps with different manaRegen rates all reach their individual maxima correctly", () => {
+    const core = buildWorld();
+    // armStaticTrapAt requires manaReserve > 0; use 1 as the minimum non-zero starting value.
+    // Trap A: mana=1/5, regen=1 → full after 4 ticks; after 5 ticks: 5
+    call(core.armStaticTrapAt, 1, 1, AffinityKind.Fire,  AffinityExpression.Emit, 1, 1, 0, 0, 0, 5, 1);
+    // Trap B: mana=1/4, regen=2 → full after 2 ticks (1+2+2=5→4); after 5 ticks: 4
+    call(core.armStaticTrapAt, 2, 1, AffinityKind.Water, AffinityExpression.Emit, 1, 1, 0, 0, 0, 4, 2);
+    // Trap C: mana=3/6, regen=0 → stays at 3 (no regen)
+    call(core.armStaticTrapAt, 3, 1, AffinityKind.Dark,  AffinityExpression.Emit, 1, 3, 0, 0, 0, 6, 0);
+    // Trap D: mana=1/3, regen=3 → full after 1 tick (1+3=4→3); after 5 ticks: 3
+    call(core.armStaticTrapAt, 4, 1, AffinityKind.Light, AffinityExpression.Emit, 1, 1, 0, 0, 0, 3, 3);
+    // Trap E: mana=1/1, regen=5 → already at max, stays at 1
+    call(core.armStaticTrapAt, 5, 1, AffinityKind.Earth, AffinityExpression.Emit, 1, 1, 0, 0, 0, 1, 5);
+
+    tick(core, 5);
+
+    expect(trapMana(core, 1, 1)).toBe(5); // A: full (1 + 5×1 = 6 → clamped 5)
+    expect(trapMana(core, 2, 1)).toBe(4); // B: full (clamped after 2 ticks)
+    expect(trapMana(core, 3, 1)).toBe(3); // C: regen=0, unchanged
+    expect(trapMana(core, 4, 1)).toBe(3); // D: full (clamped after 1 tick)
+    expect(trapMana(core, 5, 1)).toBe(1); // E: already at max
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permutations: arm → destroy → re-arm cycle — fresh regen state, no stale values
+// ---------------------------------------------------------------------------
+
+describe("permutations: arm → destroy → re-arm starts fresh regen with no stale state", () => {
+  test("destroy a trap then re-arm with new regen values — old regen does not bleed into new trap", () => {
+    const core = buildWorld();
+    // Arm with durCurrent=2/2, durRegen=99 — would destroy and regen endlessly if stale
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Corrode, AffinityExpression.Push, 1, 5,
+      2, 2, 99,  // durability: 2/2, regen=99 (intentionally large to detect leakage)
+    );
+    // Destroy via damage
+    call((core as Record<string, unknown>).applyAffinityDamageToHazard,
+      0, 2, 1, AffinityKind.Corrode, AffinityExpression.Push, 1,
+    );
+    expect(trapExists(core, 2, 1)).toBe(false);
+
+    // Re-arm with durRegen=0 — if stale, regen=99 would bleed in
+    call(core.armStaticTrapAt, 2, 1,
+      AffinityKind.Earth, AffinityExpression.Emit, 1, 3,
+      4, 8, 0,   // durCurrent=4, durMax=8, durRegen=0
+      6, 1,      // mana: max=6, regen=1
+    );
+
+    tick(core, 5);
+
+    expect(trapExists(core, 2, 1)).toBe(true);
+    expect(trapDur(core, 2, 1)).toBe(4);  // durRegen=0, unchanged
+    // mana starts at manaReserve=3, manaMax=6, regen=1 → 5 ticks → min(6, 3+5)=6
+    expect(trapMana(core, 2, 1)).toBe(6);
+  });
+});

--- a/tests/runtime/game-elements-registry.test.js
+++ b/tests/runtime/game-elements-registry.test.js
@@ -1,0 +1,78 @@
+const assert = require("node:assert/strict");
+
+test("game element visual registry covers core game vocabularies", async () => {
+  const {
+    GAME_AFFINITY_EXPRESSIONS,
+    GAME_AFFINITY_KINDS,
+    GAME_ELEMENT_VISUALS,
+    GAME_MOTIVATION_KINDS,
+    getGameElementVisualEntries,
+  } = await import("../../packages/runtime/src/contracts/game-elements.js");
+
+  assert.deepEqual(Object.keys(GAME_ELEMENT_VISUALS.actors), ["delver", "warden"]);
+  assert.ok(GAME_ELEMENT_VISUALS.tiles.floor);
+  assert.ok(GAME_ELEMENT_VISUALS.tiles.wall);
+  assert.deepEqual(Object.keys(GAME_ELEMENT_VISUALS.affinities), Array.from(GAME_AFFINITY_KINDS));
+  assert.deepEqual(Object.keys(GAME_ELEMENT_VISUALS.affinityExpressions), Array.from(GAME_AFFINITY_EXPRESSIONS));
+  assert.deepEqual(Object.keys(GAME_ELEMENT_VISUALS.motivations), Array.from(GAME_MOTIVATION_KINDS));
+  assert.deepEqual(Object.keys(GAME_ELEMENT_VISUALS.affinityStacks), ["tier1", "tier2", "tier3"]);
+
+  getGameElementVisualEntries().forEach((entry) => {
+    assert.equal(typeof entry.unicodeIcon, "string", `${entry.id} missing unicodeIcon`);
+    assert.ok(entry.unicodeIcon.length > 0, `${entry.id} has empty unicodeIcon`);
+    assert.match(entry.defaultColor, /^#[0-9a-f]{6}$/i, `${entry.id} missing defaultColor`);
+    assert.equal(typeof entry.description, "string", `${entry.id} missing description`);
+    assert.ok(entry.description.length > 0, `${entry.id} has empty description`);
+    assert.equal(typeof entry.imageResource?.assetId, "string", `${entry.id} missing image assetId`);
+    assert.ok(entry.imageResource.assetId.length > 0, `${entry.id} has empty image assetId`);
+    assert.equal(typeof entry.imageResource?.relativePath, "string", `${entry.id} missing relativePath`);
+    assert.ok(entry.imageResource.relativePath.endsWith(".png"), `${entry.id} relativePath must be png`);
+  });
+});
+
+test("domain constants and resource bundle assets use the game element registry", async () => {
+  const {
+    GAME_AFFINITY_EXPRESSIONS,
+    GAME_AFFINITY_KINDS,
+    GAME_MOTIVATION_KINDS,
+    getResourceBundleAssetSpecs,
+  } = await import("../../packages/runtime/src/contracts/game-elements.js");
+  const {
+    AFFINITY_EXPRESSIONS,
+    AFFINITY_KINDS,
+  } = await import("../../packages/runtime/src/contracts/domain-constants.js");
+  const {
+    MOTIVATION_KINDS,
+  } = await import("../../packages/runtime/src/personas/configurator/motivation-loadouts.js");
+  const {
+    createDefaultResourceBundleArtifact,
+    validateResourceBundleArtifact,
+  } = await import("../../packages/runtime/src/render/resource-bundle.js");
+
+  assert.deepEqual(Array.from(AFFINITY_KINDS), Array.from(GAME_AFFINITY_KINDS));
+  assert.deepEqual(Array.from(AFFINITY_EXPRESSIONS), Array.from(GAME_AFFINITY_EXPRESSIONS));
+  assert.deepEqual(Array.from(MOTIVATION_KINDS), Array.from(GAME_MOTIVATION_KINDS));
+
+  const bundle = createDefaultResourceBundleArtifact({
+    createMeta: ({ producedBy = "test", runId = "registry" } = {}) => ({
+      id: `${producedBy}_${runId}`,
+      runId,
+      createdAt: "2000-01-01T00:00:00.000Z",
+      producedBy,
+    }),
+    emitVisualAssets: true,
+  });
+  const validation = validateResourceBundleArtifact(bundle);
+  assert.equal(validation.ok, true, validation.errors?.join(", "));
+
+  const expectedAssetIds = new Set(getResourceBundleAssetSpecs({ emitVisualAssets: true }).map((spec) => spec.id));
+  const bundleAssetIds = new Set(bundle.assets.map((asset) => asset.id));
+  expectedAssetIds.forEach((assetId) => {
+    assert.equal(bundleAssetIds.has(assetId), true, `ResourceBundle missing ${assetId}`);
+  });
+});
+
+// ## TODO: Test Permutations
+// - registry entries with missing generated image resource should fail validation
+// - legacy v1 ResourceBundle specs should include old affinity/motivation/expression asset IDs
+// - duplicated registry asset IDs should be rejected before ResourceBundle construction


### PR DESCRIPTION
## Summary

- **M3b**: Same-affinity Pull neutralization — `applyAffinityDamage` branches to a mana-transfer path when Pull matches the target's active Emit/Push affinity; `applyAffinityPullFromHazard` new entry point for draining static trap mana (structure intact, regen-safe)
- **M3c**: Hazard durability vital — per-trap durability arrays, `applyAffinityDamageToHazard` routes Earth/Corrode/Fortify effects to trap durability, immortal guard (durMax=0), destruction via `disarmStaticTrapAt` at 0
- **M3d**: Hazard regen ticks — per-trap manaMax/manaRegen arrays, `applyTickRegen` extended to advance both mana and durability each tick (clamped, destroyed cells skipped); `applyAffinityPullFromHazard` changed from disarm to drain-only so traps recover
- **M4**: Test permutation expansion — 50 new permutation tests across all 5 test files (full routing matrix coverage, sign-reversal, polarity invariant, large-stacks safety, drain/buff sequences, boundary cells, sequential pulls, combined regen)

## Test plan

- [ ] `pnpm run test:vitest -- tests/core-ts/` — all 336 core-ts tests pass (16 files, 1 pre-existing skip)
- [ ] `pnpm run test` — no new failures introduced (pre-existing UI icon emoji failures in jsdom are unrelated)
- [ ] New test files: `affinity-neutralization.test.mts` (32), `hazard-durability.test.mts` (49), `hazard-regen.test.mts` (30)
- [ ] Expanded permutations in: `affinity-vital-matrix.test.mts` (+15), `affinity-damage.test.mts` (+14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)