### PR TITLE
Fix game economy allocation enforcement

### DIFF
--- a/packages/adapters-cli/README.md
+++ b/packages/adapters-cli/README.md
@@ -35,7 +35,7 @@ by passing `--out-dir`.
 
 ### Structured stdout contract
 The automation-facing authoring and execution commands emit exactly one JSON object line to stdout on success:
-`build`, `create`, `configure`, `room-plan`, `delver-plan`, `warden-plan`, `run`, `inspect`, `narrate`, `llm-plan`, `scenario`, `show`, `diff`, and `runs list`.
+`build`, `create`, `configure`, `room-plan`, `hazard-plan`, `resource-plan`, `delver-plan`, `warden-plan`, `run`, `inspect`, `narrate`, `llm-plan`, `scenario`, `show`, `diff`, and `runs list`.
 
 Success shape:
 ```json
@@ -163,8 +163,9 @@ Inputs/outputs:
 Generic additive agent-facing authoring commands that normalize freeform text plus
 structured object flags into an inline `AgentCommandRequestArtifact`, compile that
 request into `BuildSpec`, and run the existing deterministic build/configurator flow.
-These commands do not replace `room-plan`, `delver-plan`, `warden-plan`, `build`, or
-`configurator`; they provide a single multi-object entrypoint for automation callers.
+These commands do not replace `room-plan`, `hazard-plan`, `resource-plan`,
+`delver-plan`, `warden-plan`, `build`, or `configurator`; they provide a
+single multi-object entrypoint for automation callers.
 
 Inputs/outputs:
 - Input: optional `--text`, repeatable `--room`, `--floor-tile`, `--trap`, `--hazard`,
@@ -178,7 +179,7 @@ Inputs/outputs:
 - `--trap` format: `x=<n>;y=<n>;affinity=<kind>[;expression=<kind>][;stacks=<n>][;blocking=<true|false>][;id=<id>][;vitals=<vital>:<max>:<regen>|<vital>:<current>:<max>:<regen>,...]`
 - `--hazard` format: `affinity=<kind>;expression=<push|pull|emit|draw>;proximityRadius=<n>[;mana=one-time:<amount>|regen:<current>:<max>:<regen>][;durability=one-time:<amount>|regen:<current>:<max>:<regen>][;id=<id>]`
   Produces a `HazardArtifact` written to `hazard-<n>.json` in the output directory.
-- `--resource` format: `tier=<level|permanent>;stat=<vitalMax|vitalRegen|affinity|affinityStack|pushExpression>;delta=<n>;dropRate=<n>[;id=<id>]`
+- `--resource` format: `permanenceMode=<consumable|level|permanent>;vital=<health|mana|stamina>;delta=<n>[;id=<id>]`, or legacy `tier=<level|permanent>;stat=<vitalMax|vitalRegen|affinity|affinityStack|pushExpression>;delta=<n>;dropRate=<n>[;id=<id>]`
   Produces a `ResourceArtifact` written to `resource-artifact-<n>.json` in the output directory.
 - `--delver` accepts `goals=max_mana[:<priority>],mana_regen[:<priority>]` to record qualitative
   vitals goals as optimization directions over the existing deterministic vitals and regen cost model.
@@ -238,6 +239,44 @@ Inputs/outputs:
   `manifest.json`, `telemetry.json`.
 - `--emit-intermediates` additionally persists `intent.json` and `plan.json`.
 
+### `hazard-plan`
+Builds a `BuildSpec` directly from Hazard authoring flags and runs the standard
+build pipeline. This is the first-order hazard command for configuring hazard
+cards and hazard-only budget checks without routing through mixed-object authoring.
+
+Inputs/outputs:
+- Input: one or more `--hazard` flags (repeatable), optional `--goal`,
+  `--dungeon-affinity`, optional `--budget-tokens`, optional `--budget` +
+  `--price-list`, plus standard `--run-id`, `--created-at`, `--out-dir`.
+- `--hazard` format: `affinity=<kind>;expression=<push|pull|emit|draw>;proximityRadius=<n>[;mana=one-time:<amount>|regen:<current>:<max>:<regen>][;durability=one-time:<amount>|regen:<current>:<max>:<regen>][;id=<id>]`
+- A budgeted run uses an explicit hazards-only allocation pool, so hazard base,
+  affinity, and vital spend are capped against hazards instead of rooms or actors.
+- Output dir: `artifacts/runs/<runId>/hazard-plan` by default, or `--out-dir`.
+- Outputs: `spec.json`, optional `budget.json`, `price-list.json`,
+  `budget-receipt.json`, `hazard-<n>.json`, `sim-config.json`,
+  `initial-state.json`, `resource-bundle.json`, plus `bundle.json`,
+  `manifest.json`, `telemetry.json`.
+- `--emit-intermediates` additionally persists `intent.json` and `plan.json`.
+
+### `resource-plan`
+Builds a `BuildSpec` directly from Resource authoring flags and runs the standard
+build pipeline. This is the first-order resource command for configuring resource
+cards and resource-only budget checks without routing through mixed-object authoring.
+
+Inputs/outputs:
+- Input: one or more `--resource` flags (repeatable), optional `--goal`,
+  `--dungeon-affinity`, optional `--budget-tokens`, optional `--budget` +
+  `--price-list`, plus standard `--run-id`, `--created-at`, `--out-dir`.
+- `--resource` format: `permanenceMode=<consumable|level|permanent>;vital=<health|mana|stamina>;delta=<n>[;id=<id>]`, or legacy `tier=<level|permanent>;stat=<vitalMax|vitalRegen|affinity|affinityStack|pushExpression>;delta=<n>;dropRate=<n>[;id=<id>]`
+- A budgeted run uses an explicit resources-only allocation pool, so resource
+  grants are capped against resources instead of actor or shared spend.
+- Output dir: `artifacts/runs/<runId>/resource-plan` by default, or `--out-dir`.
+- Outputs: `spec.json`, optional `budget.json`, `price-list.json`,
+  `budget-receipt.json`, `resource-artifact-<n>.json`, `sim-config.json`,
+  `initial-state.json`, `resource-bundle.json`, plus `bundle.json`,
+  `manifest.json`, `telemetry.json`.
+- `--emit-intermediates` additionally persists `intent.json` and `plan.json`.
+
 ### `delver-plan`
 Builds a `BuildSpec` directly from Delver authoring flags (no hand-edited JSON required) and
 runs the standard build pipeline. This is the direct delver parity command for CLI card authoring.
@@ -287,8 +326,9 @@ Inputs/outputs:
 The canonical additive contract for agent-friendly CLI authoring is
 `agent-kernel/AgentCommandRequestArtifact` (schema version `1`). This milestone
 defines the contract and taxonomy only; it does not replace existing commands.
-Current `room-plan`, `delver-plan`, `warden-plan`, `build`, and `configurator`
-flows remain valid and are the backward-compatible execution paths.
+Current `room-plan`, `hazard-plan`, `resource-plan`, `delver-plan`,
+`warden-plan`, `build`, and `configurator` flows remain valid and are the
+backward-compatible execution paths.
 
 Top-level shape:
 - `meta`: standard artifact metadata (`id`, `runId`, `createdAt`, `producedBy`).
@@ -309,6 +349,8 @@ Canonical object taxonomy:
 - `room`: authored room cards and room-level composition hints. Default compile targets are `build_spec_plan` and `build_spec_configurator`.
 - `floor_tile`: authored floor/wall/barrier tile intent. Default compile target is `build_spec_configurator`.
 - `trap`: authored trap placement or trap-affinity intent. Default compile target is `build_spec_configurator`.
+- `hazard`: authored hazard cards and hazard-level affinity/vital spend. Default compile target is `build_spec_configurator`.
+- `resource`: authored resource reward cards. Default compile target is `build_spec_configurator`.
 - `delver`: authored player-facing actor cards. Default compile targets are `build_spec_plan` and `build_spec_configurator`.
 - `warden`: authored opposing actor cards. Default compile targets are `build_spec_plan` and `build_spec_configurator`.
 - `shared_config`: authored cross-cutting dungeon or run settings. Default compile targets are `build_spec_intent`, `build_spec_plan`, and `build_spec_configurator`.
@@ -321,10 +363,12 @@ Compilation target semantics:
 
 Current compatibility rules:
 - `room-plan` remains the direct additive authoring path for `room` requests and any `shared_config` budget/affinity hints it already supports.
+- `hazard-plan` remains the direct additive authoring path for `hazard` requests and compatible `shared_config` hints.
+- `resource-plan` remains the direct additive authoring path for `resource` requests and compatible `shared_config` hints.
 - `delver-plan` remains the direct additive authoring path for `delver` requests and compatible `shared_config` hints.
 - `warden-plan` remains the direct additive authoring path for `warden` requests and compatible `shared_config` hints.
 - `build --spec` remains the generic entry point once an agent command has been compiled to `BuildSpec`.
-- `configurator` remains the direct entry point for deterministic `levelGen`, `actors`, trap placement, and tile-shape payloads.
+- `configurator` remains the direct entry point for deterministic `levelGen`, `actors`, trap placement, hazard placement, resource drops, and tile-shape payloads.
 - `floor_tile` and richer `trap` requests are intentionally mapped as `build_spec_configurator` work first; when an authored request cannot be represented by current configurator inputs, it must declare `artifact_extension` instead of inventing an unversioned side channel.
 
 Build inputs/outputs:
@@ -387,6 +431,10 @@ node packages/adapters-cli/src/cli/ak.mjs create --text "Create a fire room with
 node packages/adapters-cli/src/cli/ak.mjs configure --text "Configure the trap layout for the room." --room "size=small;count=1" --trap "id=trap_fire;x=1;y=1;affinity=fire;expression=emit;stacks=1" --run-id run_configure_demo --created-at 2026-04-08T00:00:00Z --out-dir artifacts/configure_demo
 node packages/adapters-cli/src/cli/ak.mjs room-plan --room "size=small;count=2;affinities=dark:emit:2,fire:push:1" --room "size=large;count=1" --run-id run_room_plan_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/room_plan_demo
 node packages/adapters-cli/src/cli/ak.mjs room-plan --room "size=small;count=1;affinities=fire:emit:2" --budget tests/fixtures/artifacts/budget-artifact-v1-basic.json --price-list tests/fixtures/artifacts/price-list-artifact-v1-basic.json --run-id run_room_plan_budget_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/room_plan_budget_demo
+node packages/adapters-cli/src/cli/ak.mjs hazard-plan --hazard "affinity=fire;expression=emit;proximityRadius=2;mana=regen:4:4:1" --run-id run_hazard_plan_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/hazard_plan_demo
+node packages/adapters-cli/src/cli/ak.mjs hazard-plan --hazard "affinity=fire;expression=emit;proximityRadius=2;mana=regen:4:4:1" --budget-tokens 200 --run-id run_hazard_plan_budget_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/hazard_plan_budget_demo
+node packages/adapters-cli/src/cli/ak.mjs resource-plan --resource "permanenceMode=permanent;vital=mana;delta=6" --run-id run_resource_plan_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/resource_plan_demo
+node packages/adapters-cli/src/cli/ak.mjs resource-plan --resource "permanenceMode=permanent;vital=mana;delta=6" --budget-tokens 200 --run-id run_resource_plan_budget_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/resource_plan_budget_demo
 node packages/adapters-cli/src/cli/ak.mjs delver-plan --delver "count=2;affinity=fire;motivation=attacking" --delver "count=1;affinity=earth;motivation=patrolling" --run-id run_delver_plan_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/delver_plan_demo
 node packages/adapters-cli/src/cli/ak.mjs delver-plan --delver "count=1;affinity=fire" --budget tests/fixtures/artifacts/budget-artifact-v1-basic.json --price-list tests/fixtures/artifacts/price-list-artifact-v1-basic.json --run-id run_delver_plan_budget_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/delver_plan_budget_demo
 node packages/adapters-cli/src/cli/ak.mjs delver-plan --delver "count=1;affinity=fire;motivation=attacking;setup-mode=user;affinities=fire:push:3,wind:emit:2;vitals=health:12:12:1,mana:7:7:2,stamina:6:6:1,durability:5:5:0" --budget tests/fixtures/artifacts/budget-artifact-v1-basic.json --price-list tests/fixtures/artifacts/price-list-artifact-v1-basic.json --run-id run_delver_plan_advanced_demo --created-at 2025-01-01T00:00:00Z --out-dir artifacts/delver_plan_advanced_demo
@@ -413,17 +461,23 @@ node packages/adapters-cli/src/cli/ak.mjs llm --model phi4 --prompt "Summarize p
 node packages/adapters-cli/src/cli/ak.mjs solve --scenario "two actors conflict" --solver-fixture tests/fixtures/artifacts/solver-result-v1-basic.json
 ```
 
-UI-to-CLI parity recipes (Room/Delver/Warden, AD1):
+UI-to-CLI parity recipes (Room/Hazard/Resource/Delver/Warden, AD1):
 ```
 # 1) Room parity recipe (RP1-RP4): author rooms, costs, then smoke-run with one actor override.
 node packages/adapters-cli/src/cli/ak.mjs room-plan --room "size=small;count=2;affinities=dark:emit:2,fire:push:1" --room "size=large;count=1;affinities=water:pull:1" --budget tests/fixtures/artifacts/budget-artifact-v1-basic.json --price-list tests/fixtures/artifacts/price-list-artifact-v1-basic.json --run-id run_room_parity_recipe --created-at 2026-03-08T00:00:00Z --out-dir artifacts/parity-recipes/room
 node packages/adapters-cli/src/cli/ak.mjs run --sim-config artifacts/parity-recipes/room/sim-config.json --initial-state artifacts/parity-recipes/room/initial-state.json --actor room_probe,1,1,motivated --ticks 0 --run-id run_room_parity_recipe_playback --created-at 2026-03-08T00:00:00Z --out-dir artifacts/parity-recipes/room-run
 
-# 2) Delver parity recipe (AP1/AP2): direct advanced delver authoring + playback.
+# 2) Hazard parity recipe: direct hazard authoring + sidecar artifact.
+node packages/adapters-cli/src/cli/ak.mjs hazard-plan --hazard "affinity=fire;expression=emit;proximityRadius=2;mana=regen:4:4:1" --budget-tokens 200 --run-id run_hazard_parity_recipe --created-at 2026-03-08T00:00:00Z --out-dir artifacts/parity-recipes/hazard
+
+# 3) Resource parity recipe: direct resource authoring + sidecar artifact.
+node packages/adapters-cli/src/cli/ak.mjs resource-plan --resource "permanenceMode=permanent;vital=mana;delta=6" --budget-tokens 200 --run-id run_resource_parity_recipe --created-at 2026-03-08T00:00:00Z --out-dir artifacts/parity-recipes/resource
+
+# 4) Delver parity recipe (AP1/AP2): direct advanced delver authoring + playback.
 node packages/adapters-cli/src/cli/ak.mjs delver-plan --delver "count=1;affinity=fire;motivation=attacking;setup-mode=user;affinities=fire:push:3,wind:emit:2;vitals=health:12:12:1,mana:7:7:2,stamina:6:6:1,durability:5:5:0" --budget tests/fixtures/artifacts/budget-artifact-v1-basic.json --price-list tests/fixtures/artifacts/price-list-artifact-v1-basic.json --run-id run_delver_parity_recipe --created-at 2026-03-08T00:00:00Z --out-dir artifacts/parity-recipes/delver
 node packages/adapters-cli/src/cli/ak.mjs run --sim-config artifacts/parity-recipes/delver/sim-config.json --initial-state artifacts/parity-recipes/delver/initial-state.json --ticks 0 --run-id run_delver_parity_recipe_playback --created-at 2026-03-08T00:00:00Z --out-dir artifacts/parity-recipes/delver-run
 
-# 3) Warden parity recipe (DP1/DP2): direct advanced warden authoring + playback.
+# 5) Warden parity recipe (DP1/DP2): direct advanced warden authoring + playback.
 node packages/adapters-cli/src/cli/ak.mjs warden-plan --warden "count=1;affinity=dark;motivation=defending;affinities=dark:emit:4,earth:pull:1;vitals=health:15:15:0,mana:3:3:1,stamina:4:4:1,durability:8:8:0" --budget tests/fixtures/artifacts/budget-artifact-v1-basic.json --price-list tests/fixtures/artifacts/price-list-artifact-v1-basic.json --run-id run_warden_parity_recipe --created-at 2026-03-08T00:00:00Z --out-dir artifacts/parity-recipes/warden
 node packages/adapters-cli/src/cli/ak.mjs run --sim-config artifacts/parity-recipes/warden/sim-config.json --initial-state artifacts/parity-recipes/warden/initial-state.json --ticks 0 --run-id run_warden_parity_recipe_playback --created-at 2026-03-08T00:00:00Z --out-dir artifacts/parity-recipes/warden-run
 ```
@@ -442,6 +496,8 @@ node packages/adapters-cli/src/cli/ak.mjs llm-plan --scenario tests/fixtures/e2e
 node packages/adapters-cli/src/cli/ak.mjs llm-plan --text "a dungeon with two fire delvers" --catalog tests/fixtures/pool/catalog-basic.json --budget-tokens 200 --run-id run_llm_plan_text --created-at 2025-01-01T00:00:00Z
 node packages/adapters-cli/src/cli/ak.mjs llm-plan --prompt "Plan a small fire dungeon." --catalog tests/fixtures/pool/catalog-basic.json --model fixture --goal "Prompt-only goal" --budget-tokens 800 --fixture tests/fixtures/adapters/llm-generate-summary.json --run-id run_llm_plan_prompt --created-at 2025-01-01T00:00:00Z
 node packages/adapters-cli/src/cli/ak.mjs room-plan --room "size=small;count=1" --run-id run_room_plan_fixture --created-at 2025-01-01T00:00:00Z
+node packages/adapters-cli/src/cli/ak.mjs hazard-plan --hazard "affinity=fire;expression=emit;proximityRadius=2" --run-id run_hazard_plan_fixture --created-at 2025-01-01T00:00:00Z
+node packages/adapters-cli/src/cli/ak.mjs resource-plan --resource "permanenceMode=level;vital=health;delta=4" --run-id run_resource_plan_fixture --created-at 2025-01-01T00:00:00Z
 node packages/adapters-cli/src/cli/ak.mjs delver-plan --delver "count=1;affinity=fire" --run-id run_delver_plan_fixture --created-at 2025-01-01T00:00:00Z
 node packages/adapters-cli/src/cli/ak.mjs warden-plan --warden "count=1;affinity=dark" --run-id run_warden_plan_fixture --created-at 2025-01-01T00:00:00Z
 node packages/adapters-cli/src/cli/ak.mjs solve --scenario "two actors conflict" --solver-fixture tests/fixtures/artifacts/solver-result-v1-basic.json
@@ -501,6 +557,7 @@ Expected outputs (defaults when `--out-dir` is set):
 - llm: `llm.json`
 - solve: `solver-request.json`, `solver-result.json`
 - run: `tick-frames.json`, `effects-log.json`, `runtime-decision-captures.json`, `run-summary.json`, `action-log.json`
+- room-plan / hazard-plan / resource-plan / delver-plan / warden-plan: build handoff artifacts plus command-specific sidecars such as `hazard-<n>.json` and `resource-artifact-<n>.json`
 - configurator: `sim-config.json`, `initial-state.json` (plus `budget-receipt.json` when `--budget` + `--price-list` are provided)
 
 ---
@@ -522,6 +579,10 @@ Expected outputs (defaults when `--out-dir` is set):
 - Room authoring (`room-plan`): repeat `--room` with `size=<small|medium|large>;count=<n>;affinities=<kind>:<expression>:<stacks>,...`.
   If `affinities` is omitted, the command applies `dark:emit:2`.
   Use `--budget` + `--price-list` together to emit `budget-receipt.json` from the same run.
+- Hazard authoring (`hazard-plan`): repeat `--hazard` with `affinity=<kind>;expression=<push|pull|emit|draw>;proximityRadius=<n>[;mana=one-time:<amount>|regen:<current>:<max>:<regen>]`.
+  Use `--budget-tokens` or `--budget` + `--price-list` to enforce a hazards-only allocation receipt.
+- Resource authoring (`resource-plan`): repeat `--resource` with `permanenceMode=<consumable|level|permanent>;vital=<health|mana|stamina>;delta=<n>[;id=<id>]`.
+  Use `--budget-tokens` or `--budget` + `--price-list` to enforce a resources-only allocation receipt.
 - Delver authoring (`delver-plan`): repeat `--delver` with `count=<n>;affinity=<kind>;motivation=<kind>[;id=<id>]`.
   If `affinity` is omitted, the command falls back to `--dungeon-affinity` (default `fire`).
   If `motivation` is omitted, default is `attacking`.

--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -136,6 +136,8 @@ function usage() {
   node ${rel} create [--text text] [--room "..."] [--floor-tile "..."] [--trap "..."] [--hazard "..."] [--resource "..."] [--delver "..."] [--warden "..."] [--goal text] [--dungeon-affinity affinity] [--budget-tokens N] [--dungeon-budget-tokens N] [--delver-budget-tokens N] [--budget path --price-list path] [--out-dir dir] [--run-id id] [--created-at iso] [--emit-intermediates] [--dry-run]
   node ${rel} configure [--text text] [--room "..."] [--floor-tile "..."] [--trap "..."] [--hazard "..."] [--resource "..."] [--delver "..."] [--warden "..."] [--goal text] [--dungeon-affinity affinity] [--budget-tokens N] [--dungeon-budget-tokens N] [--delver-budget-tokens N] [--budget path --price-list path] [--out-dir dir] [--run-id id] [--created-at iso] [--emit-intermediates]
   node ${rel} room-plan --room "size=small;count=2" [--room "..."] [--goal text] [--dungeon-affinity affinity] [--budget-tokens N] [--budget path --price-list path] [--out-dir dir] [--run-id id] [--created-at iso] [--emit-intermediates]
+  node ${rel} hazard-plan --hazard "affinity=fire;expression=emit;proximityRadius=2[;mana=one-time:<amount>|regen:<current>:<max>:<regen>]" [--hazard "..."] [--goal text] [--dungeon-affinity affinity] [--budget-tokens N] [--budget path --price-list path] [--out-dir dir] [--run-id id] [--created-at iso] [--emit-intermediates]
+  node ${rel} resource-plan --resource "permanenceMode=<consumable|level|permanent>;vital=<health|mana|stamina>;delta=<n>" [--resource "..."] [--goal text] [--dungeon-affinity affinity] [--budget-tokens N] [--budget path --price-list path] [--out-dir dir] [--run-id id] [--created-at iso] [--emit-intermediates]
   node ${rel} delver-plan --delver "count=2;affinity=fire;motivation=attacking[;goals=max_mana:high,mana_regen:high]" [--delver "..."] [--goal text] [--dungeon-affinity affinity] [--budget-tokens N] [--budget path --price-list path] [--out-dir dir] [--run-id id] [--created-at iso] [--emit-intermediates]
   node ${rel} warden-plan --warden "count=2;affinity=dark;motivation=defending" [--warden "..."] [--goal text] [--dungeon-affinity affinity] [--budget-tokens N] [--budget path --price-list path] [--out-dir dir] [--run-id id] [--created-at iso] [--emit-intermediates]
   node ${rel} runs list
@@ -170,14 +172,14 @@ Options:
   --catalog       Catalog path for text/prompt-only llm-plan runs
   --goal          Goal text override (llm-plan prompt-only)
   --text          Freeform text for llm-plan; when no fixture is provided, CLI falls back to the default stub summary fixture
-  --dungeon-affinity Dungeon affinity for room/delver/warden summary defaults
+  --dungeon-affinity Dungeon affinity for plan summary defaults
   --budget-tokens Hard budget cap in tokens. If freeform text also states a budget, they must match.
   --dungeon-budget-tokens Separate hard budget cap for dungeon-side objects (rooms, tiles, traps, hazards).
   --delver-budget-tokens  Separate hard budget cap for delver-side objects (delvers, wardens).
   --emit-intermediates Persist non-canonical sidecar artifacts such as request/intent/plan/solver/captured-input files
   --floor-tile    Floor tile spec for create/configure (repeatable): count=<n>[;id=<id>]
-  --hazard        Hazard spec for create/configure (repeatable): affinity=<kind>;expression=<push|pull|emit|draw>;proximityRadius=<n>[;mana=one-time:<amount>|regen:<current>:<max>:<regen>][;durability=one-time:<amount>|regen:<current>:<max>:<regen>]
-  --resource      Resource artifact spec for create/configure (repeatable): tier=<level|permanent>;stat=<vitalMax|vitalRegen|affinity|affinityStack|pushExpression>;delta=<n>;dropRate=<n>[;id=<id>]
+  --hazard        Hazard spec for create/configure/hazard-plan (repeatable): affinity=<kind>;expression=<push|pull|emit|draw>;proximityRadius=<n>[;mana=one-time:<amount>|regen:<current>:<max>:<regen>]
+  --resource      Resource artifact spec for create/configure/resource-plan (repeatable): permanenceMode=<consumable|level|permanent>;vital=<health|mana|stamina>;delta=<n>[;id=<id>] or legacy tier=<level|permanent>;stat=<vitalMax|vitalRegen|affinity|affinityStack|pushExpression>;delta=<n>;dropRate=<n>[;id=<id>]
   --trap          Trap spec for create/configure (repeatable): x=<n>;y=<n>;affinity=<kind>[;expression=<push|pull|emit|draw>][;stacks=<n>][;blocking=<true|false>][;id=<id>][;vitals=<vital>:<max>:<regen>|<vital>:<current>:<max>:<regen>,...]
   --room          Room spec for room-plan (repeatable): size=<small|medium|large>;count=<n>  (rooms are generic containers; affinity comes from --trap/--hazard placement)
                     where <expression> is push|pull (spatial) or emit|draw (field)
@@ -200,7 +202,7 @@ Options:
   --fixture-mint  Fixture JSON-RPC response for blockchain-mint
   --fixture-load  Fixture JSON-RPC response for blockchain-load
   --run-id        Override run id for output artifacts
-  --created-at    Override createdAt timestamp (ISO-8601) for llm-plan/room-plan/delver-plan/warden-plan
+  --created-at    Override createdAt timestamp (ISO-8601) for llm-plan/room-plan/hazard-plan/resource-plan/delver-plan/warden-plan
   --dry-run       Validate schema/budget inputs without executing run or writing artifacts
   --help          Show this help
 
@@ -977,6 +979,19 @@ function parseHazardSpec(value, hazardIndex) {
   };
 }
 
+function parseHazardSpecs(rawHazards) {
+  const values = normalizeList(rawHazards)
+    .map((entry) => String(entry || "").trim())
+    .filter(Boolean);
+  if (values.length === 0) {
+    throw new Error("hazard-plan requires at least one --hazard entry.");
+  }
+  return values.map((value, index) => ({
+    prompt: value,
+    value: parseHazardSpec(value, index + 1),
+  }));
+}
+
 const RESOURCE_ALLOWED_TIERS = new Set(["level", "permanent"]);
 const RESOURCE_ALLOWED_STATS = new Set([
   "vitalMax", "vitalRegen", "affinity", "affinityStack", "pushExpression",
@@ -1087,6 +1102,19 @@ function parseResourceSpec(value, resourceIndex) {
     dropRate,
     _schemaVersion: 1,
   };
+}
+
+function parseResourceSpecs(rawResources) {
+  const values = normalizeList(rawResources)
+    .map((entry) => String(entry || "").trim())
+    .filter(Boolean);
+  if (values.length === 0) {
+    throw new Error("resource-plan requires at least one --resource entry.");
+  }
+  return values.map((value, index) => ({
+    prompt: value,
+    value: parseResourceSpec(value, index + 1),
+  }));
 }
 
 function parseDelverSpec(value, delverIndex, { defaultAffinity = DEFAULT_DUNGEON_AFFINITY } = {}) {
@@ -1534,11 +1562,39 @@ function assessBudgetedDelverRequirement(entry, delverIndex, priceListArtifact) 
   };
 }
 
+function assessBudgetedWardenRequirement(entry, wardenIndex, priceListArtifact) {
+  const card = entry?.value && typeof entry.value === "object" ? entry.value : {};
+  const count = Number.isInteger(card?.count) && card.count > 0 ? card.count : 1;
+  const priceMap = buildPriceMap(priceListArtifact);
+  const totalCost = calculateDelverCardUnitCost(card, priceMap) * count;
+  const requirementParts = [];
+  if (Array.isArray(card?.affinities) && card.affinities.length > 0) {
+    requirementParts.push(`affinities ${formatAffinityList(card.affinities)}`);
+  }
+  if (card?.vitals && typeof card.vitals === "object") {
+    requirementParts.push("explicit vitals");
+  }
+  return {
+    path: `warden[${wardenIndex}]`,
+    totalCost,
+    requirementSummary: requirementParts.length > 0
+      ? `requested ${joinConstraintClauses(requirementParts)}`
+      : "requested warden configuration",
+  };
+}
+
+function requirementKind(path = "") {
+  if (path.startsWith("room[")) return "room";
+  if (path.startsWith("warden[")) return "warden";
+  return "delver";
+}
+
 function ensureBudgetedFulfillmentFeasible({
   commandName,
   budgetTokens,
   rooms = [],
   delvers = [],
+  wardens = [],
   priceListArtifact,
 } = {}) {
   if (!Number.isInteger(budgetTokens) || budgetTokens <= 0) {
@@ -1559,7 +1615,8 @@ function ensureBudgetedFulfillmentFeasible({
 
   const roomRequirements = rooms.map((entry, index) => assessBudgetedRoomRequirement(entry, index + 1, priceListArtifact)).filter(Boolean);
   const delverRequirements = delvers.map((entry, index) => assessBudgetedDelverRequirement(entry, index + 1, priceListArtifact)).filter(Boolean);
-  const requirements = [...roomRequirements, ...delverRequirements];
+  const wardenRequirements = wardens.map((entry, index) => assessBudgetedWardenRequirement(entry, index + 1, priceListArtifact)).filter(Boolean);
+  const requirements = [...roomRequirements, ...delverRequirements, ...wardenRequirements];
   const minimumRequiredTokens = requirements.reduce((sum, entry) => sum + entry.totalCost, 0);
 
   if (minimumRequiredTokens > budgetTokens) {
@@ -1567,7 +1624,7 @@ function ensureBudgetedFulfillmentFeasible({
       outcome: AUTHORING_VALIDATION_OUTCOMES.insufficientBudget,
       summary: `hard budget is ${budgetTokens} tokens but minimum required spend is ${minimumRequiredTokens} tokens.`,
       issues: requirements.map((entry) => createAuthoringValidationIssue({
-        code: `${entry.path.startsWith("room[") ? "room" : "delver"}_minimum_cost_exceeds_budget`,
+        code: `${requirementKind(entry.path)}_minimum_cost_exceeds_budget`,
         path: entry.path,
         message: `${entry.path} requires at least ${entry.totalCost} tokens to preserve ${entry.requirementSummary}.`,
       })),
@@ -1946,6 +2003,8 @@ const FROM_RUN_STAGE_PRIORITY = Object.freeze([
   "create",
   "configure",
   "room-plan",
+  "hazard-plan",
+  "resource-plan",
   "delver-plan",
   "warden-plan",
   "run",
@@ -2164,6 +2223,8 @@ const STRUCTURED_STDOUT_COMMANDS = new Set([
   "create",
   "configure",
   "room-plan",
+  "hazard-plan",
+  "resource-plan",
   "delver-plan",
   "warden-plan",
   "run",
@@ -3559,6 +3620,66 @@ function assertAllowedRoomPlanArgs(args) {
   }
 }
 
+function assertAllowedHazardPlanArgs(args) {
+  const allowed = new Set([
+    "hazard",
+    "goal",
+    "dungeon-affinity",
+    "budget-tokens",
+    "budget",
+    "price-list",
+    "out-dir",
+    "run-id",
+    "created-at",
+    "emit-intermediates",
+  ]);
+  const unknown = [];
+  for (const key of Object.keys(args)) {
+    if (key === "_" || key === "help") {
+      continue;
+    }
+    if (!allowed.has(key)) {
+      unknown.push(`--${key}`);
+    }
+  }
+  if (Array.isArray(args._) && args._.length > 0) {
+    unknown.push(...args._);
+  }
+  if (unknown.length > 0) {
+    throw new Error(`hazard-plan only accepts --hazard, --goal, --dungeon-affinity, --budget-tokens, --budget, --price-list, --out-dir, --run-id, --created-at, and --emit-intermediates. Unknown: ${unknown.join(", ")}`);
+  }
+}
+
+function assertAllowedResourcePlanArgs(args) {
+  const allowed = new Set([
+    "resource",
+    "goal",
+    "dungeon-affinity",
+    "budget-tokens",
+    "budget",
+    "price-list",
+    "out-dir",
+    "run-id",
+    "created-at",
+    "emit-intermediates",
+  ]);
+  const unknown = [];
+  for (const key of Object.keys(args)) {
+    if (key === "_" || key === "help") {
+      continue;
+    }
+    if (!allowed.has(key)) {
+      unknown.push(`--${key}`);
+    }
+  }
+  if (Array.isArray(args._) && args._.length > 0) {
+    unknown.push(...args._);
+  }
+  if (unknown.length > 0) {
+    throw new Error(`resource-plan only accepts --resource, --goal, --dungeon-affinity, --budget-tokens, --budget, --price-list, --out-dir, --run-id, --created-at, and --emit-intermediates. Unknown: ${unknown.join(", ")}`);
+  }
+}
+
 function assertAllowedDelverPlanArgs(args) {
   const allowed = new Set([
     "delver",
@@ -3716,11 +3837,11 @@ function makeAgentCommandRoutes(kind) {
       ];
     case "hazard":
       return [
-        { target: "build_spec_configurator", path: "configurator.inputs.levelGen.hazards", legacyFlow: "configurator" },
+        { target: "build_spec_configurator", path: "configurator.inputs.levelGen.hazards", legacyFlow: "hazard-plan" },
       ];
     case "resource":
       return [
-        { target: "build_spec_configurator", path: "configurator.inputs.resources", legacyFlow: "configurator" },
+        { target: "build_spec_configurator", path: "configurator.inputs.resources", legacyFlow: "resource-plan" },
       ];
     case "delver":
       return [
@@ -4002,6 +4123,124 @@ function buildCostSummary(budgetReceipt, spendProposal, outDir) {
   };
 }
 
+async function writeHazardArtifactFiles({ parsedHazards = [], outDir, runId, createdAt, producedBy } = {}) {
+  for (let i = 0; i < parsedHazards.length; i += 1) {
+    const h = parsedHazards[i].value;
+    const hazardVersion = h._schemaVersion ?? 2;
+    const hazardArtifact = {
+      schema: "agent-kernel/HazardArtifact",
+      schemaVersion: hazardVersion,
+      meta: {
+        id: h.id,
+        runId,
+        createdAt,
+        producedBy,
+      },
+      affinity: h.affinity,
+      expression: h.expression,
+      proximityRadius: h.proximityRadius,
+      mana: { ...h.mana },
+      ...(hazardVersion === 1 && h.durability ? { durability: { ...h.durability } } : {}),
+    };
+    await writeJson(join(outDir, `hazard-${i + 1}.json`), hazardArtifact);
+  }
+}
+
+async function writeResourceArtifactFiles({ parsedResources = [], outDir, runId, createdAt, producedBy } = {}) {
+  for (let i = 0; i < parsedResources.length; i += 1) {
+    const r = parsedResources[i].value;
+    const resourceVersion = r._schemaVersion ?? 1;
+    const meta = { id: r.id, runId, createdAt, producedBy };
+    let resourceArtifact;
+    if (resourceVersion === 3) {
+      resourceArtifact = {
+        schema: "agent-kernel/ResourceArtifact",
+        schemaVersion: 3,
+        meta,
+        vitals: r.vitals,
+        permanenceMode: r.permanenceMode,
+      };
+    } else {
+      resourceArtifact = {
+        schema: "agent-kernel/ResourceArtifact",
+        schemaVersion: 1,
+        meta,
+        tier: r.tier,
+        stat: r.stat,
+        delta: r.delta,
+        dropRate: r.dropRate,
+      };
+    }
+    await writeJson(join(outDir, `resource-${i + 1}.json`), resourceArtifact);
+  }
+}
+
+const AUTHORING_POOL_WEIGHT_DEFAULTS = Object.freeze({
+  rooms: 0.44,
+  hazards: 0.12,
+  wardens: 0.16,
+  resources: 0.08,
+  delver: 0.20,
+});
+
+function buildPoolWeightsForAuthoredKinds({
+  rooms = [],
+  floorTiles = [],
+  traps = [],
+  hazards = [],
+  resources = [],
+  delvers = [],
+  wardens = [],
+} = {}) {
+  const weights = [];
+  if (rooms.length > 0 || floorTiles.length > 0 || traps.length > 0) {
+    weights.push({ id: "rooms", weight: AUTHORING_POOL_WEIGHT_DEFAULTS.rooms });
+  }
+  if (hazards.length > 0) weights.push({ id: "hazards", weight: AUTHORING_POOL_WEIGHT_DEFAULTS.hazards });
+  if (wardens.length > 0) weights.push({ id: "wardens", weight: AUTHORING_POOL_WEIGHT_DEFAULTS.wardens });
+  if (resources.length > 0) weights.push({ id: "resources", weight: AUTHORING_POOL_WEIGHT_DEFAULTS.resources });
+  if (delvers.length > 0) weights.push({ id: "delver", weight: AUTHORING_POOL_WEIGHT_DEFAULTS.delver });
+  return weights;
+}
+
+function buildPoolWeightsForSummary(summary = {}) {
+  const cards = Array.isArray(summary.cardSet)
+    ? summary.cardSet
+    : Array.isArray(summary.cards) ? summary.cards : [];
+  const layout = summary.layout && typeof summary.layout === "object" ? summary.layout : null;
+  const rooms = [
+    ...(Array.isArray(summary.rooms) ? summary.rooms : []),
+    ...cards.filter((entry) => entry?.type === "room" || entry?.source === "room"),
+  ];
+  const floorTiles = layout && Number.isInteger(layout.floorTiles) ? [layout] : [];
+  const traps = layout && Array.isArray(layout.traps) ? layout.traps : [];
+  const hazards = [
+    ...(Array.isArray(summary.hazards) ? summary.hazards : []),
+    ...cards.filter((entry) => entry?.type === "hazard" || entry?.source === "hazard"),
+  ];
+  const resources = [
+    ...(Array.isArray(summary.resources) ? summary.resources : []),
+    ...cards.filter((entry) => entry?.type === "resource" || entry?.source === "resource"),
+  ];
+  const actorCards = cards.filter((entry) => entry?.type === "delver" || entry?.type === "warden");
+  const actorEntries = Array.isArray(summary.actors) ? summary.actors : [];
+  const delvers = [
+    ...actorCards.filter((entry) => entry.type === "delver"),
+    ...actorEntries.filter((entry) => {
+      const role = String(entry?.actorType || entry?.type || entry?.role || entry?.motivation || "").toLowerCase();
+      return role.includes("delver") || role.includes("attack");
+    }),
+  ];
+  const wardens = [
+    ...actorCards.filter((entry) => entry.type === "warden"),
+    ...actorEntries.filter((entry) => {
+      const role = String(entry?.actorType || entry?.type || entry?.role || entry?.motivation || "").toLowerCase();
+      return role.includes("warden") || role.includes("defend") || role.includes("stationary");
+    }),
+  ];
+  return buildPoolWeightsForAuthoredKinds({ rooms, floorTiles, traps, hazards, resources, delvers, wardens });
+}
+
 async function validateRunDryRun(args) {
   const simConfigPath = resolvePath(args["sim-config"]);
   const initialStatePath = resolvePath(args["initial-state"]);
@@ -4246,6 +4485,7 @@ async function validateScenarioDryRun(args) {
   let captures = [];
   let summary = null;
   let mappedSelections;
+  let budgetPoolWeights = null;
 
   if (isLlmLiveEnabled() || Boolean(fixturePath)) {
     if (!fixturePath && !allowNetworkRequests() && !isLocalBaseUrl(baseUrl)) {
@@ -4304,6 +4544,7 @@ async function validateScenarioDryRun(args) {
       captures = loopResult.captures || [];
       summary = loopResult.summary;
       mappedSelections = loopResult.selections;
+      budgetPoolWeights = loopResult.poolWeights || null;
     } else {
       let session = await runLlmSession({
         adapter,
@@ -4394,6 +4635,14 @@ async function validateScenarioDryRun(args) {
     }
     if (Number.isFinite(resolvedBudgetTokens)) {
       summaryForSpec.budgetTokens = resolvedBudgetTokens;
+    }
+  }
+  if (!Array.isArray(summaryForSpec?.poolWeights) || summaryForSpec.poolWeights.length === 0) {
+    const poolWeights = Array.isArray(budgetPoolWeights) && budgetPoolWeights.length > 0
+      ? budgetPoolWeights
+      : buildPoolWeightsForSummary(summaryForSpec);
+    if (poolWeights.length > 0) {
+      summaryForSpec = { ...summaryForSpec, poolWeights };
     }
   }
 
@@ -4925,6 +5174,7 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
     text: authoringText,
     hardBudgetConstraint: authoringConstraints,
   });
+  const shouldMaximizeSpend = sharedOptimizationGoals.some((entry) => entry.kind === "maximize_budget_spend");
   const textDelverGoals = textVitalScope === "delver" ? textVitalGoals : [];
   const textWardenGoals = textVitalScope === "warden" ? textVitalGoals : [];
   // Resolve split budgets: explicit split flags take priority over combined budget.
@@ -4944,10 +5194,11 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
         budgetTokens: resolvedDungeonBudgetTokens,
         rooms: parsedRooms,
         delvers: [],
+        wardens: [],
         priceListArtifact,
       });
     }
-    if (Number.isInteger(resolvedDelverBudgetTokens) && parsedWardens.length === 0) {
+    if (Number.isInteger(resolvedDelverBudgetTokens)) {
       ensureBudgetedFulfillmentFeasible({
         commandName,
         budgetTokens: resolvedDelverBudgetTokens,
@@ -4959,6 +5210,7 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
             ...textDelverGoals,
           ]),
         })),
+        wardens: parsedWardens,
         priceListArtifact,
       });
     }
@@ -4968,7 +5220,6 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
     && parsedTraps.length === 0
     && parsedHazards.length === 0
     && parsedResources.length === 0
-    && parsedWardens.length === 0
   ) {
     ensureBudgetedFulfillmentFeasible({
       commandName,
@@ -4981,6 +5232,7 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
           ...textDelverGoals,
         ]),
       })),
+      wardens: parsedWardens,
       priceListArtifact,
     });
   }
@@ -4988,7 +5240,7 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
   let fulfilled;
   if (hasSplitBudget) {
     // Split-budget fulfillment: maximize each side against its own budget.
-    const dungeonFulfilled = (parsedFloorTiles.length === 0 && parsedTraps.length === 0)
+    const dungeonFulfilled = (shouldMaximizeSpend && parsedFloorTiles.length === 0 && parsedTraps.length === 0)
       ? applyBudgetCappedFulfillment({
         rooms: parsedRooms,
         delvers: [],
@@ -4996,7 +5248,7 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
         budgetTokens: resolvedDungeonBudgetTokens,
       })
       : { rooms: parsedRooms, delvers: [] };
-    const delverFulfilled = parsedWardens.length === 0
+    const delverFulfilled = shouldMaximizeSpend && parsedWardens.length === 0
       ? applyBudgetCappedFulfillment({
         rooms: [],
         delvers: parsedDelvers.map((entry) => ({
@@ -5013,7 +5265,8 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
     fulfilled = { rooms: dungeonFulfilled.rooms, delvers: delverFulfilled.delvers };
   } else {
     fulfilled = (
-      parsedFloorTiles.length === 0
+      shouldMaximizeSpend
+      && parsedFloorTiles.length === 0
       && parsedTraps.length === 0
       && parsedHazards.length === 0
       && parsedResources.length === 0
@@ -5051,7 +5304,19 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
     dungeonAffinity,
     rooms: fulfilled.rooms.map((entry) => entry.value),
     actors: [...fulfilled.delvers.map((entry) => entry.value), ...parsedWardens.map((entry) => entry.value)],
+    poolWeights: buildPoolWeightsForAuthoredKinds({
+      rooms: fulfilled.rooms,
+      floorTiles: parsedFloorTiles,
+      traps: parsedTraps,
+      hazards: parsedHazards,
+      resources: parsedResources,
+      delvers: fulfilled.delvers,
+      wardens: parsedWardens,
+    }),
   };
+  if (parsedRooms.length === 0 && parsedFloorTiles.length === 0 && parsedTraps.length === 0) {
+    summary.budgetScaffold = true;
+  }
   if (resolvedBudgetTokens !== undefined) {
     summary.budgetTokens = resolvedBudgetTokens;
   }
@@ -5106,7 +5371,7 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
   }
   built.spec.configurator.inputs.levelGen = levelGen;
 
-  if (resolvedBudgetTokens !== undefined) {
+  if (sharedOptimizationGoals.some((entry) => entry.kind === "maximize_budget_spend")) {
     built.spec.configurator.inputs.maximizeBudget = true;
   }
 
@@ -5278,55 +5543,20 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
     producedBy: `cli-${commandName}`,
   });
 
-  // Write HazardArtifact files for each --hazard flag
-  for (let i = 0; i < parsedHazards.length; i++) {
-    const h = parsedHazards[i].value;
-    const hazardVersion = h._schemaVersion ?? 2;
-    const hazardArtifact = {
-      schema: "agent-kernel/HazardArtifact",
-      schemaVersion: hazardVersion,
-      meta: {
-        id: h.id,
-        runId,
-        createdAt,
-        producedBy: `cli-${commandName}`,
-      },
-      affinity: h.affinity,
-      expression: h.expression,
-      proximityRadius: h.proximityRadius,
-      mana: { ...h.mana },
-      ...(hazardVersion === 1 && h.durability ? { durability: { ...h.durability } } : {}),
-    };
-    await writeJson(join(outDir, `hazard-${i + 1}.json`), hazardArtifact);
-  }
-
-  // Write ResourceArtifact files for each --resource flag
-  for (let i = 0; i < parsedResources.length; i++) {
-    const r = parsedResources[i].value;
-    const resourceVersion = r._schemaVersion ?? 1;
-    const meta = { id: r.id, runId, createdAt, producedBy: `cli-${commandName}` };
-    let resourceArtifact;
-    if (resourceVersion === 3) {
-      resourceArtifact = {
-        schema: "agent-kernel/ResourceArtifact",
-        schemaVersion: 3,
-        meta,
-        vitals: r.vitals,
-        permanenceMode: r.permanenceMode,
-      };
-    } else {
-      resourceArtifact = {
-        schema: "agent-kernel/ResourceArtifact",
-        schemaVersion: 1,
-        meta,
-        tier: r.tier,
-        stat: r.stat,
-        delta: r.delta,
-        dropRate: r.dropRate,
-      };
-    }
-    await writeJson(join(outDir, `resource-${i + 1}.json`), resourceArtifact);
-  }
+  await writeHazardArtifactFiles({
+    parsedHazards,
+    outDir,
+    runId,
+    createdAt,
+    producedBy: `cli-${commandName}`,
+  });
+  await writeResourceArtifactFiles({
+    parsedResources,
+    outDir,
+    runId,
+    createdAt,
+    producedBy: `cli-${commandName}`,
+  });
 
   emitJsonStdout(stdoutSummary);
 }
@@ -5435,6 +5665,7 @@ async function roomPlanCommand(argv) {
     dungeonAffinity,
     rooms: fulfilledRooms.map((entry) => entry.value),
     actors: [],
+    poolWeights: [{ id: "rooms", weight: 1 }],
   };
   if (resolvedBudgetTokens !== undefined) {
     summary.budgetTokens = resolvedBudgetTokens;
@@ -5470,6 +5701,228 @@ async function roomPlanCommand(argv) {
     commandName: "room-plan",
     producedBy: "cli-room-plan",
   }));
+}
+
+async function hazardPlanCommand(argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  assertAllowedHazardPlanArgs(args);
+
+  const parsedHazards = parseHazardSpecs(args.hazard);
+  const runId = args["run-id"] || makeId("run");
+  const createdAt = args["created-at"] || new Date().toISOString();
+  const outDir = resolvePath(args["out-dir"]) || defaultRunCommandOutDir("hazard-plan", runId);
+  const budgetPath = resolvePath(args.budget);
+  const priceListPath = resolvePath(args["price-list"]);
+
+  const dungeonAffinity = isNonEmptyString(args["dungeon-affinity"])
+    ? args["dungeon-affinity"].trim().toLowerCase()
+    : DEFAULT_DUNGEON_AFFINITY;
+  if (!ALLOWED_AFFINITIES.includes(dungeonAffinity)) {
+    throw new Error(`hazard-plan --dungeon-affinity must be one of: ${ALLOWED_AFFINITIES.join(", ")}.`);
+  }
+
+  let budgetTokensFlag;
+  if (args["budget-tokens"] !== undefined) {
+    budgetTokensFlag = parsePositiveIntStrict(args["budget-tokens"], "hazard-plan --budget-tokens");
+  }
+  if ((budgetPath && !priceListPath) || (!budgetPath && priceListPath)) {
+    throw new Error("hazard-plan requires both --budget and --price-list.");
+  }
+
+  let budgetArtifact = null;
+  let priceListArtifact = null;
+  if (budgetPath) {
+    budgetArtifact = await readJson(budgetPath);
+    assertSchema(budgetArtifact, SCHEMAS.budgetArtifact);
+  }
+  if (priceListPath) {
+    priceListArtifact = await readJson(priceListPath);
+    assertSchema(priceListArtifact, SCHEMAS.priceList);
+  }
+
+  const goal = isNonEmptyString(args.goal)
+    ? args.goal.trim()
+    : `Author hazards (${parsedHazards.length} configuration${parsedHazards.length === 1 ? "" : "s"}).`;
+  const textBudgetTokens = extractBudgetTokensFromText(goal, "hazard-plan --goal");
+  const {
+    resolvedBudgetTokens,
+    constraints: authoringConstraints,
+  } = resolveAuthoringBudget({
+    commandName: "hazard-plan",
+    textBudgetTokens,
+    flagBudgetTokens: budgetTokensFlag,
+    budgetArtifact,
+  });
+  const sharedOptimizationGoals = buildSharedOptimizationGoals({
+    text: goal,
+    hardBudgetConstraint: authoringConstraints,
+  });
+  const hazards = parsedHazards.map((entry) => entry.value);
+  const summary = {
+    goal,
+    dungeonAffinity,
+    hazards,
+    budgetScaffold: true,
+    poolWeights: [{ id: "hazards", weight: 1 }],
+  };
+  if (resolvedBudgetTokens !== undefined) {
+    summary.budgetTokens = resolvedBudgetTokens;
+  }
+
+  const built = buildBuildSpecFromSummary({
+    summary,
+    runId,
+    createdAt,
+    source: "cli-hazard-plan",
+    budgetArtifact: budgetArtifact || undefined,
+    priceListArtifact: priceListArtifact || undefined,
+  });
+  if (!built.ok) {
+    throw new Error(`hazard-plan build spec failed: ${built.errors.join("; ")}`);
+  }
+  applyAuthoringSection(built.spec, buildAuthoringSection({
+    objectKinds: ["hazard"],
+    constraints: authoringConstraints,
+    sharedOptimizationGoals,
+  }), "hazard-plan");
+
+  const buildResult = await orchestrateBuild({
+    spec: built.spec,
+    producedBy: "cli-hazard-plan",
+  });
+  attachMixedRoomAssembliesToBuildResult(buildResult);
+  const stdoutSummary = await writeBuildOutputs({
+    outDir,
+    spec: buildResult.spec,
+    buildResult,
+    emitIntermediates: Boolean(args["emit-intermediates"]),
+    commandName: "hazard-plan",
+    producedBy: "cli-hazard-plan",
+  });
+  await writeHazardArtifactFiles({
+    parsedHazards,
+    outDir,
+    runId,
+    createdAt,
+    producedBy: "cli-hazard-plan",
+  });
+  emitJsonStdout(stdoutSummary);
+}
+
+async function resourcePlanCommand(argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  assertAllowedResourcePlanArgs(args);
+
+  const parsedResources = parseResourceSpecs(args.resource);
+  const runId = args["run-id"] || makeId("run");
+  const createdAt = args["created-at"] || new Date().toISOString();
+  const outDir = resolvePath(args["out-dir"]) || defaultRunCommandOutDir("resource-plan", runId);
+  const budgetPath = resolvePath(args.budget);
+  const priceListPath = resolvePath(args["price-list"]);
+
+  const dungeonAffinity = isNonEmptyString(args["dungeon-affinity"])
+    ? args["dungeon-affinity"].trim().toLowerCase()
+    : DEFAULT_DUNGEON_AFFINITY;
+  if (!ALLOWED_AFFINITIES.includes(dungeonAffinity)) {
+    throw new Error(`resource-plan --dungeon-affinity must be one of: ${ALLOWED_AFFINITIES.join(", ")}.`);
+  }
+
+  let budgetTokensFlag;
+  if (args["budget-tokens"] !== undefined) {
+    budgetTokensFlag = parsePositiveIntStrict(args["budget-tokens"], "resource-plan --budget-tokens");
+  }
+  if ((budgetPath && !priceListPath) || (!budgetPath && priceListPath)) {
+    throw new Error("resource-plan requires both --budget and --price-list.");
+  }
+
+  let budgetArtifact = null;
+  let priceListArtifact = null;
+  if (budgetPath) {
+    budgetArtifact = await readJson(budgetPath);
+    assertSchema(budgetArtifact, SCHEMAS.budgetArtifact);
+  }
+  if (priceListPath) {
+    priceListArtifact = await readJson(priceListPath);
+    assertSchema(priceListArtifact, SCHEMAS.priceList);
+  }
+
+  const goal = isNonEmptyString(args.goal)
+    ? args.goal.trim()
+    : `Author resources (${parsedResources.length} configuration${parsedResources.length === 1 ? "" : "s"}).`;
+  const textBudgetTokens = extractBudgetTokensFromText(goal, "resource-plan --goal");
+  const {
+    resolvedBudgetTokens,
+    constraints: authoringConstraints,
+  } = resolveAuthoringBudget({
+    commandName: "resource-plan",
+    textBudgetTokens,
+    flagBudgetTokens: budgetTokensFlag,
+    budgetArtifact,
+  });
+  const sharedOptimizationGoals = buildSharedOptimizationGoals({
+    text: goal,
+    hardBudgetConstraint: authoringConstraints,
+  });
+  const resources = parsedResources.map((entry) => entry.value);
+  const summary = {
+    goal,
+    dungeonAffinity,
+    resources,
+    budgetScaffold: true,
+    poolWeights: [{ id: "resources", weight: 1 }],
+  };
+  if (resolvedBudgetTokens !== undefined) {
+    summary.budgetTokens = resolvedBudgetTokens;
+  }
+
+  const built = buildBuildSpecFromSummary({
+    summary,
+    runId,
+    createdAt,
+    source: "cli-resource-plan",
+    budgetArtifact: budgetArtifact || undefined,
+    priceListArtifact: priceListArtifact || undefined,
+  });
+  if (!built.ok) {
+    throw new Error(`resource-plan build spec failed: ${built.errors.join("; ")}`);
+  }
+  applyAuthoringSection(built.spec, buildAuthoringSection({
+    objectKinds: ["resource"],
+    constraints: authoringConstraints,
+    sharedOptimizationGoals,
+  }), "resource-plan");
+
+  const buildResult = await orchestrateBuild({
+    spec: built.spec,
+    producedBy: "cli-resource-plan",
+  });
+  attachMixedRoomAssembliesToBuildResult(buildResult);
+  const stdoutSummary = await writeBuildOutputs({
+    outDir,
+    spec: buildResult.spec,
+    buildResult,
+    emitIntermediates: Boolean(args["emit-intermediates"]),
+    commandName: "resource-plan",
+    producedBy: "cli-resource-plan",
+  });
+  await writeResourceArtifactFiles({
+    parsedResources,
+    outDir,
+    runId,
+    createdAt,
+    producedBy: "cli-resource-plan",
+  });
+  emitJsonStdout(stdoutSummary);
 }
 
 async function delverPlanCommand(argv) {
@@ -5570,6 +6023,8 @@ async function delverPlanCommand(argv) {
     goal,
     dungeonAffinity,
     cardSet: fulfilledDelvers.map((entry) => entry.value),
+    budgetScaffold: true,
+    poolWeights: [{ id: "delver", weight: 1 }],
   };
   if (resolvedBudgetTokens !== undefined) {
     summary.budgetTokens = resolvedBudgetTokens;
@@ -5673,10 +6128,23 @@ async function wardenPlanCommand(argv) {
     text: goal,
     hardBudgetConstraint: authoringConstraints,
   });
+  ensureBudgetedFulfillmentFeasible({
+    commandName: "warden-plan",
+    budgetTokens: resolvedBudgetTokens,
+    rooms: [],
+    delvers: [],
+    wardens: wardens.map((entry) => ({
+      value: entry,
+      optimizationGoals: dedupeOptimizationGoals(textVitalGoals),
+    })),
+    priceListArtifact,
+  });
   const summary = {
     goal,
     dungeonAffinity,
     cardSet: wardens,
+    budgetScaffold: true,
+    poolWeights: [{ id: "wardens", weight: 1 }],
   };
   if (resolvedBudgetTokens !== undefined) {
     summary.budgetTokens = resolvedBudgetTokens;
@@ -6240,6 +6708,8 @@ export const COMMANDS = {
   llm: llmCommand,
   ollama: llmCommand,
   "room-plan": roomPlanCommand,
+  "hazard-plan": hazardPlanCommand,
+  "resource-plan": resourcePlanCommand,
   "delver-plan": delverPlanCommand,
   "warden-plan": wardenPlanCommand,
   "llm-plan": llmPlanCommand,

--- a/packages/runtime/src/build/orchestrate-build.js
+++ b/packages/runtime/src/build/orchestrate-build.js
@@ -8,6 +8,7 @@ import { buildSimConfigArtifact, buildInitialStateArtifact } from "../personas/c
 import { evaluateConfiguratorSpend } from "../personas/configurator/spend-proposal.js";
 import { maximizeActorBudget } from "../personas/configurator/budget-maximizer.js";
 import { buildDefaultPriceList } from "../personas/allocator/default-price-list.js";
+import { buildBudgetAllocation } from "../personas/director/budget-allocation.js";
 import { normalizeMotivationRulesArtifact, resolveMotivationRules } from "../personas/configurator/motivation-rules.js";
 import { createDefaultResourceBundleArtifact } from "../render/resource-bundle.js";
 import { buildScenarioSpendReport } from "../personas/allocator/incentive-model.js";
@@ -54,6 +55,65 @@ function toRef(artifact) {
     schema: artifact.schema,
     schemaVersion: artifact.schemaVersion,
   };
+}
+
+function mergePriceListWithDefaults(priceList, { meta } = {}) {
+  const defaults = buildDefaultPriceList({ meta });
+  if (!priceList) return defaults;
+  const itemsByKey = new Map();
+  defaults.items.forEach((item) => {
+    itemsByKey.set(`${item.kind}:${item.id}`, item);
+  });
+  if (Array.isArray(priceList.items)) {
+    priceList.items.forEach((item) => {
+      if (typeof item?.id === "string" && typeof item?.kind === "string") {
+        itemsByKey.set(`${item.kind}:${item.id}`, item);
+      } else if (typeof item?.key === "string") {
+        itemsByKey.set(`legacy:${item.key}`, item);
+      }
+    });
+  }
+  return {
+    ...defaults,
+    ...priceList,
+    meta: priceList.meta || defaults.meta,
+    items: Array.from(itemsByKey.values()),
+  };
+}
+
+function formatBudgetReceiptDenial(receipt) {
+  const parts = [
+    `status=${receipt?.status}`,
+    `remaining=${receipt?.remaining}`,
+  ];
+  const deniedLines = Array.isArray(receipt?.lineItems)
+    ? receipt.lineItems
+      .filter((item) => item?.status !== "approved")
+      .slice(0, 5)
+      .map((item) => `${item.kind}:${item.id}${item.category ? `:${item.category}` : ""}`)
+    : [];
+  if (deniedLines.length > 0) {
+    parts.push(`deniedLines=${deniedLines.join(",")}`);
+  }
+  const deniedPools = Array.isArray(receipt?.poolStatuses)
+    ? receipt.poolStatuses
+      .filter((pool) => pool?.status !== "approved")
+      .map((pool) => `${pool.id}:${pool.spentTokens}/${pool.capTokens}`)
+    : [];
+  if (deniedPools.length > 0) {
+    parts.push(`deniedPools=${deniedPools.join(",")}`);
+  }
+  return `Budget receipt denied: ${parts.join("; ")}`;
+}
+
+function resolveActorPoolRemaining(receipt) {
+  if (!Array.isArray(receipt?.poolStatuses)) return null;
+  const actorPools = receipt.poolStatuses.filter((pool) => pool?.id === "delver" || pool?.id === "wardens");
+  if (actorPools.length === 0) return null;
+  return actorPools.reduce((sum, pool) => {
+    const remaining = Number.isFinite(pool?.remainingTokens) ? pool.remainingTokens : 0;
+    return sum + Math.max(0, remaining);
+  }, 0);
 }
 
 function assertSchema(artifact, expectedSchema) {
@@ -1327,6 +1387,7 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
   let motivationRules = null;
   let resourceBundle = null;
   let resolvedPriceList = null;
+  let budgetAllocation = null;
 
   if (hasLevelGen) {
     if (!hasActors) {
@@ -1375,6 +1436,9 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
     }
 
     const layout = layoutResult.value;
+    if (levelGenInput?.budgetScaffold === true) {
+      layout.budgetScaffold = true;
+    }
     const seed = Number.isFinite(levelGenInput.seed) ? levelGenInput.seed : 0;
     augmentLayoutWithRoomAffinityEffects(layout, {
       cardSet: configuratorInputs?.cardSet,
@@ -1403,10 +1467,24 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
       });
     }
 
-    resolvedPriceList = mapped.budget?.priceList
-      || (mapped.budget?.budget
-        ? buildDefaultPriceList({ meta: createBuildMeta(spec, producedBy, "default_price_list") })
-        : null);
+    resolvedPriceList = mapped.budget?.budget
+      ? mergePriceListWithDefaults(mapped.budget?.priceList, {
+        meta: createBuildMeta(spec, producedBy, "default_price_list"),
+      })
+      : null;
+    if (mapped.budget?.budget && resolvedPriceList) {
+      const allocationResult = buildBudgetAllocation({
+        budget: mapped.budget.budget,
+        priceList: resolvedPriceList,
+        meta: createBuildMeta(spec, producedBy, "budget_allocation"),
+        poolWeights: spec.intent?.hints?.poolWeights,
+      });
+      if (!allocationResult.ok) {
+        const details = allocationResult.errors.map((entry) => `${entry.field || "poolWeights"}:${entry.code}`).join(", ");
+        throw new Error(`Budget allocation invalid: ${details}`);
+      }
+      budgetAllocation = allocationResult.allocation;
+    }
 
     const configuratorResources = Array.isArray(configuratorInputs?.resources) ? configuratorInputs.resources : [];
 
@@ -1414,6 +1492,7 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
       const probeResult = evaluateConfiguratorSpend({
         budget: mapped.budget.budget,
         priceList: resolvedPriceList,
+        allocation: budgetAllocation,
         layout,
         actors: actorsInput.actors,
         resources: configuratorResources,
@@ -1421,10 +1500,14 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
         receiptMeta: createBuildMeta(spec, producedBy, "budget_receipt_probe"),
       });
       const probeRemaining = probeResult.receipt?.remaining ?? 0;
-      if (probeRemaining > 0) {
+      const actorPoolRemaining = resolveActorPoolRemaining(probeResult.receipt);
+      const maximizeRemaining = actorPoolRemaining === null
+        ? probeRemaining
+        : Math.min(probeRemaining, actorPoolRemaining);
+      if (maximizeRemaining > 0) {
         actorsInput.actors = maximizeActorBudget({
           actors: actorsInput.actors,
-          remaining: probeRemaining,
+          remaining: maximizeRemaining,
           priceList: resolvedPriceList,
         });
         if (spec?.configurator?.inputs) {
@@ -1437,6 +1520,7 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
       const spendResult = evaluateConfiguratorSpend({
         budget: mapped.budget.budget,
         priceList: resolvedPriceList,
+        allocation: budgetAllocation,
         layout,
         actors: actorsInput.actors,
         resources: configuratorResources,
@@ -1447,55 +1531,17 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
       });
       spendProposal = spendResult.proposal;
       budgetReceipt = spendResult.receipt;
-
-      // Compute scenario spend report using existing spend categorization
-      const { delvers, wardens } = partitionActorsByRole(actorsInput.actors, {
-        delverCountHint: configuratorInputs?.delverCount,
-      });
-
-      // Layout spend (rooms, traps, tiles)
-      const roomsSpend = budgetReceipt.lineItems
-        .filter((item) => item.kind === "layout" || item.kind === "trap")
-        .reduce((sum, item) => sum + item.totalCost, 0);
-
-      const resourcesSpend = budgetReceipt.lineItems
-        .filter((item) => item.kind === "resource")
-        .reduce((sum, item) => sum + item.totalCost, 0);
-
-      // Actor spend - partition by delver/warden lists
-      const delverIds = new Set(delvers.map((a) => a.id));
-      let delverSpend = 0;
-      let wardenSpend = 0;
-
-      // SpendProposal items have format "{kind}:{id}" but receipt lineItems have separate fields
-      // We need to match actors based on whether their vitals/affinities belong to delvers or wardens
-      budgetReceipt.lineItems.forEach((item) => {
-        if (item.kind === "actor") {
-          // Actor spawn cost
-          const actorId = item.id?.replace(/^actor_spawn_/, "");
-          if (actorId && delverIds.has(actorId)) {
-            delverSpend += item.totalCost;
-          } else if (actorId) {
-            wardenSpend += item.totalCost;
-          }
-        } else if (item.kind === "vital" || item.kind === "affinity" || item.kind === "motivation") {
-          // These aggregate across all actors - split proportionally
-          // This is a limitation acknowledged in the task note
-          const totalActors = actorsInput.actors.length;
-          if (totalActors > 0) {
-            delverSpend += item.totalCost * (delvers.length / totalActors);
-            wardenSpend += item.totalCost * (wardens.length / totalActors);
-          }
-        }
-      });
-
       budgetReceipt.scenarioSpendReport = buildScenarioSpendReport({
-        roomsSpend,
-        delverSpend,
-        wardenSpend,
-        resourcesSpend,
+        lineItems: budgetReceipt.lineItems,
+        allocation: budgetAllocation,
         budgetTokens: mapped.budget.budget?.budget?.tokens,
       });
+      if (budgetReceipt.status !== "approved") {
+        throw new Error(formatBudgetReceiptDenial(budgetReceipt));
+      }
+    }
+    if (budgetReceipt && budgetReceipt.status !== "approved") {
+      throw new Error(formatBudgetReceiptDenial(budgetReceipt));
     }
 
     const normalizedActors = normalizeActorPositions(actorsInput.actors, layout, {
@@ -1554,8 +1600,12 @@ export async function orchestrateBuild({ spec, producedBy = "runtime-build", sol
     });
   }
 
-  const resolvedBudget = mapped.budget && resolvedPriceList && !mapped.budget.priceList
-    ? { ...mapped.budget, priceList: resolvedPriceList }
+  const resolvedBudget = mapped.budget
+    ? {
+      ...mapped.budget,
+      ...(resolvedPriceList && !mapped.budget.priceList ? { priceList: resolvedPriceList } : {}),
+      ...(budgetAllocation ? { allocation: budgetAllocation } : {}),
+    }
     : mapped.budget;
 
   if (spendProposal && budgetReceipt) {

--- a/packages/runtime/src/commands/kernel.js
+++ b/packages/runtime/src/commands/kernel.js
@@ -76,6 +76,64 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+const SUMMARY_POOL_WEIGHT_DEFAULTS = Object.freeze({
+  rooms: 0.44,
+  hazards: 0.12,
+  wardens: 0.16,
+  resources: 0.08,
+  delver: 0.20,
+});
+
+function buildSummaryPoolWeights(summary = {}) {
+  const cards = Array.isArray(summary.cardSet)
+    ? summary.cardSet
+    : Array.isArray(summary.cards) ? summary.cards : [];
+  const layout = summary.layout && typeof summary.layout === "object" ? summary.layout : null;
+  const layoutHasRoomSpend = layout
+    && (
+      Number.isInteger(layout.floorTiles)
+      || Number.isInteger(layout.hallwayTiles)
+      || (Array.isArray(layout.traps) && layout.traps.length > 0)
+    );
+  const rooms = [
+    ...(Array.isArray(summary.rooms) ? summary.rooms : []),
+    ...cards.filter((entry) => entry?.type === "room" || entry?.source === "room"),
+  ];
+  const hazards = [
+    ...(Array.isArray(summary.hazards) ? summary.hazards : []),
+    ...cards.filter((entry) => entry?.type === "hazard" || entry?.source === "hazard"),
+  ];
+  const resources = [
+    ...(Array.isArray(summary.resources) ? summary.resources : []),
+    ...cards.filter((entry) => entry?.type === "resource" || entry?.source === "resource"),
+  ];
+  const actorCards = cards.filter((entry) => entry?.type === "delver" || entry?.type === "warden");
+  const actorEntries = Array.isArray(summary.actors) ? summary.actors : [];
+  const delvers = [
+    ...actorCards.filter((entry) => entry.type === "delver"),
+    ...actorEntries.filter((entry) => {
+      const role = String(entry?.actorType || entry?.type || entry?.role || entry?.motivation || "").toLowerCase();
+      return role.includes("delver") || role.includes("attack");
+    }),
+  ];
+  const wardens = [
+    ...actorCards.filter((entry) => entry.type === "warden"),
+    ...actorEntries.filter((entry) => {
+      const role = String(entry?.actorType || entry?.type || entry?.role || entry?.motivation || "").toLowerCase();
+      return role.includes("warden") || role.includes("defend") || role.includes("stationary");
+    }),
+  ];
+  const weights = [];
+  if (rooms.length > 0 || layoutHasRoomSpend) {
+    weights.push({ id: "rooms", weight: SUMMARY_POOL_WEIGHT_DEFAULTS.rooms });
+  }
+  if (hazards.length > 0) weights.push({ id: "hazards", weight: SUMMARY_POOL_WEIGHT_DEFAULTS.hazards });
+  if (wardens.length > 0) weights.push({ id: "wardens", weight: SUMMARY_POOL_WEIGHT_DEFAULTS.wardens });
+  if (resources.length > 0) weights.push({ id: "resources", weight: SUMMARY_POOL_WEIGHT_DEFAULTS.resources });
+  if (delvers.length > 0) weights.push({ id: "delver", weight: SUMMARY_POOL_WEIGHT_DEFAULTS.delver });
+  return weights;
+}
+
 function sanitizeFileSegment(value) {
   const raw = String(value || "").toLowerCase();
   const cleaned = raw.replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
@@ -2033,6 +2091,14 @@ export function createCommandKernel(host = {}) {
       }
       if (Number.isFinite(resolvedBudgetTokens)) {
         summaryForSpec.budgetTokens = resolvedBudgetTokens;
+      }
+    }
+    if (!Array.isArray(summaryForSpec?.poolWeights) || summaryForSpec.poolWeights.length === 0) {
+      const poolWeights = Array.isArray(budgetPoolWeights) && budgetPoolWeights.length > 0
+        ? budgetPoolWeights
+        : buildSummaryPoolWeights(summaryForSpec);
+      if (poolWeights.length > 0) {
+        summaryForSpec = { ...summaryForSpec, poolWeights };
       }
     }
 

--- a/packages/runtime/src/contracts/artifacts.ts
+++ b/packages/runtime/src/contracts/artifacts.ts
@@ -679,6 +679,18 @@ export interface BudgetReceiptLineItemV1 {
   unitCost: number;
   totalCost: number;
   status: "approved" | "denied" | "partial";
+  category?: SpendProposalCategory;
+  artifactRef?: ArtifactRef;
+  subjectRef?: ArtifactRef;
+  detail?: unknown;
+}
+
+export interface BudgetReceiptPoolStatusV1 {
+  id: string;
+  capTokens: number;
+  spentTokens: number;
+  remainingTokens: number;
+  status: "approved" | "denied";
 }
 
 export interface BudgetReceiptArtifactV1 {
@@ -688,10 +700,12 @@ export interface BudgetReceiptArtifactV1 {
   budgetRef: ArtifactRef;
   priceListRef: ArtifactRef;
   proposalRef?: ArtifactRef;
+  allocationRef?: ArtifactRef;
   status: "approved" | "denied" | "partial";
   totalCost: number;
   remaining: number;
   lineItems: BudgetReceiptLineItemV1[];
+  poolStatuses?: BudgetReceiptPoolStatusV1[];
   scenarioSpendReport?: {
     budget: number;
     totalSpend: number;
@@ -820,9 +834,14 @@ export interface PriceListItemTokenV1 {
   id: string;
   kind: string;
   /** Cost in tokens for one unit of the item. */
-  costTokens: number;
+  unitCost?: number;
+  /** Legacy cost field retained for old fixtures and imported artifacts. */
+  costTokens?: number;
+  /** Formula used to convert quantity into total cost. */
+  formula?: "linear" | "quadratic";
   /** Optional description for clarity/audit. */
   notes?: string;
+  description?: string;
 }
 
 export type PriceListItemV1 = PriceListItemLegacyV1 | PriceListItemTokenV1;

--- a/packages/runtime/src/personas/allocator/budget-ledger.js
+++ b/packages/runtime/src/personas/allocator/budget-ledger.js
@@ -19,9 +19,14 @@ function buildRef(artifact, fallbackSchema) {
   return { id: meta?.id || "unknown", schema: fallbackSchema, schemaVersion: 1 };
 }
 
-function resolveUnitCost(lineItems, { id, kind }) {
+function resolveReceiptLine(lineItems, { id, kind, quantity }) {
   const match = lineItems.find((item) => item?.id === id && item?.kind === kind && item?.status !== "denied");
-  return isFiniteNumber(match?.unitCost) ? match.unitCost : 0;
+  const unitCost = isFiniteNumber(match?.unitCost) ? match.unitCost : 0;
+  const lineQuantity = normalizeQuantity(match?.quantity);
+  const totalCost = isFiniteNumber(match?.totalCost) && lineQuantity === quantity
+    ? match.totalCost
+    : unitCost * quantity;
+  return { unitCost, totalCost };
 }
 
 export function updateBudgetLedger({ receipt, spendEvents, meta, receiptRef } = {}) {
@@ -31,8 +36,7 @@ export function updateBudgetLedger({ receipt, spendEvents, meta, receiptRef } = 
     const id = typeof event?.id === "string" ? event.id : "unknown";
     const kind = typeof event?.kind === "string" ? event.kind : "unknown";
     const quantity = normalizeQuantity(event?.quantity);
-    const unitCost = resolveUnitCost(lineItems, { id, kind });
-    const totalCost = unitCost * quantity;
+    const { unitCost, totalCost } = resolveReceiptLine(lineItems, { id, kind, quantity });
     return { id, kind, quantity, unitCost, totalCost };
   });
 

--- a/packages/runtime/src/personas/allocator/incentive-model.js
+++ b/packages/runtime/src/personas/allocator/incentive-model.js
@@ -7,10 +7,33 @@
  */
 
 import {
+  computeBudgetPools,
   REFERENCE_BUDGET_TOKENS,
   REFERENCE_TARGETS,
   TARGET_DELVER_WARDEN_RATIO,
 } from "../director/budget-allocation.js";
+
+const REPORT_CATEGORIES = Object.freeze([
+  "rooms",
+  "floor_tiles",
+  "traps",
+  "hazards",
+  "resources",
+  "delvers",
+  "wardens",
+  "shared_system",
+]);
+
+const CATEGORY_POOL_IDS = Object.freeze({
+  rooms: "rooms",
+  floor_tiles: "rooms",
+  traps: "rooms",
+  hazards: "hazards",
+  resources: "resources",
+  delvers: "delver",
+  wardens: "wardens",
+  shared_system: "rooms",
+});
 
 /**
  * Compute the incentive multiplier (design §3.3).
@@ -29,6 +52,82 @@ export function computeIncentiveMultiplier(delverSpend, wardenSpend) {
   return Math.max(0, 1 - 1.25 * mismatch);
 }
 
+function normalizeSpend(value) {
+  return Number.isFinite(value) ? value : 0;
+}
+
+function buildPoolTargets({ budgetTokens, allocation } = {}) {
+  const pools = Array.isArray(allocation?.pools)
+    ? allocation.pools
+    : computeBudgetPools({ budgetTokens }).pools;
+  return new Map((pools || []).map((pool) => [pool.id, Number.isInteger(pool.tokens) ? pool.tokens : 0]));
+}
+
+function buildCategoryTargets({ budgetTokens, allocation } = {}) {
+  const poolTargets = buildPoolTargets({ budgetTokens, allocation });
+  const fallbackScale = (Number.isInteger(budgetTokens) && budgetTokens > 0 ? budgetTokens : REFERENCE_BUDGET_TOKENS)
+    / REFERENCE_BUDGET_TOKENS;
+  const fallback = {
+    rooms: Math.round(REFERENCE_TARGETS.rooms * fallbackScale),
+    floor_tiles: Math.round(REFERENCE_TARGETS.rooms * fallbackScale),
+    traps: Math.round(REFERENCE_TARGETS.rooms * fallbackScale),
+    hazards: Math.round((REFERENCE_TARGETS.hazards || 0) * fallbackScale),
+    resources: Math.round(REFERENCE_TARGETS.resources * fallbackScale),
+    delvers: Math.round(REFERENCE_TARGETS.delvers * fallbackScale),
+    wardens: Math.round(REFERENCE_TARGETS.wardens * fallbackScale),
+    shared_system: 0,
+  };
+  return Object.fromEntries(REPORT_CATEGORIES.map((category) => {
+    const poolId = CATEGORY_POOL_IDS[category];
+    const poolTarget = poolId ? poolTargets.get(poolId) : undefined;
+    return [category, Number.isInteger(poolTarget) ? poolTarget : fallback[category] || 0];
+  }));
+}
+
+function sumLineItemsByCategory(lineItems = []) {
+  const categorySpend = Object.fromEntries(REPORT_CATEGORIES.map((category) => [category, 0]));
+  lineItems.forEach((item) => {
+    const category = typeof item?.category === "string" ? item.category : null;
+    if (!category || !Object.prototype.hasOwnProperty.call(categorySpend, category)) return;
+    categorySpend[category] += normalizeSpend(item.totalCost);
+  });
+  return categorySpend;
+}
+
+function buildLegacyCategorySpend({ roomsSpend, delverSpend, wardenSpend, resourcesSpend } = {}) {
+  return {
+    rooms: normalizeSpend(roomsSpend),
+    floor_tiles: 0,
+    traps: 0,
+    hazards: 0,
+    resources: normalizeSpend(resourcesSpend),
+    delvers: normalizeSpend(delverSpend),
+    wardens: normalizeSpend(wardenSpend),
+    shared_system: 0,
+  };
+}
+
+function buildCategorySpend(options = {}) {
+  if (Array.isArray(options.lineItems)) {
+    return sumLineItemsByCategory(options.lineItems);
+  }
+  if (options.categorySpend && typeof options.categorySpend === "object") {
+    return Object.fromEntries(REPORT_CATEGORIES.map((category) => [
+      category,
+      normalizeSpend(options.categorySpend[category]),
+    ]));
+  }
+  return buildLegacyCategorySpend(options);
+}
+
+function buildCategory(actual, target) {
+  return {
+    actual,
+    target,
+    usagePercent: target > 0 ? Math.round((actual / target) * 100) : 0,
+  };
+}
+
 /**
  * Build a scenario-level spend report (design §14).
  *
@@ -44,15 +143,30 @@ export function buildScenarioSpendReport({
   delverSpend = 0,
   wardenSpend = 0,
   resourcesSpend = 0,
+  lineItems,
+  categorySpend,
+  allocation,
   budgetTokens = REFERENCE_BUDGET_TOKENS,
 } = {}) {
-  const totalSpend = roomsSpend + delverSpend + wardenSpend + resourcesSpend;
   const budget = Number.isInteger(budgetTokens) && budgetTokens > 0
     ? budgetTokens
     : REFERENCE_BUDGET_TOKENS;
+  const spend = buildCategorySpend({
+    roomsSpend,
+    delverSpend,
+    wardenSpend,
+    resourcesSpend,
+    lineItems,
+    categorySpend,
+  });
+  spend.rooms += spend.floor_tiles + spend.traps + spend.shared_system;
+  const totalSpend = Array.isArray(lineItems)
+    ? lineItems.reduce((sum, item) => sum + normalizeSpend(item.totalCost), 0)
+    : spend.rooms + spend.hazards + spend.resources + spend.delvers + spend.wardens;
+  const targets = buildCategoryTargets({ budgetTokens: budget, allocation });
 
-  const actualRatio = wardenSpend > 0 ? delverSpend / wardenSpend : 0;
-  const incentiveMultiplier = computeIncentiveMultiplier(delverSpend, wardenSpend);
+  const actualRatio = spend.wardens > 0 ? spend.delvers / spend.wardens : 0;
+  const incentiveMultiplier = computeIncentiveMultiplier(spend.delvers, spend.wardens);
 
   return {
     budget,
@@ -60,37 +174,10 @@ export function buildScenarioSpendReport({
     remainingBudget: Math.max(0, budget - totalSpend),
     overBudget: totalSpend > budget,
 
-    // Per-category actuals and targets (design §14.1–14.3)
-    categories: {
-      rooms: {
-        actual: roomsSpend,
-        target: REFERENCE_TARGETS.rooms,
-        usagePercent: REFERENCE_TARGETS.rooms > 0
-          ? Math.round((roomsSpend / REFERENCE_TARGETS.rooms) * 100)
-          : 0,
-      },
-      delvers: {
-        actual: delverSpend,
-        target: REFERENCE_TARGETS.delvers,
-        usagePercent: REFERENCE_TARGETS.delvers > 0
-          ? Math.round((delverSpend / REFERENCE_TARGETS.delvers) * 100)
-          : 0,
-      },
-      wardens: {
-        actual: wardenSpend,
-        target: REFERENCE_TARGETS.wardens,
-        usagePercent: REFERENCE_TARGETS.wardens > 0
-          ? Math.round((wardenSpend / REFERENCE_TARGETS.wardens) * 100)
-          : 0,
-      },
-      resources: {
-        actual: resourcesSpend,
-        target: REFERENCE_TARGETS.resources,
-        usagePercent: REFERENCE_TARGETS.resources > 0
-          ? Math.round((resourcesSpend / REFERENCE_TARGETS.resources) * 100)
-          : 0,
-      },
-    },
+    categories: Object.fromEntries(REPORT_CATEGORIES.map((category) => [
+      category,
+      buildCategory(spend[category], targets[category]),
+    ])),
 
     totalBudgetUsagePercent: budget > 0
       ? Math.round((totalSpend / budget) * 100)

--- a/packages/runtime/src/personas/allocator/validate-spend.js
+++ b/packages/runtime/src/personas/allocator/validate-spend.js
@@ -1,6 +1,18 @@
 const BUDGET_RECEIPT_ARTIFACT_SCHEMA = "agent-kernel/BudgetReceiptArtifact";
 const PRICE_LIST_SCHEMA = "agent-kernel/PriceList";
 const BUDGET_ARTIFACT_SCHEMA = "agent-kernel/BudgetArtifact";
+const BUDGET_ALLOCATION_SCHEMA = "agent-kernel/BudgetAllocationArtifact";
+
+const CATEGORY_POOL_IDS = Object.freeze({
+  rooms: "rooms",
+  floor_tiles: "rooms",
+  traps: "rooms",
+  hazards: "hazards",
+  resources: "resources",
+  delvers: "delver",
+  wardens: "wardens",
+  shared_system: "rooms",
+});
 
 function isFiniteNumber(value) {
   return Number.isFinite(value);
@@ -51,15 +63,72 @@ export function buildPriceMap(priceList) {
   return map;
 }
 
+export function calculatePriceTotal(price, quantity) {
+  const unitCost = isFiniteNumber(price?.unitCost) ? price.unitCost : 0;
+  const q = normalizeQuantity(quantity);
+  return price?.formula === "quadratic" ? unitCost * q * q : unitCost * q;
+}
+
+function buildAllocationRef(allocation) {
+  return allocation ? buildRef(allocation, BUDGET_ALLOCATION_SCHEMA) : undefined;
+}
+
+function buildAllocationAudit({ allocation, lineItems, errors }) {
+  const pools = Array.isArray(allocation?.pools) ? allocation.pools : [];
+  if (pools.length === 0) return undefined;
+
+  const spendByPool = new Map(pools.map((pool) => [pool.id, 0]));
+  lineItems.forEach((item) => {
+    const poolId = CATEGORY_POOL_IDS[item.category];
+    if (!poolId) {
+      item.status = "denied";
+      errors.push(`Unattributed spend item: ${item.kind}:${item.id}`);
+      return;
+    }
+    spendByPool.set(poolId, (spendByPool.get(poolId) || 0) + item.totalCost);
+  });
+
+  const poolStatuses = pools.map((pool) => {
+    const capTokens = Number.isInteger(pool.tokens) ? pool.tokens : 0;
+    const spentTokens = spendByPool.get(pool.id) || 0;
+    const remainingTokens = capTokens - spentTokens;
+    const status = remainingTokens >= 0 ? "approved" : "denied";
+    if (status === "denied") {
+      errors.push(`Pool ${pool.id} exceeds allocation: spent ${spentTokens}, cap ${capTokens}.`);
+      lineItems.forEach((item) => {
+        if (CATEGORY_POOL_IDS[item.category] === pool.id) item.status = "denied";
+      });
+    }
+    return {
+      id: pool.id,
+      capTokens,
+      spentTokens,
+      remainingTokens,
+      status,
+    };
+  });
+
+  return { poolStatuses };
+}
+
 function normalizeQuantity(value) {
   if (!isFiniteNumber(value)) return 1;
   return value <= 0 ? 1 : value;
+}
+
+function copyAttribution(item, lineItem) {
+  if (typeof item?.category === "string") lineItem.category = item.category;
+  if (item?.artifactRef != null) lineItem.artifactRef = item.artifactRef;
+  if (item?.subjectRef != null) lineItem.subjectRef = item.subjectRef;
+  if (item?.detail !== undefined) lineItem.detail = item.detail;
+  return lineItem;
 }
 
 export function validateSpendProposal({
   budget,
   priceList,
   proposal,
+  allocation,
   meta,
   budgetRef,
   priceListRef,
@@ -76,15 +145,14 @@ export function validateSpendProposal({
     const quantity = normalizeQuantity(item?.quantity);
     if (typeof id !== "string" || typeof kind !== "string") {
       errors.push(`Invalid proposal item: ${JSON.stringify(item)}`);
-      return {
+      return copyAttribution(item, {
         id: String(id || "unknown"),
         kind: String(kind || "unknown"),
         quantity,
         unitCost: 0,
         totalCost: 0,
         status: "denied",
-        ...(typeof item?.category === "string" ? { category: item.category } : {}),
-      };
+      });
     }
 
     const key = `${kind}:${id}`;
@@ -92,18 +160,17 @@ export function validateSpendProposal({
     const price = priceMap.get(key) || priceMap.get(legacyKey);
     if (!price) {
       errors.push(`Unknown price item: ${kind}:${id}`);
-      return {
+      return copyAttribution(item, {
         id,
         kind,
         quantity,
         unitCost: 0,
         totalCost: 0,
         status: "denied",
-        ...(typeof item?.category === "string" ? { category: item.category } : {}),
-      };
+      });
     }
 
-    const totalCost = price.unitCost * quantity;
+    const totalCost = calculatePriceTotal(price, quantity);
     const lineItem = {
       id,
       kind,
@@ -112,16 +179,12 @@ export function validateSpendProposal({
       totalCost,
       status: "approved",
     };
-    // Pass through attribution fields from the proposal item if present
-    if (typeof item.category === "string") lineItem.category = item.category;
-    if (item.artifactRef != null) lineItem.artifactRef = item.artifactRef;
-    if (item.subjectRef != null) lineItem.subjectRef = item.subjectRef;
-    if (item.detail !== undefined) lineItem.detail = item.detail;
-    return lineItem;
+    return copyAttribution(item, lineItem);
   });
 
   const totalCost = lineItems.reduce((sum, item) => sum + item.totalCost, 0);
   const remaining = isFiniteNumber(budgetTokens) ? budgetTokens - totalCost : 0;
+  const allocationAudit = buildAllocationAudit({ allocation, lineItems, errors });
 
   let status = "approved";
   if (!Number.isInteger(budgetTokens)) {
@@ -131,7 +194,7 @@ export function validateSpendProposal({
 
   const hasDenied = lineItems.some((item) => item.status !== "approved");
   if (hasDenied && status !== "denied") {
-    status = lineItems.some((item) => item.status === "approved") ? "partial" : "denied";
+    status = allocation ? "denied" : lineItems.some((item) => item.status === "approved") ? "partial" : "denied";
   }
 
   if (status !== "denied" && Number.isInteger(budgetTokens) && totalCost > budgetTokens) {
@@ -150,10 +213,12 @@ export function validateSpendProposal({
       budgetRef: budgetRef || buildRef(budget, BUDGET_ARTIFACT_SCHEMA),
       priceListRef: priceListRef || buildRef(priceList, PRICE_LIST_SCHEMA),
       proposalRef,
+      ...(allocation ? { allocationRef: buildAllocationRef(allocation) } : {}),
       status,
       totalCost,
       remaining,
       lineItems,
+      ...(allocationAudit ? allocationAudit : {}),
     },
     errors: errors.length ? errors : undefined,
   };

--- a/packages/runtime/src/personas/configurator/spend-proposal.js
+++ b/packages/runtime/src/personas/configurator/spend-proposal.js
@@ -49,15 +49,83 @@ const VITAL_REGEN_IDS = Object.freeze({
   durability: "vital_durability_regen_tick",
 });
 
-function accumulateItem(counts, id, kind, quantity) {
+const DELVER_KEYWORDS = Object.freeze(["delver", "attack", "attacking", "player", "assault", "intruder", "raider", "runner"]);
+const WARDEN_KEYWORDS = Object.freeze(["warden", "defend", "defending", "stationary", "guard", "patrol", "patrolling", "sentry"]);
+
+function buildSubjectRef(id, schema) {
+  return {
+    id: String(id || "unknown"),
+    schema,
+    schemaVersion: 1,
+  };
+}
+
+function accumulateItem(counts, id, kind, quantity, { category, subjectRef, detail } = {}) {
   if (!Number.isInteger(quantity) || quantity <= 0) return;
-  const key = `${kind}:${id}`;
+  const subjectId = subjectRef?.id || "";
+  const detailKey = detail === undefined ? "" : JSON.stringify(detail);
+  const key = `${category || ""}:${subjectId}:${kind}:${id}:${detailKey}`;
   const existing = counts.get(key);
   if (existing) {
     existing.quantity += quantity;
     return;
   }
-  counts.set(key, { id, kind, quantity });
+  counts.set(key, {
+    id,
+    kind,
+    quantity,
+    ...(category ? { category } : {}),
+    ...(subjectRef ? { subjectRef } : {}),
+    ...(detail !== undefined ? { detail } : {}),
+  });
+}
+
+function countFloorTiles(layoutData) {
+  if (Number.isInteger(layoutData?.floorTiles) && layoutData.floorTiles > 0) {
+    return layoutData.floorTiles;
+  }
+  if (!Array.isArray(layoutData?.tiles)) {
+    if (isInteger(layoutData?.width) && isInteger(layoutData?.height)) {
+      return layoutData.width * layoutData.height;
+    }
+    return 0;
+  }
+  let count = 0;
+  layoutData.tiles.forEach((rowValue) => {
+    const row = String(rowValue || "");
+    for (let i = 0; i < row.length; i += 1) {
+      if (row[i] !== "#") count += 1;
+    }
+  });
+  if (count > 0) return count;
+  if (isInteger(layoutData?.width) && isInteger(layoutData?.height)) {
+    return layoutData.width * layoutData.height;
+  }
+  return 0;
+}
+
+function textBag(entry) {
+  const values = [];
+  ["id", "archetype", "actorType", "type", "kind", "role", "motivation", "source"].forEach((field) => {
+    if (typeof entry?.[field] === "string") values.push(entry[field]);
+  });
+  if (Array.isArray(entry?.motivations)) {
+    entry.motivations.forEach((motivation) => {
+      if (typeof motivation === "string") values.push(motivation);
+      if (motivation && typeof motivation === "object" && typeof motivation.kind === "string") values.push(motivation.kind);
+    });
+  }
+  return values.join(" ").toLowerCase();
+}
+
+function inferActorCategory(actor) {
+  const explicit = String(actor?.archetype || actor?.actorType || actor?.type || actor?.kind || "").toLowerCase();
+  if (explicit === "delver") return "delvers";
+  if (explicit === "warden") return "wardens";
+  const bag = textBag(actor);
+  if (DELVER_KEYWORDS.some((token) => bag.includes(token))) return "delvers";
+  if (WARDEN_KEYWORDS.some((token) => bag.includes(token))) return "wardens";
+  return undefined;
 }
 
 function extractAffinities(actor) {
@@ -68,7 +136,7 @@ function extractAffinities(actor) {
       if (!Number.isInteger(stacks) || stacks <= 0) return;
       const [kind, expression] = key.split(":");
       if (!expression) return;
-      entries.push({ expression, stacks });
+      entries.push({ kind, expression, stacks });
     });
   }
   const affinityList = Array.isArray(actor?.affinities) ? actor.affinities : [];
@@ -76,9 +144,9 @@ function extractAffinities(actor) {
     if (!entry) return;
     const stacks = Number.isInteger(entry.stacks) ? entry.stacks : 1;
     if (stacks <= 0) return;
-    const expression = entry.expression || entry.kind || entry.type;
+    const expression = entry.expression || entry.type;
     if (!expression) return;
-    entries.push({ expression, stacks });
+    entries.push({ kind: entry.kind, expression, stacks });
   });
   return entries;
 }
@@ -99,11 +167,22 @@ function extractResourcePriceEntries(resource) {
       quantity: Math.abs(Number.isFinite(v?.delta) ? v.delta : 0),
     }));
   }
+  if (resource?.resourceVitals && typeof resource.resourceVitals === "object") {
+    const permanenceMode = resource.permanenceMode || (resource.permanent ? "permanent" : resource.tier) || "consumable";
+    const priceId = RESOURCE_PRICE_IDS[permanenceMode] || RESOURCE_PRICE_IDS.consumable;
+    return Object.values(resource.resourceVitals)
+      .map((v) => Math.abs(Number.isFinite(v?.delta) ? v.delta : 0) + Math.abs(Number.isFinite(v?.regen) ? v.regen : 0))
+      .filter((quantity) => quantity > 0)
+      .map((quantity) => ({ priceId, quantity }));
+  }
   // V1: { tier, delta }
   if (resource?.tier) {
     const priceId = RESOURCE_PRICE_IDS[resource.tier];
     if (!priceId) return [];
     return [{ priceId, quantity: Math.abs(Number.isFinite(resource.delta) ? resource.delta : 0) }];
+  }
+  if (Number.isInteger(resource?.budgetCeiling) && resource.budgetCeiling > 0) {
+    return [{ priceId: RESOURCE_PRICE_IDS.consumable, quantity: resource.budgetCeiling }];
   }
   return [];
 }
@@ -111,20 +190,41 @@ function extractResourcePriceEntries(resource) {
 function buildSpendItems({ layoutData, actors, traps, resources }) {
   const counts = new Map();
   const trapArray = Array.isArray(traps) ? traps : [];
+  const hazardArray = Array.isArray(layoutData?.hazards) ? layoutData.hazards : [];
+  const resourceArray = [
+    ...(Array.isArray(resources) ? resources : []),
+    ...(Array.isArray(layoutData?.resources) ? layoutData.resources : []),
+  ];
 
-  if (isInteger(layoutData?.width) && isInteger(layoutData?.height)) {
-    accumulateItem(counts, `layout_grid_${layoutData.width}x${layoutData.height}`, "layout", 1);
+  const floorTiles = layoutData?.budgetScaffold === true ? 0 : countFloorTiles(layoutData);
+  if (floorTiles > 0) {
+    accumulateItem(counts, "tile_floor", "tile", floorTiles, {
+      category: "floor_tiles",
+      subjectRef: buildSubjectRef("layout", "agent-kernel/LayoutArtifact"),
+    });
   }
 
   if (Array.isArray(actors) && actors.length > 0) {
-    accumulateItem(counts, "actor_spawn", "actor", actors.length);
+    actors.forEach((actor, index) => {
+      const category = inferActorCategory(actor);
+      accumulateItem(counts, "actor_spawn", "actor", 1, {
+        category,
+        subjectRef: buildSubjectRef(actor?.id || `actor_${index + 1}`, "agent-kernel/ActorArtifact"),
+      });
+    });
   }
 
   if (trapArray.length > 0) {
-    accumulateItem(counts, "trap_basic", "trap", trapArray.length);
+    trapArray.forEach((trap, index) => {
+      accumulateItem(counts, "trap_basic", "trap", 1, {
+        category: "traps",
+        subjectRef: buildSubjectRef(trap?.id || `trap_${index + 1}`, "agent-kernel/TrapArtifact"),
+      });
+    });
   }
 
-  trapArray.forEach((trap) => {
+  trapArray.forEach((trap, index) => {
+    const subjectRef = buildSubjectRef(trap?.id || `trap_${index + 1}`, "agent-kernel/TrapArtifact");
     const vitals = trap?.vitals;
     if (vitals && typeof vitals === "object") {
       Object.keys(vitals).forEach((key) => {
@@ -136,8 +236,8 @@ function buildSpendItems({ layoutData, actors, traps, resources }) {
             ? vital.current
             : 0;
         const regen = Number.isInteger(vital.regen) ? vital.regen : 0;
-        accumulateItem(counts, `vital_${key}_point`, "vital", max);
-        accumulateItem(counts, `vital_${key}_regen_tick`, "vital", regen);
+        accumulateItem(counts, `vital_${key}_point`, "vital", max, { category: "traps", subjectRef });
+        accumulateItem(counts, `vital_${key}_regen_tick`, "vital", regen, { category: "traps", subjectRef });
       });
     }
     const affinity = trap?.affinity;
@@ -145,22 +245,52 @@ function buildSpendItems({ layoutData, actors, traps, resources }) {
       const stacks = Number.isInteger(affinity.stacks) && affinity.stacks > 0 ? affinity.stacks : 1;
       const expressionId = AFFINITY_EXPRESSION_IDS[affinity.expression];
       if (expressionId) {
-        accumulateItem(counts, expressionId, "affinity", stacks);
+        accumulateItem(counts, expressionId, "affinity", stacks, { category: "traps", subjectRef });
       }
-      accumulateItem(counts, "affinity_stack", "affinity", stacks);
+      accumulateItem(counts, "affinity_stack", "affinity", stacks, { category: "traps", subjectRef });
     }
   });
 
-  if (Array.isArray(resources)) {
-    resources.forEach((resource) => {
+  hazardArray.forEach((hazard, index) => {
+    const subjectRef = buildSubjectRef(hazard?.id || `hazard_${index + 1}`, "agent-kernel/HazardArtifact");
+    accumulateItem(counts, "hazard_base", "hazard", 1, { category: "hazards", subjectRef });
+    const mana = hazard?.mana;
+    if (mana && typeof mana === "object") {
+      const max = Number.isInteger(mana.max)
+        ? mana.max
+        : Number.isInteger(mana.current)
+          ? mana.current
+          : Number.isInteger(mana.amount)
+            ? mana.amount
+            : 0;
+      const regen = Number.isInteger(mana.regen) ? mana.regen : 0;
+      accumulateItem(counts, "vital_mana_point", "vital", max, { category: "hazards", subjectRef });
+      accumulateItem(counts, "vital_mana_regen_tick", "vital", regen, { category: "hazards", subjectRef });
+    }
+    const expression = hazard?.expression || hazard?.affinities?.[0]?.expression;
+    const stacks = Number.isInteger(hazard?.stacks) && hazard.stacks > 0 ? hazard.stacks : 1;
+    const expressionId = AFFINITY_EXPRESSION_IDS[expression];
+    if (expressionId) {
+      accumulateItem(counts, expressionId, "affinity", stacks, { category: "hazards", subjectRef });
+    }
+    if (typeof hazard?.affinity === "string" || expressionId) {
+      accumulateItem(counts, "affinity_stack", "affinity", stacks, { category: "hazards", subjectRef });
+    }
+  });
+
+  if (resourceArray.length > 0) {
+    resourceArray.forEach((resource, index) => {
+      const subjectRef = buildSubjectRef(resource?.id || `resource_${index + 1}`, "agent-kernel/ResourceArtifact");
       extractResourcePriceEntries(resource).forEach(({ priceId, quantity }) => {
-        accumulateItem(counts, priceId, "resource", quantity);
+        accumulateItem(counts, priceId, "resource", Math.floor(quantity), { category: "resources", subjectRef });
       });
     });
   }
 
   if (Array.isArray(actors)) {
-    actors.forEach((actor) => {
+    actors.forEach((actor, index) => {
+      const category = inferActorCategory(actor);
+      const subjectRef = buildSubjectRef(actor?.id || `actor_${index + 1}`, "agent-kernel/ActorArtifact");
       const vitals = actor?.vitals;
       if (vitals && typeof vitals === "object") {
         VITAL_KEYS.forEach((key) => {
@@ -171,20 +301,20 @@ function buildSpendItems({ layoutData, actors, traps, resources }) {
             : Number.isInteger(vital.current)
               ? vital.current
               : 0;
-          accumulateItem(counts, `vital_${key}_point`, "vital", max);
+          accumulateItem(counts, `vital_${key}_point`, "vital", max, { category, subjectRef });
           const regen = Number.isInteger(vital.regen) ? vital.regen : 0;
-          accumulateItem(counts, `vital_${key}_regen_tick`, "vital", regen);
+          accumulateItem(counts, `vital_${key}_regen_tick`, "vital", regen, { category, subjectRef });
         });
       }
 
       const affinities = extractAffinities(actor);
       if (affinities.length > 0) {
         const totalStacks = affinities.reduce((sum, entry) => sum + entry.stacks, 0);
-        accumulateItem(counts, "affinity_stack", "affinity", totalStacks);
+        accumulateItem(counts, "affinity_stack", "affinity", totalStacks, { category, subjectRef });
         affinities.forEach((entry) => {
           const expressionId = AFFINITY_EXPRESSION_IDS[entry.expression];
           if (!expressionId) return;
-          accumulateItem(counts, expressionId, "affinity", entry.stacks);
+          accumulateItem(counts, expressionId, "affinity", entry.stacks, { category, subjectRef });
         });
       }
 
@@ -193,12 +323,16 @@ function buildSpendItems({ layoutData, actors, traps, resources }) {
         const motivationId = MOTIVATION_KIND_IDS[entry.kind];
         if (!motivationId) return;
         const quantity = Number.isInteger(entry.intensity) && entry.intensity > 0 ? entry.intensity : 1;
-        accumulateItem(counts, motivationId, "motivation", quantity);
+        accumulateItem(counts, motivationId, "motivation", quantity, { category, subjectRef });
       });
     });
   }
 
   return Array.from(counts.values()).sort((a, b) => {
+    const categoryOrder = String(a.category || "").localeCompare(String(b.category || ""));
+    if (categoryOrder !== 0) return categoryOrder;
+    const subjectOrder = String(a.subjectRef?.id || "").localeCompare(String(b.subjectRef?.id || ""));
+    if (subjectOrder !== 0) return subjectOrder;
     const kindOrder = a.kind.localeCompare(b.kind);
     if (kindOrder !== 0) return kindOrder;
     return a.id.localeCompare(b.id);
@@ -210,7 +344,10 @@ export function buildSpendProposal({ meta, layout, actors, traps, resources } = 
   const trapArray = Array.isArray(traps) ? traps
     : Array.isArray(layoutData?.traps) ? layoutData.traps
     : [];
-  const items = buildSpendItems({ layoutData, actors, traps: trapArray, resources });
+  const resourceArray = Array.isArray(resources) && resources.length > 0
+    ? resources
+    : Array.isArray(layoutData?.resources) ? layoutData.resources : [];
+  const items = buildSpendItems({ layoutData, actors, traps: trapArray, resources: resourceArray });
 
   return {
     schema: SPEND_PROPOSAL_SCHEMA,
@@ -227,6 +364,7 @@ export function evaluateConfiguratorSpend({
   actors,
   traps,
   resources,
+  allocation,
   proposalMeta,
   receiptMeta,
 } = {}) {
@@ -238,6 +376,7 @@ export function evaluateConfiguratorSpend({
     budget,
     priceList,
     proposal,
+    allocation,
     meta: receiptMeta,
     proposalRef,
   });

--- a/packages/runtime/src/personas/director/budget-allocation.js
+++ b/packages/runtime/src/personas/director/budget-allocation.js
@@ -30,7 +30,8 @@ export const REFERENCE_TARGETS = Object.freeze({
   rooms: 1100,
   delvers: 500,
   wardens: 400,
-  resources: 160,
+  hazards: 300,
+  resources: 200,
 });
 
 /** Target delver/warden spend ratio (design §3.2): 200/250 = 0.8. */
@@ -175,7 +176,12 @@ function normalizePoolWeights(poolWeights) {
     errors.push({ field: "poolWeights", code: "invalid_pool_weight_total" });
   }
 
-  return { pools: normalized, errors };
+  const positivePools = normalized.filter((pool) => pool.weight > 0);
+  const resourceOnlyExplicit = callerProvidedExplicit
+    && positivePools.length === 1
+    && positivePools[0].id === "resources";
+
+  return { pools: normalized, errors, resourceOnlyExplicit };
 }
 
 export function computeBudgetPools({ budgetTokens, policy = {}, dungeonPct, delverPct, poolWeights } = {}) {
@@ -190,7 +196,9 @@ export function computeBudgetPools({ budgetTokens, policy = {}, dungeonPct, delv
   let pools = allocatePools({ tokens: availableTokens, pools: normalized.pools });
 
   // Apply resource cap: resources must not exceed hazards + wardens (excess → rooms)
-  pools = applyResourceCap(pools);
+  if (!normalized.resourceOnlyExplicit) {
+    pools = applyResourceCap(pools);
+  }
 
   // Compute convenience totals for two-tier reporting
   const dungeonPoolIds = new Set(["rooms", "hazards", "wardens", "resources"]);

--- a/packages/runtime/src/personas/director/buildspec-assembler.js
+++ b/packages/runtime/src/personas/director/buildspec-assembler.js
@@ -310,10 +310,13 @@ export function buildBuildSpecFromSummary({
         id: entry.id,
         permanenceMode: entry.permanenceMode,
         vitals: Array.isArray(entry.vitals) ? entry.vitals.map((v) => ({ ...v })) : undefined,
+        resourceVitals: entry.resourceVitals && typeof entry.resourceVitals === "object" ? { ...entry.resourceVitals } : undefined,
+        permanent: entry.permanent === true,
         tier: entry.tier,
         stat: entry.stat,
         delta: entry.delta,
         dropRate: entry.dropRate,
+        budgetCeiling: entry.budgetCeiling,
       }))
     : [];
   const prebuiltLevelGen = resolvedSummary?.levelGen && typeof resolvedSummary.levelGen === "object"
@@ -323,6 +326,9 @@ export function buildBuildSpecFromSummary({
     || (layout || roomDesign
       ? deriveLevelGenFromLayout(layout || {}, roomDesign)
       : deriveLevelGen({ roomCount }));
+  if (resolvedSummary?.budgetScaffold === true) {
+    levelGen.budgetScaffold = true;
+  }
   if (hazards.length > 0) {
     levelGen.hazards = hazards;
   }

--- a/packages/runtime/src/personas/director/pool-mapper.js
+++ b/packages/runtime/src/personas/director/pool-mapper.js
@@ -118,6 +118,12 @@ export function mapSummaryToPool({ summary, catalog }) {
         if (affinities.length > 0) {
           instance.affinities = affinities.map((entry) => ({ ...entry }));
         }
+        if (pick.actorType === "delver" || pick.actorType === "warden") {
+          instance.actorType = pick.actorType;
+        }
+        if (typeof pick.setupMode === "string" && pick.setupMode.trim()) {
+          instance.setupMode = pick.setupMode.trim();
+        }
         const copiedVitals = copyActorVitals(pick?.vitals);
         if (copiedVitals) instance.vitals = copiedVitals;
         return instance;

--- a/packages/runtime/src/personas/director/summary-selections.js
+++ b/packages/runtime/src/personas/director/summary-selections.js
@@ -373,6 +373,9 @@ export function normalizeCardEntry(entry, { dungeonAffinity = DEFAULT_DUNGEON_AF
     vitals: type === "resource"
       ? (Array.isArray(entry?.vitals) ? entry.vitals : undefined)
       : (type === "room" || type === "hazard" ? undefined : normalizeVitals(entry?.vitals)),
+    resourceVitals: type === "resource" && entry?.resourceVitals && typeof entry.resourceVitals === "object"
+      ? { ...entry.resourceVitals }
+      : undefined,
     proximityRadius: type === "hazard" ? normalizePositiveInt(entry?.proximityRadius, 1) : undefined,
     mana: type === "hazard" ? normalizeHazardVital(entry?.mana, { kind: "one-time", amount: 3 }) : undefined,
     durability: type === "room" && entry?.durability ? normalizeHazardVital(entry.durability, { kind: "one-time", amount: 1 }) : undefined,
@@ -381,6 +384,7 @@ export function normalizeCardEntry(entry, { dungeonAffinity = DEFAULT_DUNGEON_AF
     delta: type === "resource" && Number.isFinite(Number(entry?.delta)) ? Number(entry.delta) : undefined,
     dropRate: type === "resource" && Number.isFinite(Number(entry?.dropRate)) ? Math.floor(Number(entry.dropRate)) : undefined,
     permanenceMode: type === "resource" ? entry?.permanenceMode : undefined,
+    permanent: type === "resource" ? entry?.permanent === true : undefined,
     budgetCeiling: type === "resource" && Number.isFinite(Number(entry?.budgetCeiling))
       ? Math.max(0, Math.floor(Number(entry.budgetCeiling)))
       : undefined,
@@ -561,8 +565,11 @@ export function buildCardSetFromSummary(summary) {
       entry?.motivations,
       entry?.motivation || entry?.role || "defending",
     );
-    const delver = motivations.some((motivation) => isAttackingMotivation(motivation));
-    const type = delver ? "delver" : "warden";
+    const explicitType = normalizeActorType(entry?.actorType ?? entry?.type);
+    const delver = explicitType
+      ? explicitType === "delver"
+      : motivations.some((motivation) => isAttackingMotivation(motivation));
+    const type = explicitType || (delver ? "delver" : "warden");
     return normalizeCardEntry(
     {
       id: entry?.id || `card_${type}_${index + 1}`,
@@ -619,10 +626,13 @@ export function extractSummaryFromCardSet(summary) {
     id: card.id,
     permanenceMode: card.permanenceMode,
     vitals: card.vitals,
+    resourceVitals: card.resourceVitals,
+    permanent: card.permanent,
     tier: card.tier,
     stat: card.stat,
     delta: card.delta,
     dropRate: card.dropRate,
+    budgetCeiling: card.budgetCeiling,
   }));
   const actors = actorCards.map((card) => (
     card.type === "delver"

--- a/packages/runtime/src/personas/orchestrator/llm-budget-loop.js
+++ b/packages/runtime/src/personas/orchestrator/llm-budget-loop.js
@@ -1071,6 +1071,24 @@ function buildCombinedSummary({ baseSummary, selections, layout } = {}) {
   return summary;
 }
 
+function applyActorTypeToSelections(selections = [], actorType) {
+  if (actorType !== "delver" && actorType !== "warden") return selections;
+  return selections.map((selection) => {
+    if (selection?.kind !== "actor") return selection;
+    const next = { ...selection };
+    if (next.requested && typeof next.requested === "object") {
+      next.requested = { ...next.requested, actorType: next.requested.actorType || actorType };
+    }
+    if (Array.isArray(next.instances)) {
+      next.instances = next.instances.map((instance) => ({
+        ...instance,
+        actorType: instance.actorType || actorType,
+      }));
+    }
+    return next;
+  });
+}
+
 function buildActorPhaseGoal({ baseGoal, dungeonAffinity, wardenAffinities } = {}) {
   const wardenPhrase = formatAffinityPhrase(wardenAffinities);
   if (isNonEmptyString(wardenPhrase)) {
@@ -1326,8 +1344,9 @@ export async function runLlmBudgetLoop({
       return { ok: false, errors: actorsPhase.errors || [], captures, trace };
     }
 
+    const actorSelections = applyActorTypeToSelections(actorsPhase.selections, "warden");
     const actorSpend = evaluateSelectionSpend({
-      selections: actorsPhase.selections,
+      selections: actorSelections,
       budgetTokens: remainingBudgetTokens,
       priceList,
     });

--- a/packages/ui-web/src/budget-input-validation.js
+++ b/packages/ui-web/src/budget-input-validation.js
@@ -65,25 +65,27 @@ export function validatePercentage(value, defaultValue = 0) {
 
 /**
  * Validates that budget percentages sum to 100%
- * @param {Object} percentages - Object with room, delver, warden keys
+ * @param {Object} percentages - Object with room, delver, warden, hazard, resource keys
  * @param {number} percentages.room - Room percentage
  * @param {number} percentages.delver - Delver percentage
  * @param {number} percentages.warden - Warden percentage
  * @returns {Object} - Validated percentages
  * @throws {Error} - If percentages don't sum to 100
  */
-export function validateBudgetPercentages({ room = 0, delver = 0, warden = 0 }) {
+export function validateBudgetPercentages({ room = 0, delver = 0, warden = 0, hazard = 0, resource = 0 }) {
   const validated = {
     room: validatePercentage(room),
     delver: validatePercentage(delver),
     warden: validatePercentage(warden),
+    hazard: validatePercentage(hazard),
+    resource: validatePercentage(resource),
   };
 
-  const total = validated.room + validated.delver + validated.warden;
+  const total = validated.room + validated.delver + validated.warden + validated.hazard + validated.resource;
 
   if (total !== 100) {
     throw new Error(
-      `Budget percentages must sum to 100%. Got: ${total}% (room: ${validated.room}%, delver: ${validated.delver}%, warden: ${validated.warden}%)`
+      `Budget percentages must sum to 100%. Got: ${total}% (room: ${validated.room}%, delver: ${validated.delver}%, warden: ${validated.warden}%, hazard: ${validated.hazard}%, resource: ${validated.resource}%)`
     );
   }
 
@@ -97,14 +99,18 @@ export function validateBudgetPercentages({ room = 0, delver = 0, warden = 0 }) 
  * @param {number|string} input.roomPercent - Room percentage
  * @param {number|string} input.delverPercent - Delver percentage
  * @param {number|string} input.wardenPercent - Warden percentage
+ * @param {number|string} input.hazardPercent - Hazard percentage
+ * @param {number|string} input.resourcePercent - Resource percentage
  * @returns {Object} - Normalized and validated values
  * @throws {Error} - If any value fails validation
  */
 export function normalizeBudgetInputs({
   levelBudget = 1000,
-  roomPercent = 55,
+  roomPercent = 44,
   delverPercent = 20,
-  wardenPercent = 25,
+  wardenPercent = 16,
+  hazardPercent = 12,
+  resourcePercent = 8,
 } = {}) {
   return {
     levelBudget: validateLevelBudget(levelBudget),
@@ -112,6 +118,8 @@ export function normalizeBudgetInputs({
       room: roomPercent,
       delver: delverPercent,
       warden: wardenPercent,
+      hazard: hazardPercent,
+      resource: resourcePercent,
     }),
   };
 }

--- a/tests/adapters-cli/ak-authoring-commands.test.js
+++ b/tests/adapters-cli/ak-authoring-commands.test.js
@@ -1,6 +1,6 @@
 const assert = require("node:assert/strict");
 const { spawnSync } = require("node:child_process");
-const { mkdtempSync, readFileSync, existsSync } = require("node:fs");
+const { mkdtempSync, readFileSync, existsSync, writeFileSync } = require("node:fs");
 const { resolve, join } = require("node:path");
 const os = require("node:os");
 
@@ -50,17 +50,33 @@ test("cli help documents generic create and configure authoring commands", () =>
   assert.equal(result.status, 0);
   assert.match(result.stdout, /\bcreate\b/);
   assert.match(result.stdout, /\bconfigure\b/);
+  assert.match(result.stdout, /\bhazard-plan\b/);
+  assert.match(result.stdout, /\bresource-plan\b/);
   assert.match(result.stdout, /--floor-tile/);
   assert.match(result.stdout, /--trap/);
+  assert.match(result.stdout, /--hazard/);
+  assert.match(result.stdout, /--resource/);
   assert.match(result.stdout, /goals=max_mana/);
 });
 
 test("cli create emits a complete playable artifact bundle for agent requests", () => {
   const outDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-create-authoring-"));
+  const budgetPath = join(outDir, "budget-input.json");
+  writeFileSync(budgetPath, JSON.stringify({
+    schema: "agent-kernel/BudgetArtifact",
+    schemaVersion: 1,
+    meta: {
+      id: "budget_create_authoring_1200",
+      runId: "run_create_authoring",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      producedBy: "test",
+    },
+    budget: { tokens: 1200 },
+  }, null, 2));
   const result = runCliOk([
     "create",
     "--text",
-    "Create a fire room with a trap, one delver, and one warden. Total budget 1000 tokens.",
+    "Create a fire room with a trap, one delver, and one warden. Total budget 1200 tokens.",
     "--room",
     "size=large;count=1",
     "--floor-tile",
@@ -72,13 +88,13 @@ test("cli create emits a complete playable artifact bundle for agent requests", 
     "--warden",
     "id=ember_warden;count=1;affinity=fire;motivation=defending",
     "--budget-tokens",
-    "1000",
+    "1200",
     "--run-id",
     "run_create_authoring",
     "--created-at",
     "2026-04-08T00:00:00.000Z",
     "--budget",
-    BUDGET,
+    budgetPath,
     "--price-list",
     PRICE_LIST,
     "--out-dir",
@@ -117,17 +133,17 @@ test("cli create emits a complete playable artifact bundle for agent requests", 
 
   assert.equal(request.schema, "agent-kernel/AgentCommandRequestArtifact");
   assert.equal(request.command.action, "author");
-  assert.equal(request.command.text, "Create a fire room with a trap, one delver, and one warden. Total budget 1000 tokens.");
+  assert.equal(request.command.text, "Create a fire room with a trap, one delver, and one warden. Total budget 1200 tokens.");
   assert.deepEqual(
     request.objects.map((entry) => entry.kind),
     ["room", "floor_tile", "trap", "delver", "warden", "shared_config"],
   );
 
   assert.deepEqual(spec.authoring.objectKinds, ["room", "floor_tile", "trap", "delver", "warden", "shared_config"]);
-  assert.equal(request.sharedConfig.constraints.hardBudget.totalTokens, 1000);
+  assert.equal(request.sharedConfig.constraints.hardBudget.totalTokens, 1200);
   assert.deepEqual(request.sharedConfig.constraints.hardBudget.sources, ["text", "flag", "budget_artifact"]);
   assert.equal(request.sharedConfig.optimizationGoals, undefined);
-  assert.equal(spec.authoring.constraints.hardBudget.totalTokens, 1000);
+  assert.equal(spec.authoring.constraints.hardBudget.totalTokens, 1200);
   assert.ok(spec.authoring.optimizationGoals.every((entry) => entry.kind !== "maximize_budget_spend"));
   const delverRequest = request.objects.find((entry) => entry.kind === "delver");
   assert.equal(delverRequest.optimizationGoals.length, 2);

--- a/tests/adapters-cli/ak-configurator.test.js
+++ b/tests/adapters-cli/ak-configurator.test.js
@@ -123,23 +123,24 @@ test("cli configurator emits a budget receipt from budget inputs", () => {
   });
   assert.deepEqual(receiptOutData, receipt);
 
-  const layoutLine = receipt.lineItems.find((item) => item.id === "layout_grid_5x5");
+  const layoutLine = receipt.lineItems.find((item) => item.id === "tile_floor" && item.kind === "tile");
   assert.ok(layoutLine);
+  assert.equal(layoutLine.quantity, 9);
   assert.equal(layoutLine.unitCost, 0);
   assert.equal(layoutLine.totalCost, 0);
   assert.equal(layoutLine.status, "denied");
 
-  const healthLine = receipt.lineItems.find((item) => item.id === "vital_health_point");
-  assert.ok(healthLine);
-  assert.equal(healthLine.unitCost, 1);
-  assert.equal(healthLine.totalCost, 16);
-  assert.equal(healthLine.status, "approved");
+  const healthLines = receipt.lineItems.filter((item) => item.id === "vital_health_point");
+  assert.ok(healthLines.length > 0);
+  assert.ok(healthLines.every((item) => item.unitCost === 1));
+  assert.equal(healthLines.reduce((sum, item) => sum + item.totalCost, 0), 16);
+  assert.ok(healthLines.every((item) => item.status === "approved"));
 
-  const manaLine = receipt.lineItems.find((item) => item.id === "vital_mana_point");
-  assert.ok(manaLine);
-  assert.equal(manaLine.unitCost, 1);
-  assert.equal(manaLine.totalCost, 4); // actor mana(1) + trap mana.max(3)
-  assert.equal(manaLine.status, "approved");
+  const manaLines = receipt.lineItems.filter((item) => item.id === "vital_mana_point");
+  assert.ok(manaLines.length > 0);
+  assert.ok(manaLines.every((item) => item.unitCost === 1));
+  assert.equal(manaLines.reduce((sum, item) => sum + item.totalCost, 0), 4); // actor mana(1) + trap mana.max(3)
+  assert.ok(manaLines.every((item) => item.status === "approved"));
 });
 
 test("cli configurator rejects invalid level-gen input", () => {

--- a/tests/adapters-cli/ak-cost-summary.test.js
+++ b/tests/adapters-cli/ak-cost-summary.test.js
@@ -34,7 +34,7 @@ test("ak create with --budget-tokens emits top-level cost summary", () => {
     "--room", "size=small;count=1",
     "--delver", "count=1;motivation=attacking",
     "--text", "Cost summary test",
-    "--budget-tokens", "500",
+    "--budget-tokens", "1000",
     "--run-id", "run_cost_summary_create",
     "--created-at", "2026-04-22T00:00:00.000Z",
     "--out-dir", outDir,
@@ -43,7 +43,7 @@ test("ak create with --budget-tokens emits top-level cost summary", () => {
   assert.ok(summary.cost, "create output must include a top-level cost field when budget is present");
   assert.ok(Number.isInteger(summary.cost.totalSpend), "cost.totalSpend must be an integer");
   assert.ok(Number.isInteger(summary.cost.budgetTokens), "cost.budgetTokens must be an integer");
-  assert.equal(summary.cost.budgetTokens, 500, "cost.budgetTokens must equal the --budget-tokens value");
+  assert.equal(summary.cost.budgetTokens, 1000, "cost.budgetTokens must equal the --budget-tokens value");
   assert.ok(Number.isInteger(summary.cost.remaining), "cost.remaining must be an integer");
   assert.ok(typeof summary.cost.status === "string", "cost.status must be a string");
   assert.ok(typeof summary.cost.receiptPath === "string", "cost.receiptPath must be a string");
@@ -73,7 +73,7 @@ test("ak create cost.totalSpend + cost.remaining equals cost.budgetTokens", () =
     "create",
     "--room", "size=small;count=1",
     "--delver", "count=1;motivation=exploring",
-    "--budget-tokens", "500",
+    "--budget-tokens", "1000",
     "--run-id", "run_cost_budget_math",
     "--created-at", "2026-04-22T00:00:00.000Z",
     "--out-dir", outDir,

--- a/tests/adapters-cli/ak-hazard-resource-plan.test.js
+++ b/tests/adapters-cli/ak-hazard-resource-plan.test.js
@@ -1,0 +1,191 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, readFileSync, existsSync } = require("node:fs");
+const { resolve, join } = require("node:path");
+const os = require("node:os");
+
+const ROOT = resolve(__dirname, "../..");
+const CLI = resolve(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+}
+
+function runCliOk(args) {
+  const result = runCli(args);
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    throw new Error(`CLI failed (${result.status}): ${output}`);
+  }
+  return result;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function readStdoutJson(result) {
+  return JSON.parse((result.stdout || "").trim());
+}
+
+test("cli hazard-plan authors hazards directly from hazard flags", () => {
+  const outDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-hazard-plan-basic-"));
+  const result = runCliOk([
+    "hazard-plan",
+    "--hazard",
+    "affinity=fire;expression=emit;proximityRadius=2;mana=regen:4:4:1",
+    "--run-id",
+    "run_hazard_plan_basic",
+    "--created-at",
+    "2026-06-29T00:00:00.000Z",
+    "--out-dir",
+    outDir,
+  ]);
+  const summary = readStdoutJson(result);
+
+  assert.equal(summary.command, "hazard-plan");
+  assert.equal(existsSync(join(outDir, "spec.json")), true);
+  assert.equal(existsSync(join(outDir, "hazard-1.json")), true);
+
+  const spec = readJson(join(outDir, "spec.json"));
+  const hazards = spec.configurator?.inputs?.levelGen?.hazards;
+  assert.equal(spec.meta.source, "cli-hazard-plan");
+  assert.equal(spec.configurator.inputs.levelGen.budgetScaffold, true);
+  assert.equal(Array.isArray(hazards), true);
+  assert.equal(hazards.length, 1);
+  assert.equal(hazards[0].affinity, "fire");
+  assert.equal(hazards[0].expression, "emit");
+  assert.equal(hazards[0].mana.regen, 1);
+  assert.deepEqual(spec.intent.hints.poolWeights, [{ id: "hazards", weight: 1 }]);
+
+  const artifact = readJson(join(outDir, "hazard-1.json"));
+  assert.equal(artifact.schema, "agent-kernel/HazardArtifact");
+  assert.equal(artifact.schemaVersion, 2);
+  assert.equal(artifact.meta.producedBy, "cli-hazard-plan");
+});
+
+test("cli hazard-plan writes hazard-only budget receipt categories", () => {
+  const outDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-hazard-plan-budget-"));
+  runCliOk([
+    "hazard-plan",
+    "--hazard",
+    "affinity=fire;expression=emit;proximityRadius=2;mana=regen:4:4:1",
+    "--budget-tokens",
+    "200",
+    "--run-id",
+    "run_hazard_plan_budget",
+    "--created-at",
+    "2026-06-29T00:00:00.000Z",
+    "--out-dir",
+    outDir,
+  ]);
+
+  const receipt = readJson(join(outDir, "budget-receipt.json"));
+  assert.equal(receipt.status, "approved");
+  assert.equal(receipt.lineItems.every((item) => item.category === "hazards"), true);
+  const hazardPool = receipt.poolStatuses.find((pool) => pool.id === "hazards");
+  const roomsPool = receipt.poolStatuses.find((pool) => pool.id === "rooms");
+  assert.equal(hazardPool.capTokens, 200);
+  assert.equal(hazardPool.spentTokens, receipt.totalCost);
+  assert.equal(roomsPool.spentTokens, 0);
+});
+
+test("cli hazard-plan rejects insufficient hard budget", () => {
+  const outDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-hazard-plan-budget-fail-"));
+  const result = runCli([
+    "hazard-plan",
+    "--hazard",
+    "affinity=fire;expression=emit;proximityRadius=2;mana=regen:4:4:1",
+    "--budget-tokens",
+    "10",
+    "--run-id",
+    "run_hazard_plan_budget_fail",
+    "--created-at",
+    "2026-06-29T00:00:00.000Z",
+    "--out-dir",
+    outDir,
+  ]);
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}\n${result.stderr}`, /Budget receipt denied|budget/i);
+  assert.equal(existsSync(join(outDir, "budget-receipt.json")), false);
+});
+
+test("cli resource-plan authors V3 resources directly from resource flags", () => {
+  const outDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-resource-plan-basic-"));
+  const result = runCliOk([
+    "resource-plan",
+    "--resource",
+    "permanenceMode=permanent;vital=mana;delta=6",
+    "--run-id",
+    "run_resource_plan_basic",
+    "--created-at",
+    "2026-06-29T00:00:00.000Z",
+    "--out-dir",
+    outDir,
+  ]);
+  const summary = readStdoutJson(result);
+
+  assert.equal(summary.command, "resource-plan");
+  assert.equal(existsSync(join(outDir, "spec.json")), true);
+  assert.equal(existsSync(join(outDir, "resource-1.json")), true);
+
+  const spec = readJson(join(outDir, "spec.json"));
+  const resources = spec.configurator?.inputs?.resources;
+  assert.equal(spec.meta.source, "cli-resource-plan");
+  assert.equal(spec.configurator.inputs.levelGen.budgetScaffold, true);
+  assert.equal(Array.isArray(resources), true);
+  assert.equal(resources.length, 1);
+  assert.equal(resources[0].permanenceMode, "permanent");
+  assert.deepEqual(resources[0].vitals, [{ key: "mana", delta: 6 }]);
+  assert.deepEqual(spec.intent.hints.poolWeights, [{ id: "resources", weight: 1 }]);
+
+  const artifact = readJson(join(outDir, "resource-1.json"));
+  assert.equal(artifact.schema, "agent-kernel/ResourceArtifact");
+  assert.equal(artifact.schemaVersion, 3);
+  assert.equal(artifact.meta.producedBy, "cli-resource-plan");
+});
+
+test("cli resource-plan writes resource-only receipt categories and rejects low budgets", () => {
+  const outDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-resource-plan-budget-"));
+  runCliOk([
+    "resource-plan",
+    "--resource",
+    "permanenceMode=permanent;vital=mana;delta=6",
+    "--budget-tokens",
+    "200",
+    "--run-id",
+    "run_resource_plan_budget",
+    "--created-at",
+    "2026-06-29T00:00:00.000Z",
+    "--out-dir",
+    outDir,
+  ]);
+
+  const receipt = readJson(join(outDir, "budget-receipt.json"));
+  assert.equal(receipt.status, "approved");
+  assert.equal(receipt.lineItems.every((item) => item.category === "resources"), true);
+  const resourcePool = receipt.poolStatuses.find((pool) => pool.id === "resources");
+  assert.equal(resourcePool.capTokens, 200);
+  assert.equal(resourcePool.spentTokens, receipt.totalCost);
+
+  const failDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-resource-plan-budget-fail-"));
+  const result = runCli([
+    "resource-plan",
+    "--resource",
+    "permanenceMode=permanent;vital=mana;delta=6",
+    "--budget-tokens",
+    "10",
+    "--run-id",
+    "run_resource_plan_budget_fail",
+    "--created-at",
+    "2026-06-29T00:00:00.000Z",
+    "--out-dir",
+    failDir,
+  ]);
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}\n${result.stderr}`, /Budget receipt denied|budget/i);
+  assert.equal(existsSync(join(failDir, "budget-receipt.json")), false);
+});

--- a/tests/adapters-cli/ak-llm-plan.test.js
+++ b/tests/adapters-cli/ak-llm-plan.test.js
@@ -388,7 +388,7 @@ test("cli llm-plan supports text mode without an explicit fixture", () => {
       "--catalog",
       "tests/fixtures/pool/catalog-basic.json",
       "--budget-tokens",
-      "200",
+      "300",
       "--run-id",
       "run_llm_plan_text",
       "--created-at",
@@ -401,7 +401,7 @@ test("cli llm-plan supports text mode without an explicit fixture", () => {
 
   const spec = JSON.parse(readFileSync(join(outDir, "spec.json"), "utf8"));
   assert.equal(spec.intent.goal, "a dungeon with two fire delvers");
-  assert.equal(spec.intent.hints.budgetTokens, 200);
+  assert.equal(spec.intent.hints.budgetTokens, 300);
 
   const manifest = JSON.parse(readFileSync(join(outDir, "manifest.json"), "utf8"));
   const captureEntry = manifest.artifacts.find(

--- a/tests/adapters-cli/ak-room-plan.test.js
+++ b/tests/adapters-cli/ak-room-plan.test.js
@@ -193,10 +193,12 @@ test("cli room-plan writes budget receipt with room layout spend only — no aff
   assert.equal(receipt.schema, "agent-kernel/BudgetReceiptArtifact");
   assert.equal(receipt.status, "approved");
 
-  const layoutLine = receipt.lineItems.find((item) => item.id === "layout_grid_7x7" && item.kind === "layout");
+  const layoutLine = receipt.lineItems.find((item) => item.id === "tile_floor" && item.kind === "tile");
   assert.ok(layoutLine);
   assert.equal(layoutLine.status, "approved");
-  assert.equal(layoutLine.totalCost, 11);
+  assert.equal(layoutLine.category, "floor_tiles");
+  assert.equal(layoutLine.quantity, 9);
+  assert.equal(layoutLine.totalCost, 9);
 
   const affinityLines = receipt.lineItems.filter((item) => item.kind === "affinity");
   assert.equal(affinityLines.length, 0, "room receipt must contain no affinity line items");

--- a/tests/adapters-cli/ak-warden-plan.test.js
+++ b/tests/adapters-cli/ak-warden-plan.test.js
@@ -183,11 +183,34 @@ test("cli warden-plan supports advanced affinities, vitals, and receipt accounti
 
   const receipt = readJson(join(outDir, "budget-receipt.json"));
   const byId = new Map(receipt.lineItems.map((item) => [item.id, item]));
+  assert.equal(receipt.status, "approved");
+  assert.equal(receipt.lineItems.some((item) => item.category === "wardens"), true);
+  assert.equal(receipt.lineItems.some((item) => item.category === "delvers"), false);
   assert.equal(byId.get("affinity_stack")?.quantity, 5);
   assert.equal(byId.get("affinity_expression_localized")?.quantity, 4);
   assert.equal(byId.get("affinity_expression_internalize")?.quantity, 1);
   assert.equal(byId.get("vital_health_point")?.quantity, 15);
   assert.equal(byId.get("vital_stamina_regen_tick")?.quantity, 1);
+});
+
+test("cli warden-plan rejects insufficient hard budget", () => {
+  const outDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-warden-plan-budget-fail-"));
+  const result = runCli([
+    "warden-plan",
+    "--warden",
+    "count=1;affinity=dark;motivation=defending;affinities=dark:emit:4;vitals=health:15:15:0,mana:3:3:1,stamina:4:4:1,durability:8:8:0",
+    "--budget-tokens",
+    "10",
+    "--run-id",
+    "run_warden_plan_budget_fail",
+    "--created-at",
+    "2026-03-07T00:00:00.000Z",
+    "--out-dir",
+    outDir,
+  ]);
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}\n${result.stderr}`, /budget|minimum_cost_exceeds_budget|Budget receipt denied/i);
+  assert.equal(existsSync(join(outDir, "budget-receipt.json")), false);
 });
 
 test("cli warden-plan rejects invalid motivation", () => {

--- a/tests/allocator/budget-ledger.test.js
+++ b/tests/allocator/budget-ledger.test.js
@@ -21,3 +21,42 @@ const { updateBudgetLedger } = await import("../../packages/runtime/src/personas
 const result = updateBudgetLedger({ receipt, spendEvents, meta: ledger.meta });
 assert.deepEqual(result.ledger, ledger);
 });
+
+test("allocator ledger reuses receipt totalCost for quadratic line items", async () => {
+const { updateBudgetLedger } = await import("../../packages/runtime/src/personas/allocator/budget-ledger.js");
+
+const result = updateBudgetLedger({
+  receipt: {
+    schema: "agent-kernel/BudgetReceiptArtifact",
+    schemaVersion: 1,
+    meta: {
+      id: "receipt_quadratic",
+      runId: "run_quadratic",
+      createdAt: "2026-04-22T00:00:00.000Z",
+      producedBy: "allocator",
+    },
+    budgetRef: { id: "budget_quadratic", schema: "agent-kernel/BudgetArtifact", schemaVersion: 1 },
+    remaining: 100,
+    lineItems: [
+      {
+        id: "affinity_stack",
+        kind: "affinity",
+        quantity: 4,
+        unitCost: 1,
+        totalCost: 16,
+        status: "approved",
+      },
+    ],
+  },
+  spendEvents: [{ id: "affinity_stack", kind: "affinity", quantity: 4 }],
+  meta: {
+    id: "ledger_quadratic",
+    runId: "run_quadratic",
+    createdAt: "2026-04-22T00:00:00.000Z",
+    producedBy: "allocator",
+  },
+});
+
+assert.equal(result.ledger.spendEvents[0].totalCost, 16);
+assert.equal(result.ledger.remaining, 84);
+});

--- a/tests/contracts/budget-receipt-artifact.test.js
+++ b/tests/contracts/budget-receipt-artifact.test.js
@@ -3,7 +3,16 @@ const { readFileSync } = require("node:fs");
 const { resolve } = require("node:path");
 
 const ROOT = resolve(__dirname, "../..");
-const SOURCE_BACKED_SCENARIO_CATEGORIES = ["rooms", "delvers", "wardens", "resources"];
+const SOURCE_BACKED_SCENARIO_CATEGORIES = [
+  "rooms",
+  "floor_tiles",
+  "traps",
+  "hazards",
+  "resources",
+  "delvers",
+  "wardens",
+  "shared_system",
+];
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));

--- a/tests/financial-model/budget-allocation.test.js
+++ b/tests/financial-model/budget-allocation.test.js
@@ -4,40 +4,59 @@ const assert = require("node:assert/strict");
 test("default pool weights: 44% rooms, async 20% delver, 16% wardens, 12% hazards, 8% resources (design §2.2)", async () => {
   const { computeBudgetPools, REFERENCE_BUDGET_TOKENS } = await import("../../packages/runtime/src/personas/director/budget-allocation.js");
 
-const result = computeBudgetPools({ budgetTokens: 2500 });
-assert.ok(result.ok);
+  const result = computeBudgetPools({ budgetTokens: 2500 });
+  assert.ok(result.ok);
 
-const poolMap = new Map(result.pools.map(p => [p.id, p.tokens]));
-assert.equal(poolMap.get("rooms"), 1100);
-assert.equal(poolMap.get("delver"), 500);
-assert.equal(poolMap.get("wardens"), 400);
-assert.equal(poolMap.get("hazards"), 300);
-assert.equal(poolMap.get("resources"), 200);
+  const poolMap = new Map(result.pools.map(p => [p.id, p.tokens]));
+  assert.equal(poolMap.get("rooms"), 1100);
+  assert.equal(poolMap.get("delver"), 500);
+  assert.equal(poolMap.get("wardens"), 400);
+  assert.equal(poolMap.get("hazards"), 300);
+  assert.equal(poolMap.get("resources"), 200);
 });
 
 test("reference budget constant is 2500 (design §2.1)", async () => {
   const { REFERENCE_BUDGET_TOKENS } = await import("../../packages/runtime/src/personas/director/budget-allocation.js");
 
-assert.equal(REFERENCE_BUDGET_TOKENS, 2500);
+  assert.equal(REFERENCE_BUDGET_TOKENS, 2500);
 });
 
 test("custom pool weights override defaults", async () => {
   const { computeBudgetPools } = await import("../../packages/runtime/src/personas/director/budget-allocation.js");
 
-const result = computeBudgetPools({
-  budgetTokens: 800,
-  poolWeights: [
-    { id: "rooms", weight: 0.60 },
-    { id: "delver", weight: 0.15 },
-    { id: "wardens", weight: 0.25 }
-  ]
-});
-assert.ok(result.ok);
+  const result = computeBudgetPools({
+    budgetTokens: 800,
+    poolWeights: [
+      { id: "rooms", weight: 0.60 },
+      { id: "delver", weight: 0.15 },
+      { id: "wardens", weight: 0.25 }
+    ]
+  });
+  assert.ok(result.ok);
 
-const poolMap = new Map(result.pools.map(p => [p.id, p.tokens]));
-assert.equal(poolMap.get("rooms"), 480);
-assert.equal(poolMap.get("delver"), 120);
-assert.equal(poolMap.get("wardens"), 200);
-assert.equal(poolMap.get("hazards"), 0);
-assert.equal(poolMap.get("resources"), 0);
+  const poolMap = new Map(result.pools.map(p => [p.id, p.tokens]));
+  assert.equal(poolMap.get("rooms"), 480);
+  assert.equal(poolMap.get("delver"), 120);
+  assert.equal(poolMap.get("wardens"), 200);
+  assert.equal(poolMap.get("hazards"), 0);
+  assert.equal(poolMap.get("resources"), 0);
+});
+
+test("explicit resource-only pool weights are honored for first-order resource authoring", async () => {
+  const { computeBudgetPools } = await import("../../packages/runtime/src/personas/director/budget-allocation.js");
+
+  const result = computeBudgetPools({
+    budgetTokens: 200,
+    poolWeights: [
+      { id: "resources", weight: 1 },
+    ],
+  });
+  assert.ok(result.ok);
+
+  const poolMap = new Map(result.pools.map(p => [p.id, p.tokens]));
+  assert.equal(poolMap.get("resources"), 200);
+  assert.equal(poolMap.get("rooms"), 0);
+  assert.equal(poolMap.get("hazards"), 0);
+  assert.equal(poolMap.get("wardens"), 0);
+  assert.equal(poolMap.get("delver"), 0);
 });

--- a/tests/financial-model/incentive-model.test.js
+++ b/tests/financial-model/incentive-model.test.js
@@ -31,11 +31,13 @@ test("reference budget is 2500 (design §2.1)", async () => {
 assert.equal(REFERENCE_BUDGET_TOKENS, 2500);
 });
 
-test("reference targets: rooms=1100, async delvers=500, wardens=400 (design §2.2)", async () => {
+test("reference targets include five budget pools for the 2500-token budget (design §2.2)", async () => {
   const { REFERENCE_TARGETS } = await import("../../packages/runtime/src/personas/allocator/incentive-model.js");
 assert.equal(REFERENCE_TARGETS.rooms, 1100);
 assert.equal(REFERENCE_TARGETS.delvers, 500);
 assert.equal(REFERENCE_TARGETS.wardens, 400);
+assert.equal(REFERENCE_TARGETS.hazards, 300);
+assert.equal(REFERENCE_TARGETS.resources, 200);
 });
 
 test("scenario spend report includes all required fields (design §14)", async () => {
@@ -67,4 +69,18 @@ assert.equal(report.incentive.targetRatio, 0.8);
 assert.equal(typeof report.incentive.multiplier, "number");
 assert.ok(report.incentive.multiplier > 0);
 assert.ok(report.incentive.multiplier <= 1);
+});
+
+test("scenario spend report scales default allocation targets for a 10000-token budget", async () => {
+  const { buildScenarioSpendReport } = await import("../../packages/runtime/src/personas/allocator/incentive-model.js");
+
+const report = buildScenarioSpendReport({ budgetTokens: 10000 });
+
+assert.equal(report.categories.rooms.target, 4400);
+assert.equal(report.categories.floor_tiles.target, 4400);
+assert.equal(report.categories.traps.target, 4400);
+assert.equal(report.categories.delvers.target, 2000);
+assert.equal(report.categories.wardens.target, 1600);
+assert.equal(report.categories.hazards.target, 1200);
+assert.equal(report.categories.resources.target, 800);
 });

--- a/tests/fixtures/allocator/spend-proposal-v1-basic.json
+++ b/tests/fixtures/allocator/spend-proposal-v1-basic.json
@@ -8,8 +8,47 @@
     "producedBy": "configurator"
   },
   "items": [
-    { "id": "actor_spawn", "kind": "actor", "quantity": 2 },
-    { "id": "layout_grid_9x9", "kind": "layout", "quantity": 1 },
-    { "id": "trap_basic", "kind": "trap", "quantity": 1 }
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_one",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_two",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "tile_floor",
+      "kind": "tile",
+      "quantity": 81,
+      "category": "floor_tiles",
+      "subjectRef": {
+        "id": "layout",
+        "schema": "agent-kernel/LayoutArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_1",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    }
   ]
 }

--- a/tests/fixtures/allocator/spend-proposal-v1-over-budget.json
+++ b/tests/fixtures/allocator/spend-proposal-v1-over-budget.json
@@ -8,8 +8,846 @@
     "producedBy": "configurator"
   },
   "items": [
-    { "id": "actor_spawn", "kind": "actor", "quantity": 50 },
-    { "id": "layout_grid_9x9", "kind": "layout", "quantity": 1 },
-    { "id": "trap_basic", "kind": "trap", "quantity": 30 }
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_0",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_1",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_10",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_11",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_12",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_13",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_14",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_15",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_16",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_17",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_18",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_19",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_2",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_20",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_21",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_22",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_23",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_24",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_25",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_26",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_27",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_28",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_29",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_3",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_30",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_31",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_32",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_33",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_34",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_35",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_36",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_37",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_38",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_39",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_4",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_40",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_41",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_42",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_43",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_44",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_45",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_46",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_47",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_48",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_49",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_5",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_6",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_7",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_8",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_9",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "tile_floor",
+      "kind": "tile",
+      "quantity": 81,
+      "category": "floor_tiles",
+      "subjectRef": {
+        "id": "layout",
+        "schema": "agent-kernel/LayoutArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_1",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_10",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_11",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_12",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_13",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_14",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_15",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_16",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_17",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_18",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_19",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_2",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_20",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_21",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_22",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_23",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_24",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_25",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_26",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_27",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_28",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_29",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_3",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_30",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_4",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_5",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_6",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_7",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_8",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_9",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    }
   ]
 }

--- a/tests/fixtures/allocator/spend-proposal-v1-vam.json
+++ b/tests/fixtures/allocator/spend-proposal-v1-vam.json
@@ -8,16 +8,115 @@
     "producedBy": "configurator"
   },
   "items": [
-    { "id": "actor_spawn", "kind": "actor", "quantity": 1 },
-    { "id": "affinity_expression_externalize", "kind": "affinity", "quantity": 2 },
-    { "id": "affinity_expression_internalize", "kind": "affinity", "quantity": 1 },
-    { "id": "affinity_stack", "kind": "affinity", "quantity": 3 },
-    { "id": "motivation_reflexive", "kind": "motivation", "quantity": 1 },
-    { "id": "vital_durability_point", "kind": "vital", "quantity": 1 },
-    { "id": "vital_health_point", "kind": "vital", "quantity": 10 },
-    { "id": "vital_health_regen_tick", "kind": "vital", "quantity": 2 },
-    { "id": "vital_mana_point", "kind": "vital", "quantity": 3 },
-    { "id": "vital_stamina_point", "kind": "vital", "quantity": 4 },
-    { "id": "vital_stamina_regen_tick", "kind": "vital", "quantity": 1 }
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "affinity_expression_externalize",
+      "kind": "affinity",
+      "quantity": 2,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "affinity_expression_internalize",
+      "kind": "affinity",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "affinity_stack",
+      "kind": "affinity",
+      "quantity": 3,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "motivation_reflexive",
+      "kind": "motivation",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "vital_durability_point",
+      "kind": "vital",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "vital_health_point",
+      "kind": "vital",
+      "quantity": 10,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "vital_health_regen_tick",
+      "kind": "vital",
+      "quantity": 2,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "vital_mana_point",
+      "kind": "vital",
+      "quantity": 3,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "vital_stamina_point",
+      "kind": "vital",
+      "quantity": 4,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "vital_stamina_regen_tick",
+      "kind": "vital",
+      "quantity": 1,
+      "subjectRef": {
+        "id": "actor_vam",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    }
   ]
 }

--- a/tests/fixtures/allocator/spend-receipt-v1-basic.json
+++ b/tests/fixtures/allocator/spend-receipt-v1-basic.json
@@ -29,18 +29,42 @@
     {
       "id": "actor_spawn",
       "kind": "actor",
-      "quantity": 2,
-      "unitCost": 0,
-      "totalCost": 0,
-      "status": "denied"
-    },
-    {
-      "id": "layout_grid_9x9",
-      "kind": "layout",
       "quantity": 1,
       "unitCost": 0,
       "totalCost": 0,
-      "status": "denied"
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_one",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_two",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "tile_floor",
+      "kind": "tile",
+      "quantity": 81,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "floor_tiles",
+      "subjectRef": {
+        "id": "layout",
+        "schema": "agent-kernel/LayoutArtifact",
+        "schemaVersion": 1
+      }
     },
     {
       "id": "trap_basic",
@@ -48,7 +72,13 @@
       "quantity": 1,
       "unitCost": 0,
       "totalCost": 0,
-      "status": "denied"
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_1",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
     }
   ]
 }

--- a/tests/fixtures/allocator/spend-receipt-v1-over-budget.json
+++ b/tests/fixtures/allocator/spend-receipt-v1-over-budget.json
@@ -29,26 +29,1086 @@
     {
       "id": "actor_spawn",
       "kind": "actor",
-      "quantity": 50,
-      "unitCost": 0,
-      "totalCost": 0,
-      "status": "denied"
-    },
-    {
-      "id": "layout_grid_9x9",
-      "kind": "layout",
       "quantity": 1,
       "unitCost": 0,
       "totalCost": 0,
-      "status": "denied"
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_0",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_1",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_10",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_11",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_12",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_13",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_14",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_15",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_16",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_17",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_18",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_19",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_2",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_20",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_21",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_22",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_23",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_24",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_25",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_26",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_27",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_28",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_29",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_3",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_30",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_31",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_32",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_33",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_34",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_35",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_36",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_37",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_38",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_39",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_4",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_40",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_41",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_42",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_43",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_44",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_45",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_46",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_47",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_48",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_49",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_5",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_6",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_7",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_8",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "actor_spawn",
+      "kind": "actor",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "subjectRef": {
+        "id": "actor_9",
+        "schema": "agent-kernel/ActorArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "tile_floor",
+      "kind": "tile",
+      "quantity": 81,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "floor_tiles",
+      "subjectRef": {
+        "id": "layout",
+        "schema": "agent-kernel/LayoutArtifact",
+        "schemaVersion": 1
+      }
     },
     {
       "id": "trap_basic",
       "kind": "trap",
-      "quantity": 30,
+      "quantity": 1,
       "unitCost": 0,
       "totalCost": 0,
-      "status": "denied"
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_1",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_10",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_11",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_12",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_13",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_14",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_15",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_16",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_17",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_18",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_19",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_2",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_20",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_21",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_22",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_23",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_24",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_25",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_26",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_27",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_28",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_29",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_3",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_30",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_4",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_5",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_6",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_7",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_8",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
+    },
+    {
+      "id": "trap_basic",
+      "kind": "trap",
+      "quantity": 1,
+      "unitCost": 0,
+      "totalCost": 0,
+      "status": "denied",
+      "category": "traps",
+      "subjectRef": {
+        "id": "trap_9",
+        "schema": "agent-kernel/TrapArtifact",
+        "schemaVersion": 1
+      }
     }
   ]
 }

--- a/tests/fixtures/artifacts/build-spec-v1-budget-tokens-only.json
+++ b/tests/fixtures/artifacts/build-spec-v1-budget-tokens-only.json
@@ -47,6 +47,7 @@
         {
           "id": "actor_test",
           "kind": "ambulatory",
+          "archetype": "delver",
           "position": { "x": 2, "y": 2 },
           "vitals": {
             "health": { "current": 10, "max": 10, "regen": 0 },

--- a/tests/fixtures/e2e/e2e-scenario-v1-tier3-rooms.json
+++ b/tests/fixtures/e2e/e2e-scenario-v1-tier3-rooms.json
@@ -5,7 +5,7 @@
   "tier": 3,
   "levelSize": { "width": 20, "height": 20 },
   "actorCount": 10,
-  "budgetTokens": 800,
+  "budgetTokens": 4500,
   "catalogPath": "tests/fixtures/pool/catalog-basic.json",
   "summaryPath": "tests/fixtures/e2e/summary-v1-tier3-rooms.json",
   "expectedSelectionsPath": "tests/fixtures/e2e/expected-selections-v1-tier3-rooms.json",

--- a/tests/fixtures/e2e/summary-v1-tier3-rooms.json
+++ b/tests/fixtures/e2e/summary-v1-tier3-rooms.json
@@ -1,6 +1,6 @@
 {
   "dungeonAffinity": "fire",
-  "budgetTokens": 800,
+  "budgetTokens": 4500,
   "rooms": [
     {
       "motivation": "stationary",

--- a/tests/personas/configurator-spend-proposal.test.js
+++ b/tests/personas/configurator-spend-proposal.test.js
@@ -127,3 +127,71 @@ test("configurator prices room cards by layout only — affinities on room card 
   assert.ok(large.cost >= medium.cost);
   assert.equal(large.detail.affinitySpend, undefined, "rooms must not include affinity spend in cost detail");
 });
+
+test("configurator emits per-subject delver and warden attribution", async () => {
+  const { buildSpendProposal } = await import(
+    "../../packages/runtime/src/personas/configurator/spend-proposal.js"
+  );
+
+  const proposal = buildSpendProposal({
+    meta: {
+      id: "proposal_actor_attribution",
+      runId: "run_fixture",
+      createdAt: "2025-01-01T00:00:00.000Z",
+      producedBy: "configurator",
+    },
+    actors: [
+      { id: "delver_one", actorType: "delver" },
+      { id: "warden_one", archetype: "warden", motivations: ["defending"] },
+    ],
+  });
+
+  const bySubject = new Map(proposal.items.map((item) => [item.subjectRef?.id, item]));
+  assert.equal(bySubject.get("delver_one").category, "delvers");
+  assert.equal(bySubject.get("warden_one").category, "wardens");
+});
+
+test("configurator accounts for hazards and UI-authored resources", async () => {
+  const { buildSpendProposal } = await import(
+    "../../packages/runtime/src/personas/configurator/spend-proposal.js"
+  );
+
+  const proposal = buildSpendProposal({
+    meta: {
+      id: "proposal_hazard_resource",
+      runId: "run_fixture",
+      createdAt: "2025-01-01T00:00:00.000Z",
+      producedBy: "configurator",
+    },
+    layout: {
+      hazards: [
+        {
+          id: "hazard_fire",
+          affinity: "fire",
+          expression: "emit",
+          stacks: 2,
+          mana: { current: 3, max: 3, regen: 1 },
+        },
+      ],
+    },
+    resources: [
+      {
+        id: "ui_resource",
+        permanenceMode: "permanent",
+        resourceVitals: { health: { delta: 4 } },
+      },
+      {
+        id: "budget_only_resource",
+        budgetCeiling: 7,
+      },
+    ],
+  });
+
+  const byId = new Map(proposal.items.map((item) => [`${item.subjectRef?.id}:${item.id}`, item]));
+  assert.equal(byId.get("hazard_fire:hazard_base").category, "hazards");
+  assert.equal(byId.get("hazard_fire:vital_mana_point").quantity, 3);
+  assert.equal(byId.get("hazard_fire:affinity_stack").quantity, 2);
+  assert.equal(byId.get("ui_resource:resource_permanent").category, "resources");
+  assert.equal(byId.get("ui_resource:resource_permanent").quantity, 4);
+  assert.equal(byId.get("budget_only_resource:resource_base").quantity, 7);
+});

--- a/tests/runtime/allocator/validate-spend-proposal.test.js
+++ b/tests/runtime/allocator/validate-spend-proposal.test.js
@@ -19,6 +19,17 @@ function makeBudget(tokens) {
   };
 }
 
+function makeAllocation(pools) {
+  return {
+    schema: "agent-kernel/BudgetAllocationArtifact",
+    schemaVersion: 1,
+    meta: { id: "allocation-1", runId: "run-1", createdAt: "2026-04-22T00:00:00Z", producedBy: "test" },
+    budgetRef: { id: "budget-1", schema: "agent-kernel/BudgetArtifact", schemaVersion: 1 },
+    priceListRef: { id: "price-list-1", schema: "agent-kernel/PriceList", schemaVersion: 1 },
+    pools,
+  };
+}
+
 test("buildDefaultPriceList returns a valid PriceList artifact", () => {
   const pl = buildDefaultPriceList();
   assert.equal(pl.schema, "agent-kernel/PriceList");
@@ -147,6 +158,94 @@ test("validateSpendProposal denies when total cost exceeds budget", () => {
   });
   assert.equal(result.receipt.status, "denied");
   assert.ok(result.errors?.length > 0);
+});
+
+test("validateSpendProposal applies quadratic price formulas", () => {
+  const proposal = {
+    schema: "agent-kernel/SpendProposal",
+    schemaVersion: 1,
+    meta: { ...baseMeta, id: "prop-quadratic" },
+    items: [
+      { id: "affinity_stack", kind: "affinity", quantity: 4 },
+    ],
+  };
+  const result = validateSpendProposal({
+    budget: makeBudget(500),
+    priceList: buildDefaultPriceList(),
+    proposal,
+    meta: { ...baseMeta, id: "receipt-quadratic" },
+  });
+  assert.equal(result.receipt.status, "approved");
+  assert.equal(result.receipt.totalCost, 16);
+  assert.equal(result.receipt.lineItems[0].totalCost, 16);
+});
+
+test("validateSpendProposal keeps legacy partial status for mixed known and unknown spend without allocation", () => {
+  const proposal = {
+    schema: "agent-kernel/SpendProposal",
+    schemaVersion: 1,
+    meta: { ...baseMeta, id: "prop-partial" },
+    items: [
+      { id: "vital_health_point", kind: "vital", quantity: 5 },
+      { id: "mystery", kind: "unknown", quantity: 1 },
+    ],
+  };
+  const result = validateSpendProposal({
+    budget: makeBudget(500),
+    priceList: buildDefaultPriceList(),
+    proposal,
+    meta: { ...baseMeta, id: "receipt-partial" },
+  });
+  assert.equal(result.receipt.status, "partial");
+  assert.equal(result.receipt.totalCost, 5);
+  assert.equal(result.receipt.lineItems[0].status, "approved");
+  assert.equal(result.receipt.lineItems[1].status, "denied");
+});
+
+test("validateSpendProposal denies category pool overspend even when total budget remains", () => {
+  const proposal = {
+    schema: "agent-kernel/SpendProposal",
+    schemaVersion: 1,
+    meta: { ...baseMeta, id: "prop-pool-over" },
+    items: [
+      { id: "tile_floor", kind: "tile", quantity: 6, category: "floor_tiles" },
+    ],
+  };
+  const result = validateSpendProposal({
+    budget: makeBudget(1000),
+    priceList: buildDefaultPriceList(),
+    allocation: makeAllocation([
+      { id: "rooms", tokens: 5 },
+      { id: "delver", tokens: 995 },
+    ]),
+    proposal,
+    meta: { ...baseMeta, id: "receipt-pool-over" },
+  });
+  assert.equal(result.receipt.status, "denied");
+  assert.equal(result.receipt.totalCost, 6);
+  assert.equal(result.receipt.poolStatuses.find((pool) => pool.id === "rooms").status, "denied");
+  assert.equal(result.receipt.lineItems[0].status, "denied");
+});
+
+test("validateSpendProposal denies unattributed spend when allocation is enforced", () => {
+  const proposal = {
+    schema: "agent-kernel/SpendProposal",
+    schemaVersion: 1,
+    meta: { ...baseMeta, id: "prop-unattributed" },
+    items: [
+      { id: "actor_spawn", kind: "actor", quantity: 1 },
+    ],
+  };
+  const result = validateSpendProposal({
+    budget: makeBudget(1000),
+    priceList: buildDefaultPriceList(),
+    allocation: makeAllocation([{ id: "delver", tokens: 1000 }]),
+    proposal,
+    meta: { ...baseMeta, id: "receipt-unattributed" },
+  });
+  assert.equal(result.receipt.status, "denied");
+  assert.equal(result.receipt.lineItems[0].status, "denied");
+  assert.match(result.errors.join("\n"), /Unattributed spend item/);
 });
 
 // ## TODO: Test Permutations


### PR DESCRIPTION
## Summary
- make allocator pricing and receipt enforcement allocation-aware across budget pools
- add first-order `hazard-plan` and `resource-plan` CLI authoring commands
- report spend by canonical categories and enforce hard budget denial before final artifacts

## Validation
- `pnpm exec vitest run tests/adapters-cli/ak-hazard-resource-plan.test.js tests/integration/ak-create-hazard-resource.test.js tests/adapters-cli/ak-authoring-commands.test.js tests/financial-model/budget-allocation.test.js`
- `pnpm exec vitest run tests/personas/director-budget-allocation.test.js tests/financial-model/budget-allocation.test.js tests/adapters-cli/ak-hazard-resource-plan.test.js`
- `pnpm run test`

## Notes
- Content-gen benchmark was attempted with `node tools/remote-ollama-control/scripts/remote-ollama-mac.js run-content-gen --profiles dual --runs 3 --route external`, but the external SSH route timed out before benchmark execution.
- Unrelated local `graphify-out/` and `tools/benchmark/` changes are intentionally excluded from this PR.