### PR TITLE
[codex] Improve README overviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # agent-kernel
 
-Pure TypeScript simulation kernel built around the **Ports & Adapters** architectural pattern.
+`agent-kernel` is a fixture-first simulation framework for building, running, replaying, and inspecting deterministic dungeon scenarios.
 
-The deterministic core now lives in `packages/core-ts`. Runtime personas, UI, CLI, and external IO remain outside the core and communicate through explicit artifacts and adapter boundaries.
+The project is organized around **Ports & Adapters**. The deterministic simulation core lives in `packages/core-ts`; runtime personas, CLI tools, browser UI, test doubles, and external IO live outside the core and communicate through explicit, versioned artifacts.
+
+## What This Repo Contains
+
+- A pure TypeScript simulation core for world state, movement, affinities, motivations, hazards, resources, and combat rules.
+- Runtime personas that plan, configure, budget, execute, observe, and integrate simulation runs without putting policy or IO into the core.
+- CLI and MCP adapters for authoring scenarios, building artifact bundles, running simulations, replaying tick frames, and inspecting prior runs.
+- Browser UI surfaces for card building, preview, gameplay playback, and diagnostics.
+- Fixture-backed adapters and tests so most workflows run offline and deterministically.
+
+The old binary build path has been removed. CLI, runtime, and UI preview workflows use the TypeScript core directly.
 
 ## Quick Start
 
@@ -14,12 +24,25 @@ pnpm run serve:ui
 
 Open `http://localhost:8001/packages/ui-web/index.html` after starting the UI server.
 
+For a CLI-first smoke path, use:
+
+```bash
+node packages/adapters-cli/src/cli/ak.mjs create \
+  --room "size=small;count=1" \
+  --delver "count=1;affinity=fire;motivation=attacking" \
+  --warden "count=1;affinity=dark;motivation=defending"
+```
+
+By default, generated artifacts are written under `artifacts/runs/<runId>/<command>/`.
+
 ## Architecture
 
 - **`packages/core-ts`**: deterministic simulation state, rules, affinity/motivation codebooks, field computation, and render buffers. It performs no IO.
 - **`packages/runtime`**: personas, tick orchestration, command kernel, artifact contracts, telemetry, replay, and policy coordination.
 - **`packages/adapters-*`**: concrete host adapters for CLI, browser, and tests.
 - **`packages/ui-web`**: browser rendering and interaction surfaces.
+
+The important boundary is that `core-ts` decides what happens in the simulation, while adapters and personas decide how requests enter the system, how artifacts are assembled, and where outputs are written.
 
 Allowed dependency direction:
 
@@ -36,8 +59,13 @@ pnpm run benchmark:core-ts-affinity
 pnpm run serve:ui
 ```
 
-The old binary build path has been removed. CLI, runtime, and UI preview workflows use the TypeScript core directly.
-
 ## Documentation
 
-Start with `docs/README.md`. The architecture charter and diagram are normative when implementation plans or older notes disagree.
+Start with `docs/README.md` for the project map and reading order. The architecture charter and diagram are normative when implementation plans or older notes disagree.
+
+Useful next stops:
+
+- `packages/adapters-cli/README.md` for CLI workflows and artifact outputs.
+- `packages/adapters-cli/src/mcp/README.md` for MCP tool usage.
+- `tests/README.md` for deterministic test workflow.
+- `tools/remote-ollama-control/README.md` for remote Ollama benchmark/control workflows.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,19 @@
 # Documentation Index
 
-This folder contains the design intent and architecture rules for the project.
+This folder contains the design intent, architecture rules, and current execution model for the project. Treat it as the starting point when you need to understand why the repo is shaped the way it is.
+
+## Reading Order
+
+For a newcomer, read these in order:
+
+1. `README.md` at the repo root for the high-level project map.
+2. `docs/vision-contract.md` for the constraints the project is preserving.
+3. `docs/architecture-charter.md` for dependency direction and Ports & Adapters rules.
+4. `docs/architecture/diagram.mmd` for the package-level map.
+5. `docs/architecture/persona-state-machines.md` for runtime persona phases and transitions.
+6. Package READMEs for the area you are working in.
+
+When older notes disagree with the charter or vision contract, the charter and vision contract win.
 
 ## Core Documents
 
@@ -9,9 +22,16 @@ This folder contains the design intent and architecture rules for the project.
 - `docs/architecture/diagram.mmd` — Mermaid architecture overview.
 - `docs/architecture/persona-state-machines.md` — deterministic persona FSM rules and state sets.
 
-If a plan or README conflicts with these documents, the charter and vision contract win.
-
 ## Current Execution Model
+
+At runtime, the system moves from authored intent to deterministic replayable artifacts:
+
+1. A user, agent, fixture, or UI surface describes a scenario.
+2. Runtime personas translate that intent into plans, budgets, configuration, and execution requests.
+3. The TypeScript core applies deterministic rules and emits state changes.
+4. Runtime writes TickFrames, effects, summaries, telemetry, and bundles for replay and inspection.
+
+Key facts:
 
 - The deterministic simulation core is `packages/core-ts`.
 - The tick FSM (`init -> observe -> decide -> apply -> emit -> summarize`) is the canonical runtime loop.
@@ -42,7 +62,7 @@ The TypeScript core is synchronous and does not require a separate binary build 
 
 ## Builder Workflow
 
-Agent/CLI/UI share the same BuildSpec (`agent-kernel/BuildSpec`). The agent writes a spec, the CLI builds artifacts, and the UI can load/edit the emitted bundle without translation.
+Agent, CLI, and UI share the same BuildSpec (`agent-kernel/BuildSpec`). The agent writes a spec, the CLI builds artifacts, and the UI can load or edit the emitted bundle without translation.
 
 `create`, `configure`, `room-plan`, `delver-plan`, and `warden-plan` share one canonical preview handoff: `bundle.json`, `manifest.json`, `sim-config.json`, `initial-state.json`, `telemetry.json`, and `resource-bundle.json`.
 

--- a/packages/adapters-cli/README.md
+++ b/packages/adapters-cli/README.md
@@ -14,6 +14,28 @@ Minimum-install baseline:
 
 ---
 
+## How to Read This README
+
+Start with the workflow map below, then jump to the command family you need. The long command examples later in the file are reference material; they intentionally preserve exact CLI invocations for automation and regression checks.
+
+| Need | Start with | Produces |
+| --- | --- | --- |
+| Author a room, delver, warden, trap, hazard, or resource | `create`, `configure`, `room-plan`, `delver-plan`, `warden-plan` | `spec.json`, `bundle.json`, `sim-config.json`, `initial-state.json` |
+| Build from an existing BuildSpec | `build` | Canonical persisted handoff artifacts |
+| Run or replay deterministic simulation artifacts | `run`, `replay` | TickFrames, effects log, run summary |
+| Inspect prior outputs | `show`, `diff`, `runs list`, `inspect`, `narrate` | Structured summaries and narrative artifacts |
+| Use LLM planning with captured inputs | `llm-plan`, `scenario`, `llm` | Captured LLM artifacts plus build/run outputs |
+| Exercise external adapters directly | `ipfs`, `blockchain`, `llm`, publish/load variants | Adapter response artifacts |
+
+## Typical Local Workflow
+
+1. Author or build a scenario into artifacts.
+2. Inspect `bundle.json` and `manifest.json`, or load them in the UI.
+3. Run the scenario from `sim-config.json` and `initial-state.json`.
+4. Inspect, narrate, diff, or replay the emitted TickFrames.
+
+The default output root is `artifacts/runs/<runId>/<command>`, which keeps each command stage readable and chainable.
+
 ## Scope
 
 CLI adapters:
@@ -27,7 +49,7 @@ They do **not**:
 
 ---
 
-## CLI Commands (MVP)
+## CLI Commands
 
 Default output layout: `artifacts/runs/<runId>/<command>`. Older layouts
 (`artifacts/build_<runId>`, `artifacts/<command>_<timestamp>`) can be preserved

--- a/packages/adapters-cli/src/adapters/blockchain/README.md
+++ b/packages/adapters-cli/src/adapters/blockchain/README.md
@@ -2,6 +2,10 @@
 
 Purpose: query blockchain state (e.g., balances) from CLI tools via JSON-RPC.
 
+## How it fits
+
+This is a Node/CLI adapter for external chain IO. Runtime code can ask for blockchain facts through a port, but `core-ts` never imports this adapter and never performs JSON-RPC calls. Use fixture inputs when a test or demo needs deterministic behavior.
+
 This adapter:
 - Provides a minimal JSON-RPC client.
 - Exposes `getBalance`, `getChainId`, `mintCard`, and `loadMintedCard` helpers.
@@ -10,7 +14,7 @@ It is intended for Orchestrator/Allocator tooling and never used inside `core-ts
 
 ## Usage
 
-```
+```js
 import { createBlockchainAdapter } from "./index.js";
 
 const blockchain = createBlockchainAdapter({ rpcUrl: "https://rpc.example" });

--- a/packages/adapters-cli/src/adapters/ipfs/README.md
+++ b/packages/adapters-cli/src/adapters/ipfs/README.md
@@ -2,6 +2,10 @@
 
 Purpose: fetch artifacts from IPFS via an HTTP gateway for CLI workflows.
 
+## How it fits
+
+This is a Node/CLI adapter for loading external artifact payloads. It is useful around orchestration, budgeting, and persistence workflows, but simulation execution stays deterministic because any externally loaded data must be captured as artifacts before it influences a run.
+
 This adapter:
 - Builds gateway URLs for IPFS CIDs.
 - Fetches text or JSON payloads using Node's fetch.
@@ -10,7 +14,7 @@ It is intended for Orchestrator/Allocator tooling and never used inside `core-ts
 
 ## Usage
 
-```
+```js
 import { createIpfsAdapter } from "./index.js";
 
 const ipfs = createIpfsAdapter({ gatewayUrl: "https://ipfs.io/ipfs" });

--- a/packages/adapters-cli/src/adapters/llm/README.md
+++ b/packages/adapters-cli/src/adapters/llm/README.md
@@ -2,6 +2,10 @@
 
 Purpose: request strategic guidance or content from an LLM HTTP endpoint (Ollama/OpenAI-compatible).
 
+## How it fits
+
+This is a Node/CLI adapter for LLM IO. It can support planning and content generation around a run, but live model output is not part of deterministic core execution unless it has first been captured and replayed as an explicit artifact.
+
 This adapter:
 - Calls an Ollama-style `/api/generate` endpoint.
 - Returns the raw JSON response for downstream processing.
@@ -10,7 +14,7 @@ It is intended for Orchestrator/Director tooling and never used inside `core-ts`
 
 ## Usage
 
-```
+```js
 import { createLlmAdapter } from "./index.js";
 
 const llm = createLlmAdapter({ baseUrl: "http://localhost:11434" });

--- a/packages/adapters-cli/src/adapters/solver-z3/README.md
+++ b/packages/adapters-cli/src/adapters/solver-z3/README.md
@@ -2,6 +2,10 @@
 
 Deterministic, fixture-friendly solver adapter used by the CLI `solve` command. No real IO or process spawn.
 
+## How it fits
+
+This adapter represents the solver port for CLI workflows without depending on a live solver process. It lets tests, demos, and early integration paths exercise solver-shaped artifacts while preserving deterministic output.
+
 ## Behavior
 - `createSolverAdapter({ fixturePath })` returns an adapter with `solve(request)`.
 - If `fixturePath` is provided, the adapter returns the parsed JSON fixture as the SolverResult.

--- a/packages/adapters-cli/src/mcp/README.md
+++ b/packages/adapters-cli/src/mcp/README.md
@@ -12,6 +12,16 @@
 
 The server is a thin adapter over the CLI command surface in `packages/adapters-cli/src/cli/ak-impl.mjs`. Each MCP tool maps to one CLI command, translates JSON input into CLI flags, executes the command, and returns structured JSON back to the client.
 
+## Mental Model
+
+The MCP server is the structured-tool version of `ak.mjs`. It does not create a separate runtime path:
+
+```text
+MCP client -> agent-kernel-cli MCP server -> adapters-cli command -> runtime -> core-ts
+```
+
+Use MCP when a harness can call tools directly and needs JSON-shaped inputs and outputs. Use the CLI when you are manually debugging, scripting outside an MCP client, or want to inspect raw stdout/stderr behavior.
+
 Use the MCP server when your harness can call tools directly and you want:
 
 - structured JSON inputs instead of shell-escaped flags
@@ -25,6 +35,18 @@ Use the CLI directly when you want:
 - manual debugging with stdout/stderr
 - shell pipelines or scripting outside an MCP client
 - to inspect raw command behavior without MCP wrapping
+
+## Workflow Map
+
+| Workflow | MCP tools | Typical result |
+| --- | --- | --- |
+| Author content | `ak_create`, `ak_configure`, `ak_room_plan`, `ak_delver_plan`, `ak_warden_plan` | BuildSpec, bundle, manifest, runtime inputs |
+| Build and execute | `ak_build`, `ak_configurator`, `ak_run`, `ak_replay`, `ak_budget`, `ak_scenario` | Run artifacts, TickFrames, budget receipts |
+| Inspect outputs | `ak_show`, `ak_diff`, `ak_runs_list`, `ak_inspect`, `ak_narrate`, `ak_schemas` | Summaries, schema catalog, narrative output |
+| LLM planning | `ak_llm`, `ak_ollama`, `ak_llm_plan` | Captured LLM responses and generated artifacts |
+| External adapters | `ak_ipfs`, `ak_ipfs_publish`, `ak_ipfs_load`, `ak_blockchain`, `ak_blockchain_mint`, `ak_blockchain_load` | Adapter response artifacts |
+
+The most common agent loop is: `ak_create` or `ak_llm_plan` -> `ak_run` -> `ak_show`/`ak_inspect` -> `ak_narrate` or `ak_diff`.
 
 ## Quick Start
 

--- a/packages/adapters-test/README.md
+++ b/packages/adapters-test/README.md
@@ -3,6 +3,10 @@
 This package contains **adapter implementations** that return deterministic,
 fixture-backed responses for tests and replay. It is not a test suite itself.
 
+## Where it fits
+
+`adapters-test` sits beside the real CLI and web adapters. It implements the same port-shaped behavior with in-memory fixtures so tests can exercise runtime flows without IPFS gateways, JSON-RPC endpoints, or live model servers.
+
 ## Purpose
 
 `adapters-test` exists to provide predictable versions of external IO adapters:
@@ -19,7 +23,7 @@ is **where tests live**.
 
 ## Usage
 
-```
+```js
 import { createIpfsTestAdapter } from "./src/adapters/ipfs/index.js";
 
 const ipfs = createIpfsTestAdapter({ fixtures: { bafy123: "{\"ok\":true}" } });

--- a/packages/adapters-test/src/adapters/blockchain/README.md
+++ b/packages/adapters-test/src/adapters/blockchain/README.md
@@ -2,6 +2,10 @@
 
 Purpose: deterministic blockchain fixtures for tests without network access.
 
+## How it fits
+
+Use this adapter when runtime, CLI, or UI tests need blockchain-shaped behavior but must stay offline and repeatable. It mirrors the blockchain port at the fixture level; it is not a JSON-RPC client.
+
 This adapter:
 - Returns fixed balances by address.
 - Returns fixed RPC responses by method/params.
@@ -10,7 +14,7 @@ Use this in tests to keep budget checks and policies deterministic.
 
 ## Usage
 
-```
+```js
 import { createBlockchainTestAdapter } from "./index.js";
 
 const blockchain = createBlockchainTestAdapter({ balances: { "0xabc": "0x1" } });

--- a/packages/adapters-test/src/adapters/ipfs/README.md
+++ b/packages/adapters-test/src/adapters/ipfs/README.md
@@ -2,6 +2,10 @@
 
 Purpose: deterministic IPFS fixtures for tests without network access.
 
+## How it fits
+
+Use this adapter when tests need CID/path lookup behavior without touching an IPFS gateway. Fixtures can be provided up front or registered during the test.
+
 This adapter:
 - Returns fixture text/JSON for a CID and optional path.
 - Allows tests to register fixtures at runtime.
@@ -10,7 +14,7 @@ Use this in tests to keep runs deterministic and replayable.
 
 ## Usage
 
-```
+```js
 import { createIpfsTestAdapter } from "./index.js";
 
 const ipfs = createIpfsTestAdapter({ fixtures: { bafy123: "{\"ok\":true}" } });

--- a/packages/adapters-test/src/adapters/llm/README.md
+++ b/packages/adapters-test/src/adapters/llm/README.md
@@ -2,6 +2,10 @@
 
 Purpose: deterministic LLM fixtures for tests without model dependencies.
 
+## How it fits
+
+Use this adapter when a test needs LLM-shaped responses without loading a model or making network calls. The response map is keyed by `model:prompt`, which keeps planner tests deterministic and replayable.
+
 This adapter:
 - Returns fixed responses for model/prompt pairs.
 - Allows tests to register responses at runtime.
@@ -10,7 +14,7 @@ Use this to keep strategy generation deterministic in test runs.
 
 ## Usage
 
-```
+```js
 import { createLlmTestAdapter } from "./index.js";
 
 const llm = createLlmTestAdapter({

--- a/packages/adapters-web/src/adapters/blockchain/README.md
+++ b/packages/adapters-web/src/adapters/blockchain/README.md
@@ -2,6 +2,10 @@
 
 Purpose: query blockchain state (e.g., balances) from the browser via JSON-RPC.
 
+## How it fits
+
+This browser adapter is for UI-hosted workflows that need blockchain facts through the same port boundary as the CLI. It performs browser `fetch` calls and remains outside `core-ts`.
+
 This adapter:
 - Provides a minimal JSON-RPC client.
 - Exposes `getBalance` and `getChainId` helpers.
@@ -10,7 +14,7 @@ It is intended for Orchestrator/Allocator workflows and never used inside `core-
 
 ## Usage
 
-```
+```js
 import { createBlockchainAdapter } from "./index.js";
 
 const blockchain = createBlockchainAdapter({ rpcUrl: "https://rpc.example" });

--- a/packages/adapters-web/src/adapters/ipfs/README.md
+++ b/packages/adapters-web/src/adapters/ipfs/README.md
@@ -2,6 +2,10 @@
 
 Purpose: fetch artifacts from IPFS via an HTTP gateway for browser-based workflows.
 
+## How it fits
+
+This browser adapter loads artifact payloads through an HTTP gateway for UI workflows. Any data that affects deterministic execution should still be represented as captured artifacts before replay.
+
 This adapter:
 - Builds gateway URLs for IPFS CIDs.
 - Fetches text or JSON payloads using `fetch`.
@@ -10,7 +14,7 @@ It is intended for use by runtime personas (e.g., Orchestrator) and never called
 
 ## Usage
 
-```
+```js
 import { createIpfsAdapter } from "./index.js";
 
 const ipfs = createIpfsAdapter({ gatewayUrl: "https://ipfs.io/ipfs" });

--- a/packages/adapters-web/src/adapters/llm/README.md
+++ b/packages/adapters-web/src/adapters/llm/README.md
@@ -2,6 +2,10 @@
 
 Purpose: request strategic guidance or content from an LLM HTTP endpoint (Ollama/OpenAI-compatible).
 
+## How it fits
+
+This browser adapter is for UI-hosted planning or guidance flows. It returns raw endpoint responses to downstream runtime code and remains outside deterministic simulation execution unless responses are captured as artifacts.
+
 This adapter:
 - Calls an Ollama-style `/api/generate` endpoint.
 - Returns the raw JSON response for downstream processing.
@@ -10,7 +14,7 @@ It is intended for Orchestrator/Director workflows and never used inside `core-t
 
 ## Usage
 
-```
+```js
 import { createLlmAdapter } from "./index.js";
 
 const llm = createLlmAdapter({ baseUrl: "http://localhost:11434" });

--- a/packages/runtime/src/personas/actor/README.md
+++ b/packages/runtime/src/personas/actor/README.md
@@ -14,6 +14,16 @@ This document focuses on the **Actor persona** as a decision-making and behavior
 
 ---
 
+## At a Glance
+
+| Area | Actor responsibility |
+| --- | --- |
+| Owns | Intent selection and action proposals for actors |
+| Does not own | Rule legality, state mutation, IO, or artifact persistence |
+| Primary inputs | Observations, motivations, candidate actions, runtime-decision context |
+| Primary outputs | Proposed actions and runtime-decision request artifacts |
+| Boundary | `core-ts` remains authoritative for accepted/rejected outcomes |
+
 ## Persona Scope
 
 The Actor persona is responsible for **deciding what to do**, not for enforcing what happens.

--- a/packages/runtime/src/personas/allocator/README.md
+++ b/packages/runtime/src/personas/allocator/README.md
@@ -8,6 +8,16 @@ This document defines the Allocator as a **policy and coordination role**. Detai
 
 ---
 
+## At a Glance
+
+| Area | Allocator responsibility |
+| --- | --- |
+| Owns | Budgets, price lists, spend proposals, allocation decisions, receipts |
+| Does not own | Simulation state mutation, action legality, or direct resource deduction |
+| Primary inputs | Budget artifacts, price lists, proposed actor/layout/action costs |
+| Primary outputs | Budget receipts, approval/rejection decisions, reconciliation signals |
+| Boundary | `core-ts` enforces provided caps; Allocator defines policy |
+
 ## Persona Scope
 
 The Allocator persona is responsible for **deciding whether proposed activity is affordable**, not for enforcing the effects of that activity.

--- a/packages/runtime/src/personas/annotator/README.md
+++ b/packages/runtime/src/personas/annotator/README.md
@@ -1,13 +1,24 @@
-The Annotator is the steward of runtime truth. It actively “visits” actors and other personas each tick to collect telemetry, aggregates those raw signals into structured summaries, and emits the results so Orchestrator, the UI, and observability stacks (Prometheus/Grafana) can consume an accurate view of what happened.
 # Annotator Persona
 
 The Annotator is the **telemetry and observability persona** for the simulation.
 
 It is responsible for capturing what occurred during execution, structuring that information into stable, queryable formats, and emitting it for downstream consumption. The Annotator does not influence simulation outcomes; it records them.
 
+In practice, the Annotator is the steward of runtime truth: it collects telemetry from actors and personas, aggregates raw signals into structured summaries, and emits accurate run views for the Orchestrator, UI, and observability stacks.
+
 This document defines the Annotator as a **runtime observation and formatting role**. Simulation rules, state transitions, and event generation remain the responsibility of the simulation core (`core-ts`).
 
 ---
+
+## At a Glance
+
+| Area | Annotator responsibility |
+| --- | --- |
+| Owns | Telemetry collection, summarization, and inspection-ready records |
+| Does not own | Decisions, rule enforcement, state mutation, or feedback into execution |
+| Primary inputs | Events, effects, TickFrames, persona views, state snapshots |
+| Primary outputs | Telemetry records, summaries, timeline/inspection artifacts |
+| Boundary | Observes runtime truth; never changes it |
 
 ## Persona Scope
 

--- a/packages/runtime/src/personas/configurator/README.md
+++ b/packages/runtime/src/personas/configurator/README.md
@@ -8,6 +8,16 @@ This document defines the Configurator as a **runtime composition and validation
 
 ---
 
+## At a Glance
+
+| Area | Configurator responsibility |
+| --- | --- |
+| Owns | Building coherent executable configuration artifacts |
+| Does not own | Runtime conflict resolution, tick execution, or simulation rule outcomes |
+| Primary inputs | Director plans, level-gen inputs, actor payloads, budget receipts |
+| Primary outputs | `SimConfigArtifact`, `InitialStateArtifact`, spend proposals, resource bundles |
+| Boundary | Prepares startup state; `core-ts` enforces rules after execution begins |
+
 ## Persona Scope
 
 The Configurator persona is responsible for **deciding how a simulation is set up**, not for enforcing what happens once it runs.

--- a/packages/runtime/src/personas/director/README.md
+++ b/packages/runtime/src/personas/director/README.md
@@ -1,14 +1,24 @@
-The Director turns goals into structured plans. When LLMs are used (Ollama/OpenAI-style), the Director authors the prompt plan and response contract, and the Orchestrator performs the IO, captures the exchange, and hands the resulting guidance back as explicit artifacts.
-
 # Director Persona
 
 The Director is the **planning and intent-translation persona**.
 
 It is responsible for turning high-level strategy into **structured, actionable plans** that can be executed by downstream personas. The Director bridges the gap between external intent and internal execution by shaping goals, constraints, and tactics into a form the system can reason about.
 
+When LLMs are used, the Director authors the prompt plan and response contract. The Orchestrator performs the IO, captures the exchange, and hands the resulting guidance back as explicit artifacts.
+
 This document defines the Director as a **runtime planning role**. Simulation rules, configuration assembly, budgeting policy, and execution remain the responsibility of other personas and the simulation core (`core-ts`).
 
 ---
+
+## At a Glance
+
+| Area | Director responsibility |
+| --- | --- |
+| Owns | Translating goals into structured plans and prompt contracts |
+| Does not own | IO, configuration assembly, budget enforcement, or execution |
+| Primary inputs | Human/agent intent, scenario objectives, external guidance artifacts |
+| Primary outputs | Planning artifacts, constraints, directives, prompt plans |
+| Boundary | Defines what should be attempted; downstream personas decide feasibility and execution |
 
 ## Persona Scope
 

--- a/packages/runtime/src/personas/moderator/README.md
+++ b/packages/runtime/src/personas/moderator/README.md
@@ -8,6 +8,16 @@ This document defines the Moderator as a **runtime execution role**. Simulation 
 
 ---
 
+## At a Glance
+
+| Area | Moderator responsibility |
+| --- | --- |
+| Owns | Tick advancement, phase order, action sequencing, effect routing |
+| Does not own | Strategy, configuration assembly, external IO, or rule legality |
+| Primary inputs | Configuration artifacts, actor action proposals, execution policies |
+| Primary outputs | Ordered action batches, TickFrames, effects logs, run summaries |
+| Boundary | Calls `core-ts`; does not replace `core-ts` rule enforcement |
+
 ## Persona Scope
 
 The Moderator persona is responsible for **how the simulation is executed**, not for deciding what should be attempted or how the world is configured.

--- a/packages/runtime/src/personas/orchestrator/README.md
+++ b/packages/runtime/src/personas/orchestrator/README.md
@@ -8,6 +8,16 @@ This document defines the Orchestrator as a **runtime integration role**. Planni
 
 ---
 
+## At a Glance
+
+| Area | Orchestrator responsibility |
+| --- | --- |
+| Owns | External request intake, adapter selection, deferred side-effect coordination |
+| Does not own | Planning decisions, configuration assembly, action choice, or core state |
+| Primary inputs | UI/CLI/API requests, prompts, adapter payloads, deferred effects |
+| Primary outputs | Normalized request envelopes, captured external inputs, post-run side effects |
+| Boundary | Interacts with the outside world around execution, not inside deterministic core execution |
+
 ## Persona Scope
 
 The Orchestrator persona is responsible for **managing external interaction**, not for deciding what the simulation should do internally.

--- a/packages/runtime/src/render/source-assets/actor-medallions/README.md
+++ b/packages/runtime/src/render/source-assets/actor-medallions/README.md
@@ -2,6 +2,10 @@
 
 These are checked-in source contact sheets for the actor medallion sprite pipeline.
 
+## How these assets fit
+
+The source sheets are design inputs for generated review/runtime assets. Runtime rendering composes medallions through deterministic RGBA buffer logic; image decoding and PNG writing stay in the asset-generation CLI.
+
 - `approved-affinity-sprite-sheet.png` is a repo-local copy derived from the approved skill reference at `/Users/darren/.codex/skills/ak-sprite-art-director/assets/approved-affinity-sprite-sheet.png`. Do not overwrite the original skill reference.
 - `frame-template-components.png`, `actor-symbol-components.png`, and `motivation-symbol-components.png` are source contact sheets used by `tools/visual-assets/generate-actor-medallion-assets.mts`.
 - Runtime composition is pure RGBA buffer logic in `packages/runtime/src/render/actor-medallion-composer.ts`; PNG decoding and writing stays in the generation CLI.

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -4,6 +4,12 @@
 **macOS** (primary) and **Ubuntu** (secondary). It is **idempotent** — re-running it
 fixes drift rather than duplicating state.
 
+## What this is for
+
+The repo keeps load-bearing source, tests, fixtures, and architecture docs in git. Long-lived working notes, active plans, snapshots, and non-load-bearing research live in the paired Obsidian vault. This script wires those two worlds together so local agent workflows can read and update `local-codex/*` paths while the content actually lives in `~/vault`.
+
+Run this when setting up a new machine, repairing vault symlinks, refreshing Claude/Obsidian skills, or validating the knowledge-management hooks.
+
 ## What it sets up
 
 1. **Prerequisites** — `git`, `gh`, `jq`, `node`, `syncthing` (via Homebrew on Mac,
@@ -43,6 +49,11 @@ fixes drift rather than duplicating state.
 8. **Verify** — sanity checks each component.
 
 ## Usage
+
+Choose exactly one role:
+
+- **Primary Mac**: owns the one-time repo migration and pushes the resulting git changes.
+- **Secondary Ubuntu**: installs the same tooling and waits for Syncthing to fill the vault.
 
 ### One-time on the Mac (primary)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,6 +4,12 @@
 
 This file is the entry point for **low-complexity test work** delegated to a local model, typically Ollama launched through the Claude Code harness.
 
+## Mental Model
+
+The test suite protects deterministic behavior. Tests should prove that artifact contracts, adapters, runtime personas, UI surfaces, and `core-ts` rules behave as specified against stable fixtures.
+
+Benchmarks are separate. They measure LLM tool-call quality and stress behavior; they do not replace correctness tests.
+
 The goal is not to invent tests from raw prose. The goal is to:
 
 1. discover an existing test pattern
@@ -17,6 +23,15 @@ The goal is not to invent tests from raw prose. The goal is to:
 - Ollama or another local/cheap model running through the Claude harness
 - Claude Code when delegating low-risk test expansion work
 - Codex when it needs a repo-local test authoring reference
+
+## Where Tests Live
+
+- `tests/core-ts/`: pure deterministic core behavior.
+- `tests/runtime/` and `tests/personas/`: runtime contracts, command kernel behavior, persona transitions.
+- `tests/adapters-cli/`, `tests/adapters-web/`, `tests/adapters-test/`: adapter-level behavior.
+- `tests/integration/`: cross-package and MCP/CLI/UI flows.
+- `tests/ui-web/` and `tests/playwright/`: browser/UI behavior.
+- `tests/fixtures/`: shared deterministic input and expected-output artifacts.
 
 ## Default Rule
 

--- a/tests/fixtures/adapters/README.md
+++ b/tests/fixtures/adapters/README.md
@@ -3,6 +3,12 @@
 These files are deterministic payloads used by adapter tests to avoid network calls.
 Use them to stub fetch/RPC responses when testing CLI or web adapters.
 
+## How to use these fixtures
+
+These payloads represent external systems at the adapter boundary. They should stay small, explicit, and stable so tests can verify IPFS, blockchain, LLM, and effect-routing behavior without live services.
+
+Add a new fixture here when a test needs a reusable external response shape. Keep one-off runtime artifacts under `tests/fixtures/artifacts/` instead.
+
 ## Files
 - ipfs-price-list.json: PriceList artifact returned by IPFS adapter tests.
 - blockchain-chain-id.json: JSON-RPC chain id result for blockchain adapter tests.

--- a/tests/fixtures/artifacts/README.md
+++ b/tests/fixtures/artifacts/README.md
@@ -4,6 +4,12 @@ These JSON files are minimal, schema-valid artifacts used by tests to validate
 loading, serialization, and cross-artifact wiring. Each file contains a single
 artifact and should stay stable unless the schema version changes.
 
+## How to use these fixtures
+
+Use these files when a test needs canonical artifact input or a stable expected shape. Prefer adding the smallest fixture that demonstrates the schema edge, and keep negative cases under `tests/fixtures/artifacts/invalid`.
+
+When a schema changes, update the fixture and the tests in the same change so the contract remains auditable.
+
 General rules:
 - Each file uses schemaVersion 1 and includes required meta where applicable.
 - References (intent/plan/budget/simConfig) point to other fixture ids.

--- a/tests/llm-suitability/README.md
+++ b/tests/llm-suitability/README.md
@@ -3,6 +3,10 @@
 These scenarios benchmark whether a local Ollama model can generate useful Vitests for
 agent-kernel code. They are used by `/Users/darren/remote-ollama-mac llm-suitability-test`.
 
+## How this differs from tests
+
+These files are benchmark prompts and scoring oracles, not production tests. They evaluate whether a model can author plausible tests from constrained context. The actual deterministic correctness suite still lives under `tests/**/*.test.*` and runs through `pnpm run test`.
+
 Each scenario contains:
 - `task.md` — prompt task shown to the candidate model.
 - `context.md` — repo conventions and relevant existing-test style.

--- a/tools/remote-ollama-control/README.md
+++ b/tools/remote-ollama-control/README.md
@@ -7,6 +7,25 @@ This package makes the MacBook the control/client machine and the Ubuntu box the
 - Default architecture: `Mac Claude CLI -> selected remote Ollama endpoint`.
 - Optional project workflow: Ubuntu can keep a git checkout synced, snapshot dirty work, pull from `origin/main`, and push `HEAD` back to `main` when explicitly invoked.
 
+## What this tool is for
+
+Use this tool when local agent workflows should spend inference work on the Ubuntu GPU machine while the Mac keeps control of prompts, tunnels, benchmarks, and result files. It manages three concerns in one place:
+
+- starting/stopping profile-specific Ollama instances on Ubuntu;
+- opening safe SSH-tunnel routes from the Mac;
+- running local or remote benchmark/control commands with consistent environment variables.
+
+## Common tasks
+
+| Need | Command family |
+| --- | --- |
+| Check remote Ollama state | `status`, `ps`, `logs`, `telemetry`, `doctor` |
+| Start or restart a profile | `start`, `restart`, `stop`, `dry-run start` |
+| Run Claude/Codex-side work through remote Ollama | `claude`, `run-local`, `use-remote-ollama` |
+| Run commands on Ubuntu | `exec` |
+| Benchmark models or tool-call generation | `benchmark`, `benchmark-matrix`, `benchmark-hardware`, `run-content-gen` |
+| Keep the remote checkout safe | `project-safety-check`, `project-sync`, `project-push-main` |
+
 ## Profiles
 
 Profiles live at `tools/remote-ollama-control/config/llm-profiles.json` in the `agent-kernel` repo. From this tool directory, the relative path is `config/llm-profiles.json`.
@@ -264,6 +283,7 @@ Results are written locally under `results/<timestamp>-<scenario>/` as `runs.jso
   --models qwen2.5-coder:14b,qwen2.5-coder:7b,qwen3-coder:30b \
   --contexts 4096,8192,16384,32768 \
   --scenario vitest-generation
+```
 
 Use the hardware benchmark when you want standard settings for the installed
 model catalog. It reads `config/models.json`, runs 30B models only on `dual`,
@@ -296,6 +316,7 @@ section: `defaultScenarios`, `defaultContexts`, and `defaultEfforts`. Use
 `--no-reset` only when you intentionally want the command to fail instead of
 restarting an already-running profile.
 
+```bash
 ./bin/remote-ollama-mac benchmark \
   --profile dual \
   --model GLM-4.7-Flash:latest \


### PR DESCRIPTION
## Summary

- Add newcomer-oriented overview and reading-order guidance to the root and docs READMEs.
- Add workflow maps to the CLI and MCP READMEs so readers can pick the right command/tool family before reading reference details.
- Add concise boundary/context sections to adapter, persona, setup, test, fixture, asset, and remote Ollama README files.
- Fix a Markdown code-fence issue in the remote Ollama benchmark section.

## Impact

This is a documentation-only update intended to make the existing project structure and workflows easier to skim for someone unfamiliar with the repo. It does not change command semantics, artifact contracts, runtime behavior, or tests.

## Validation

- `git diff --check`
- Markdown fence sanity check across all 29 modified README files
- `pnpm run test` (280 test files passed; 1852 tests passed, 8 skipped)

## Notes

The local worktree had unrelated staged/deleted/code changes before this documentation pass. This PR commit includes only the README documentation updates.