### PR TITLE
Fix Phaser UI entry point and content-aware budget pool display

### DIFF
--- a/packages/ui-web/src/build-spec-ui.js
+++ b/packages/ui-web/src/build-spec-ui.js
@@ -45,6 +45,30 @@ export function collectBuildSpecCardSet(specInput) {
   );
 }
 
+const POOL_TYPES = ["room", "delver", "warden", "hazard", "resource"];
+
+function deriveContentAwareSplit(cards) {
+  const present = new Set();
+  (Array.isArray(cards) ? cards : []).forEach((card) => {
+    const type = typeof card?.type === "string" ? card.type : "";
+    if (type === "delver") present.add("delver");
+    else if (type === "warden") present.add("warden");
+    else if (type === "room") present.add("room");
+    else if (type === "hazard") present.add("hazard");
+    else if (type === "resource") present.add("resource");
+  });
+  if (present.size === 0) return null;
+  const share = Math.floor(100 / present.size);
+  const split = {};
+  POOL_TYPES.forEach((type) => { split[type] = present.has(type) ? share : 0; });
+  const assigned = present.size * share;
+  if (assigned < 100) {
+    const first = POOL_TYPES.find((t) => present.has(t));
+    if (first) split[first] += 100 - assigned;
+  }
+  return split;
+}
+
 export function extractDesignStateFromBuildSpec(specInput) {
   const { spec, changed, specText } = normalizeBuildSpecForEditor(specInput);
   const poolWeights = Array.isArray(spec?.intent?.hints?.poolWeights) ? spec.intent.hints.poolWeights : [];
@@ -54,7 +78,9 @@ export function extractDesignStateFromBuildSpec(specInput) {
       .map((entry) => [String(entry.id || ""), poolWeightToPercent(entry.weight)]),
   );
 
-  const budgetSplitPercent = [
+  const cards = collectBuildSpecCardSet(spec);
+
+  const explicitSplit = [
     weights.layout,
     weights.player,
     weights.wardens,
@@ -66,11 +92,13 @@ export function extractDesignStateFromBuildSpec(specInput) {
     }
     : null;
 
+  const budgetSplitPercent = explicitSplit || deriveContentAwareSplit(cards);
+
   return {
     spec,
     changed,
     specText,
-    cards: collectBuildSpecCardSet(spec),
+    cards,
     budgetTokens: Number.isFinite(spec?.intent?.hints?.budgetTokens)
       ? Math.floor(spec.intent.hints.budgetTokens)
       : null,

--- a/packages/ui-web/src/main.js
+++ b/packages/ui-web/src/main.js
@@ -196,16 +196,14 @@ globalThis.__ak_loadScenario = async (scenario, options = {}) => {
 };
 
 // D3+D4: also hydrate Design/Preview from the bundle spec and honor targetTab
-globalThis.__ak_loadGameplayBundle = (bundle, { targetTab = "gameplay" } = {}) => {
+globalThis.__ak_loadGameplayBundle = (bundle, { targetTab = "design" } = {}) => {
   if (!loadGameplayBundle(bundle)) return false;
-  // D3: hydrate Design tab from the incoming spec so it reflects the pushed build
-  if (bundle?.spec && designView?.loadBuildSpec) {
-    designView.loadBuildSpec(bundle.spec, { source: "sandbox-bridge" });
+  // Route spec to Phaser card builder (index_c.html path)
+  if (bundle?.spec) {
+    void phaserFrame?.ingest?.(bundle.spec);
   }
-  // D3: sync Preview/icon state with the new bundle
-  void syncBundleViews({ bundle, source: "sandbox-bridge" });
-  // D4: honor targetTab — default to "gameplay", but "design" is valid
-  openTab(targetTab === "design" ? "design" : "gameplay");
+  const ALLOWED_TABS = new Set(["design", "gameplay", "preview"]);
+  openTab(ALLOWED_TABS.has(targetTab) ? targetTab : "design");
   return true;
 };
 

--- a/scripts/serve-ui.mjs
+++ b/scripts/serve-ui.mjs
@@ -21,7 +21,7 @@ const root = resolve(__dirname, "..");
 const DEFAULT_PORT = Number(process.env.PORT) || 8001;
 
 const _entryArg = process.argv.indexOf("--entry");
-const ENTRY_FILE = _entryArg !== -1 ? process.argv[_entryArg + 1] : "index.html";
+const ENTRY_FILE = _entryArg !== -1 ? process.argv[_entryArg + 1] : "index_c.html";
 
 const MIME_TYPES = {
   ".html": "text/html; charset=utf-8",

--- a/tests/playwright/serve-ui-redirect-health.spec.mjs
+++ b/tests/playwright/serve-ui-redirect-health.spec.mjs
@@ -38,10 +38,10 @@ test("serve-ui falls back to the next port and keeps the root redirect", async (
       maxRedirects: 0,
     });
     expect(root.status()).toBe(302);
-    expect(root.headers().location).toBe("/packages/ui-web/index.html");
+    expect(root.headers().location).toBe("/packages/ui-web/index_c.html");
 
     await page.goto(`http://127.0.0.1:${port}/`);
-    await expect(page).toHaveURL(/\/packages\/ui-web\/index\.html$/);
+    await expect(page).toHaveURL(/\/packages\/ui-web\/index_c\.html$/);
   } finally {
     await closeServer(server);
     await closeServer(blocker);

--- a/tests/scripts/serve-ui.test.js
+++ b/tests/scripts/serve-ui.test.js
@@ -64,15 +64,15 @@ test("serve-ui falls back to the next port and keeps the root redirect", async (
 
     try {
       assert.equal(port, startPort + 1);
-      assert.equal(url, `http://localhost:${startPort + 1}/packages/ui-web/index.html`);
+      assert.equal(url, `http://localhost:${startPort + 1}/packages/ui-web/index_c.html`);
 
       const rootResponse = await fetch(`http://127.0.0.1:${port}/`, {
         redirect: "manual",
       });
       assert.equal(rootResponse.status, 302);
-      assert.equal(rootResponse.headers.get("location"), "/packages/ui-web/index.html");
+      assert.equal(rootResponse.headers.get("location"), "/packages/ui-web/index_c.html");
 
-      const uiResponse = await fetch(`http://127.0.0.1:${port}/packages/ui-web/index.html`);
+      const uiResponse = await fetch(`http://127.0.0.1:${port}/packages/ui-web/index_c.html`);
       assert.equal(uiResponse.status, 200);
       assert.match(uiResponse.headers.get("content-type") || "", /text\/html/);
 


### PR DESCRIPTION
## Summary
- **serve-ui default → index_c.html**: eliminates legacy DOM elements (inventory panel, budget bar, "Add cards" message) appearing alongside Phaser components when loading via MCP
- **`__ak_loadGameplayBundle` routes through `phaserFrame.ingest()`**: specs now populate the Phaser card builder instead of the legacy `designView`; default `targetTab` changed to `"design"` (load for review, user switches to gameplay)
- **Content-aware budget pool split**: when no explicit pool weights are in the spec, budget pools are allocated equally across card types actually present (e.g., delver+warden → 50/50) instead of using fixed weights (room 44%, delver 20%, warden 16%, hazard 12%, resource 8%) — aligns with PR #50's content-aware allocation in the runtime

## Test plan
- [x] All 1878 vitest tests pass (284 files)
- [x] Verified 5 constrained benchmark scenarios through `__ak_loadGameplayBundle` → Design → Gameplay on `index_c.html`
- [x] Confirmed no legacy DOM elements appear in any tab
- [x] Confirmed inventory pool allocations match authored content (no false overspend)
- [x] serve-ui redirect tests updated for `index_c.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)