### PR TITLE
Phaser affinity editor redesign (M11)

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-06-18)
+# Graph Report - .  (2026-06-30)
 
 ## Corpus Check
-- 453 files · ~1,549,166 words
+- 455 files · ~1,560,666 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2534 nodes · 3888 edges · 433 communities detected
+- 2561 nodes · 3932 edges · 434 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS · INFERRED: 8 edges (avg confidence: 0.86)
 - Token cost: 0 input · 0 output
 
@@ -443,6 +443,7 @@
 - [[_COMMUNITY_Community 430|Community 430]]
 - [[_COMMUNITY_Community 431|Community 431]]
 - [[_COMMUNITY_Community 432|Community 432]]
+- [[_COMMUNITY_Community 433|Community 433]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `addError()` - 33 edges
@@ -480,12 +481,12 @@ Cohesion: 0.06
 Nodes (85): applyPatternOverlay(), applyTrapBlocking(), buildBackbonePath(), buildBlockingTrapIndex(), buildKinds(), buildLegend(), buildRoomIndex(), buildRoomSurfaceSlots() (+77 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.06
-Nodes (51): adler32(), alphaBlend(), base64FromBytes(), blitSprite(), buildFloorAffinityMap(), buildSpriteForSemantic(), buildTileAffinityProjectionMap(), bytesFromBase64() (+43 more)
+Cohesion: 0.04
+Nodes (40): affinityExpressionAllowsEnvironmentMutation(), affinityExpressionAllowsTrapArming(), affinityExpressionIsPersistentField(), buildAffinityVitalMatrix(), getAffinityTargetVital(), getAffinityVitalEffect(), getAffinityVitalEffectBase(), getDefaultAffinityTargetType() (+32 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.05
-Nodes (28): affinityExpressionAllowsEnvironmentMutation(), affinityExpressionAllowsTrapArming(), affinityExpressionIsPersistentField(), buildAffinityVitalMatrix(), getAffinityTargetVital(), getAffinityVitalEffect(), getAffinityVitalEffectBase(), getDefaultAffinityTargetType() (+20 more)
+Cohesion: 0.06
+Nodes (51): adler32(), alphaBlend(), base64FromBytes(), blitSprite(), buildFloorAffinityMap(), buildSpriteForSemantic(), buildTileAffinityProjectionMap(), bytesFromBase64() (+43 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.09
@@ -516,24 +517,24 @@ Cohesion: 0.22
 Nodes (35): addError(), isNonEmptyString(), isObject(), validateActorGroupHints(), validateActorHints(), validateAgentCommandCompatibility(), validateAgentCommandCompilation(), validateAgentCommandObject() (+27 more)
 
 ### Community 10 - "Community 10"
+Cohesion: 0.11
+Nodes (29): applyActorTypeToSelections(), applyPhaseTimingToCaptures(), buildActorPhaseGoal(), buildCombinedSummary(), buildPhaseContext(), buildPhaseRepairPrompt(), chooseCatalogEntryByHint(), computeCheapestCost() (+21 more)
+
+### Community 11 - "Community 11"
 Cohesion: 0.08
 Nodes (35): Actor Persona, Actor Motivation System, Runtime Decision Envelope, Static vs Dynamic Actor Types, Adapter Fixtures Catalog, Allocator Persona, Budget Receipt Artifact, Price List Policy (+27 more)
 
-### Community 11 - "Community 11"
-Cohesion: 0.11
-Nodes (28): applyPhaseTimingToCaptures(), buildActorPhaseGoal(), buildCombinedSummary(), buildPhaseContext(), buildPhaseRepairPrompt(), chooseCatalogEntryByHint(), computeCheapestCost(), countInstances() (+20 more)
-
 ### Community 12 - "Community 12"
+Cohesion: 0.09
+Nodes (16): buildBuildArtifacts(), buildBuildManifestEntries(), buildCapturedInputPath(), buildRepairPrompt(), buildSpecMeta(), captureAdapterPayload(), collectBuildOutputArtifactRecords(), createCommandKernel() (+8 more)
+
+### Community 13 - "Community 13"
 Cohesion: 0.23
 Nodes (31): actorRecord(), blendPixel(), blitScaled(), buildActorMedallionComponentSprite(), clamp01(), clampByte(), composeActorMedallion(), createPixelBuffer() (+23 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.14
 Nodes (31): applyVitalMaxOverrides(), buildAffinityMapForDelverConfig(), buildCardSetFromSummary(), buildSelectionsFromSummary(), buildVitalsConfigForDelver(), cardEntryToDelverConfig(), cardEntryToDelverPick(), cardEntryToRoomPick() (+23 more)
-
-### Community 14 - "Community 14"
-Cohesion: 0.09
-Nodes (16): buildBuildArtifacts(), buildBuildManifestEntries(), buildCapturedInputPath(), buildRepairPrompt(), buildSpecMeta(), captureAdapterPayload(), collectBuildOutputArtifactRecords(), createCommandKernel() (+8 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.1
@@ -548,28 +549,28 @@ Cohesion: 0.12
 Nodes (17): actor_base(), algorithmic_affinity_glyph(), crop_reference_glyph(), draw_delver_circle(), draw_earth(), draw_polyline(), draw_stone_base(), draw_vital_bars() (+9 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.11
-Nodes (11): applyActorOverrides(), cloneVitalRecords(), collectRuntimeDecisionCaptureRecords(), collectRuntimeDecisionRecords(), compareRuntimeDecisionCaptureSummaries(), compareRuntimeDecisionSummaries(), getGridBounds(), resolveVitalDefaults() (+3 more)
+Cohesion: 0.15
+Nodes (23): accumulateItem(), asActorEntries(), buildCategory(), buildDesignSpendLedger(), buildSpendItems(), buildSpendProposal(), buildSubjectRef(), calculateActorConfigurationUnitCost() (+15 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.11
-Nodes (5): allowedEvents(), findTransition(), hasIntent(), hasIntentOrPlan(), hasPlan()
+Nodes (11): applyActorOverrides(), cloneVitalRecords(), collectRuntimeDecisionCaptureRecords(), collectRuntimeDecisionRecords(), compareRuntimeDecisionCaptureSummaries(), compareRuntimeDecisionSummaries(), getGridBounds(), resolveVitalDefaults() (+3 more)
 
 ### Community 20 - "Community 20"
+Cohesion: 0.11
+Nodes (5): allowedEvents(), findTransition(), hasIntent(), hasIntentOrPlan(), hasPlan()
+
+### Community 21 - "Community 21"
 Cohesion: 0.17
 Nodes (18): appendLlmPromptSuffix(), appendPromptSection(), asFiniteInt(), asList(), buildBuildSpecPromptTemplate(), buildLlmActorConfigPromptTemplate(), buildLlmCatalogRepairPromptTemplate(), buildLlmLevelPromptTemplate() (+10 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.23
 Nodes (21): addError(), applySpendPolicy(), findAffinityRule(), findExpressionRule(), findInteractionRule(), isNonEmptyString(), isNonNegativeNumber(), isPlainObject() (+13 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.24
 Nodes (21): addError(), buildPatternMap(), buildRuleGroups(), cloneJson(), findMotivationRule(), getMotivationDisplayGroups(), getMotivationExclusiveGroups(), getMotivationPatterns() (+13 more)
-
-### Community 23 - "Community 23"
-Cohesion: 0.18
-Nodes (18): accumulateItem(), asActorEntries(), buildCategory(), buildDesignSpendLedger(), buildSpendItems(), buildSpendProposal(), calculateActorConfigurationUnitCost(), calculateRoomCardUnitCost() (+10 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.18
@@ -588,63 +589,63 @@ Cohesion: 0.24
 Nodes (19): addSessionError(), applySummaryContentErrors(), buildCardModelFromLlmSummary(), buildRepairRequestOptions(), captureWithFallback(), extractJsonObject(), extractResponseText(), getNumPredict() (+11 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.16
-Nodes (12): getDefaultMotivationPattern(), getMotivationDefaultDesignCost(), getMotivationDefaultFlagMask(), getMotivationDefaultUnitCost(), getMotivationExclusiveGroup(), getMotivationFamily(), getMotivationPatternCodeAt(), getMotivationPatternCount() (+4 more)
-
-### Community 29 - "Community 29"
 Cohesion: 0.22
 Nodes (18): buildActionFromEffect(), buildEnvironmentEffects(), buildVitalEffect(), findAdjacent(), isBarrierTile(), isFloorTile(), normalizeAffinityEntry(), normalizeAffinityTargetType() (+10 more)
 
-### Community 30 - "Community 30"
+### Community 29 - "Community 29"
 Cohesion: 0.12
 Nodes (4): clearElement(), createFixtureAdapter(), normalizeFixtureResponses(), replaceChildren()
 
-### Community 31 - "Community 31"
+### Community 30 - "Community 30"
 Cohesion: 0.2
 Nodes (16): addAffinityStack(), addAffinityTargetStack(), applyPresetToVitals(), applyVitalModifier(), computeTrapVitals(), deriveAbilitiesFromEffects(), ensureVitalRecord(), ensureVitals() (+8 more)
 
-### Community 32 - "Community 32"
+### Community 31 - "Community 31"
 Cohesion: 0.26
 Nodes (17): buildCommandResult(), cloneJson(), collectDirectoryArtifacts(), createBrowserKernelHost(), dirnamePath(), ensureDirectoryHref(), ensureLeadingSlash(), executeBrowserCommand() (+9 more)
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.15
 Nodes (7): extractJsonObject(), extractResponseText(), isNotFound(), normalizeBaseUrl(), postJson(), requestLlmResponse(), unwrapCodeFence()
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.18
 Nodes (5): makeMeta(), makeTickFrame(), McpServerHarness, scaffoldRun(), writeJson()
 
-### Community 35 - "Community 35"
+### Community 34 - "Community 34"
 Cohesion: 0.2
 Nodes (4): makeTempDir(), McpServerHarness, runCliSync(), setupSandboxRun()
 
-### Community 36 - "Community 36"
+### Community 35 - "Community 35"
 Cohesion: 0.22
 Nodes (10): endpointFor(), expandHome(), hostForRoute(), loadConfig(), numberFrom(), parseEnvFile(), positiveIntegerFrom(), readJson() (+2 more)
 
-### Community 37 - "Community 37"
+### Community 36 - "Community 36"
 Cohesion: 0.21
 Nodes (2): McpServerHarness, setupSessionWithDelver()
 
-### Community 38 - "Community 38"
+### Community 37 - "Community 37"
 Cohesion: 0.26
 Nodes (14): crop_affinity(), draw_delver(), draw_draw(), draw_emit(), draw_pull(), draw_push(), draw_warden(), main() (+6 more)
 
-### Community 39 - "Community 39"
+### Community 38 - "Community 38"
 Cohesion: 0.18
 Nodes (6): findBundleAsset(), inferActorRole(), normalizeResourceAssets(), primaryAffinityKind(), resolveActorAssetId(), resolveSurfaceAsset()
 
-### Community 40 - "Community 40"
+### Community 39 - "Community 39"
 Cohesion: 0.28
 Nodes (12): buildActorsAndGroups(), buildBuildSpecFromSummary(), defaultMeta(), deriveLevelGen(), deriveLevelGenFromLayout(), deriveLevelSideForWalkableTiles(), deriveRoomCountFromRooms(), deriveRoomShapeFromDesign() (+4 more)
 
-### Community 41 - "Community 41"
+### Community 40 - "Community 40"
 Cohesion: 0.36
 Nodes (13): clampNumber(), clampOptionalInt(), isInteger(), normalizeLevelGenInput(), normalizePatternType(), normalizeTrapList(), pushError(), pushWarning() (+5 more)
 
-### Community 42 - "Community 42"
+### Community 41 - "Community 41"
 Cohesion: 0.21
+Nodes (1): McpServerHarness
+
+### Community 42 - "Community 42"
+Cohesion: 0.22
 Nodes (1): McpServerHarness
 
 ### Community 43 - "Community 43"
@@ -652,76 +653,76 @@ Cohesion: 0.22
 Nodes (1): McpServerHarness
 
 ### Community 44 - "Community 44"
-Cohesion: 0.22
-Nodes (1): McpServerHarness
-
-### Community 45 - "Community 45"
 Cohesion: 0.19
 Nodes (6): indexToLineColumn(), loadState(), parseJsonWithDetails(), safeLocalStorage(), setOutput(), wireOllamaPromptPanel()
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.16
 Nodes (4): formatMissingCardTypes(), summarizeActor(), summarizeVitals(), validatePreviewLaunchBundle()
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.27
 Nodes (11): addSortIndicators(), enableUI(), getNthColumn(), getTable(), getTableBody(), getTableHeader(), loadColumns(), loadData() (+3 more)
 
-### Community 48 - "Community 48"
+### Community 47 - "Community 47"
 Cohesion: 0.27
 Nodes (8): createBundleReviewElements(), createPreviewRoot(), createStorage(), makeButton(), makeCanvas(), makeElement(), makeInput(), withUiGlobals()
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.22
 Nodes (3): McpServerHarness, scaffoldRun(), writeJson()
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.21
 Nodes (5): element(), getResourceBundleAssetSpecs(), ipfsUriForAssetId(), relativePathForGameAssetId(), specForVisual()
 
-### Community 51 - "Community 51"
+### Community 50 - "Community 50"
 Cohesion: 0.27
 Nodes (10): alphaBlend(), applyAuraMask(), clamp01(), conflictMask(), deterministicNoise(), drawMask(), emitMask(), layeredMask() (+2 more)
 
-### Community 52 - "Community 52"
+### Community 51 - "Community 51"
 Cohesion: 0.32
 Nodes (12): buildRoomDesignFromRoomCards(), deriveLayoutFromRoomCards(), deriveLevelGenFromRoomCards(), deriveLevelSideForWalkableTiles(), deriveRoomShapeFromRoomCards(), extractRoomCards(), isRoomCard(), normalizeCardCount() (+4 more)
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.24
 Nodes (1): McpServerHarness
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.35
 Nodes (11): color_mask(), component(), contact_sheet(), content_box(), main(), make_components(), new_mask(), normalize_source() (+3 more)
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.35
 Nodes (11): color_mask(), contact_sheet(), content_box(), main(), make_components(), new_mask(), normalize_source(), rectangle_mask() (+3 more)
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.26
 Nodes (6): findArtifact(), getBundleRunId(), loadGameplayBundle(), populateUIIcons(), syncBundleViews(), updateStatusRail()
 
-### Community 57 - "Community 57"
+### Community 56 - "Community 56"
 Cohesion: 0.23
 Nodes (5): readSnapshot(), setOutput(), setStatus(), storageFor(), wireBuildOrchestrator()
 
-### Community 58 - "Community 58"
+### Community 57 - "Community 57"
 Cohesion: 0.38
 Nodes (11): computeEffectivePotency(), computeIntensity(), computeManaCost(), computePotency(), computeRadius(), computeStackAlphaMultiplier(), computeTileAlpha(), resolveMergedStacks() (+3 more)
 
-### Community 59 - "Community 59"
+### Community 58 - "Community 58"
 Cohesion: 0.39
 Nodes (11): addError(), getConflictingMotivationKinds(), getMotivationExclusiveGroup(), normalizeFlags(), normalizeGoal(), normalizeGoalParams(), normalizeMotivation(), normalizeMotivationKind() (+3 more)
 
-### Community 60 - "Community 60"
+### Community 59 - "Community 59"
 Cohesion: 0.35
 Nodes (9): addError(), isInteger(), isNumber(), isPlainObject(), normalizeAbility(), normalizeActorLoadoutCatalog(), normalizeAffinityPresetCatalog(), normalizeEffect() (+1 more)
 
-### Community 61 - "Community 61"
+### Community 60 - "Community 60"
 Cohesion: 0.24
 Nodes (7): createCliWorkerAdapter(), createInProcessCliWorkerAdapter(), createInProcessLevelBuilderAdapter(), createLevelBuilderAdapter(), createLlmAdapter(), fetchWithTimeout(), resolvePositiveInt()
+
+### Community 61 - "Community 61"
+Cohesion: 0.36
+Nodes (9): buildAllocationAudit(), buildAllocationRef(), buildPriceMap(), buildRef(), calculatePriceTotal(), isFiniteNumber(), normalizePriceItems(), normalizeQuantity() (+1 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.38
@@ -752,116 +753,116 @@ Cohesion: 0.27
 Nodes (5): compileScenarioPlaybackBundle(), createPlaybackRuntime(), createRuntimeCore(), readCoreAffinityFieldRecords(), readCoreAffinityFieldRecordsFromArtifacts()
 
 ### Community 69 - "Community 69"
+Cohesion: 0.36
+Nodes (8): buildCategorySpend(), buildCategoryTargets(), buildLegacyCategorySpend(), buildPoolTargets(), buildScenarioSpendReport(), computeIncentiveMultiplier(), normalizeSpend(), sumLineItemsByCategory()
+
+### Community 70 - "Community 70"
 Cohesion: 0.38
 Nodes (8): buildLayoutLineItems(), evaluateLayoutSpend(), evaluateRoomCardLayoutSpend(), isInteger(), normalizeLayoutCosts(), normalizeLayoutCounts(), normalizeTileCount(), resolveLayoutTileCosts()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.27
 Nodes (5): collectCoreStaticTraps(), mergeTrapLists(), readObservation(), renderBaseTiles(), renderFrameBuffer()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.33
 Nodes (6): announceReady(), connect(), connectSandboxBridge(), handleBundle(), scheduleReconnect(), sendJson()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
+Cohesion: 0.36
+Nodes (5): collectBuildSpecCardSet(), deriveContentAwareSplit(), extractDesignStateFromBuildSpec(), mergeCardArrays(), normalizeBuildSpecForEditor()
+
+### Community 74 - "Community 74"
 Cohesion: 0.44
 Nodes (8): assertCoreSupportsGrid(), directionFromDelta(), findChar(), isDiagonalStepAllowed(), isWalkable(), reconstructPath(), runMvpMovement(), shortestPath()
 
-### Community 73 - "Community 73"
+### Community 75 - "Community 75"
 Cohesion: 0.39
 Nodes (7): addCoordinateLegend(), buildActorDetails(), buildBlankGrid(), computeActorPositions(), createVisualizationSnapshot(), inferKind(), markPosition()
 
-### Community 74 - "Community 74"
+### Community 76 - "Community 76"
 Cohesion: 0.36
 Nodes (5): buildPlanArtifactFromIntent(), isNonEmptyString(), resolveIntentEnvelope(), resolveIntentRef(), resolvePlanArtifact()
 
-### Community 75 - "Community 75"
+### Community 77 - "Community 77"
 Cohesion: 0.33
 Nodes (5): buildLlmTraceTelemetryRecord(), buildLlmTraceTurns(), isLlmCaptureArtifact(), isObject(), summarizeLlmTrace()
 
-### Community 76 - "Community 76"
+### Community 78 - "Community 78"
 Cohesion: 0.36
 Nodes (6): addError(), buildActorCatalogFromAtoms(), buildActorCatalogFromConfig(), isPlainObject(), normalizeMeta(), normalizeTags()
 
-### Community 77 - "Community 77"
+### Community 79 - "Community 79"
 Cohesion: 0.42
 Nodes (8): buildSpecFromSummaryFlow(), cloneJson(), normalizeAgentHints(), normalizeArrayField(), normalizeArtifactRef(), normalizeBuildSpecForUi(), normalizeRepeatableField(), runPoolFlow()
 
-### Community 78 - "Community 78"
+### Community 80 - "Community 80"
 Cohesion: 0.43
 Nodes (6): extractMcpPayload(), extractPrompt(), loadScenarios(), parseIndexTable(), scenarioBudget(), scenarioTier()
 
-### Community 79 - "Community 79"
+### Community 81 - "Community 81"
 Cohesion: 0.39
 Nodes (5): affinityByType(), countByType(), partialOverlap(), readJson(), scoreRun()
 
-### Community 80 - "Community 80"
+### Community 82 - "Community 82"
 Cohesion: 0.32
 Nodes (3): buildRoomIndex(), countInternalBlocked(), hasGapAroundInternalBarrier()
 
-### Community 81 - "Community 81"
+### Community 83 - "Community 83"
 Cohesion: 0.36
 Nodes (5): listCardSet(), listDelverCards(), listRoomCards(), runCli(), runCliOk()
 
-### Community 82 - "Community 82"
-Cohesion: 0.39
-Nodes (4): collectBuildSpecCardSet(), extractDesignStateFromBuildSpec(), mergeCardArrays(), normalizeBuildSpecForEditor()
-
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.46
 Nodes (7): allocatePools(), applyResourceCap(), buildBudgetAllocation(), buildRef(), computeBudgetPools(), normalizePoolWeights(), normalizeReserveTokens()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.52
 Nodes (6): getMcpBuildTools(), normalizeEntitySpec(), normalizeToolArgs(), pythonReprToJson(), runScenario(), toArray()
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.52
 Nodes (6): displayCommand(), remoteCommand(), remoteCommandFor(), runRemote(), runRemoteScript(), sshBaseArgs()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.38
 Nodes (4): isWalkable(), pickGreatestDeltaPair(), roomAnchor(), roomCenter()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.38
 Nodes (3): createMeta(), createSimArtifacts(), writeJson()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.43
 Nodes (4): createFrame(), createInitialState(), createMeta(), createSimConfig()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.33
 Nodes (2): runCli(), runCliOk()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.48
 Nodes (6): loadFixtureJson(), loadFixtureText(), runBlockchainDemo(), runIpfsDemo(), runLlmDemo(), runSolverDemo()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.43
 Nodes (4): clearBundleCanvas(), ensureCanvas(), findArtifact(), renderBundleBoardToCanvas()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.38
 Nodes (3): readArtifactFile(), readSchemaArtifact(), resolveBudgetTriplet()
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.48
 Nodes (4): buildBoardState(), buildEntityIndex(), findArtifact(), resolveHazards()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.48
 Nodes (5): getAffinityRgba(), hexToRgba(), normalizeHex(), resolveAuraRgba(), resolveStackIntensity()
-
-### Community 96 - "Community 96"
-Cohesion: 0.52
-Nodes (6): buildPriceMap(), buildRef(), isFiniteNumber(), normalizePriceItems(), normalizeQuantity(), validateSpendProposal()
 
 ### Community 97 - "Community 97"
 Cohesion: 0.48
@@ -932,144 +933,144 @@ Cohesion: 0.6
 Nodes (5): createActorMedallionTextureDescriptor(), normalizeActorMedallionTextureSize(), safeSegment(), shouldComposeActorMedallion(), vitalSegment()
 
 ### Community 114 - "Community 114"
-Cohesion: 0.53
-Nodes (5): chebyshevDistance(), computeAuraMap(), projectExpression(), resolveInteractionAtTile(), serializeAuraMap()
-
-### Community 115 - "Community 115"
 Cohesion: 0.33
 Nodes (0): 
 
+### Community 115 - "Community 115"
+Cohesion: 0.53
+Nodes (5): chebyshevDistance(), computeAuraMap(), projectExpression(), resolveInteractionAtTile(), serializeAuraMap()
+
 ### Community 116 - "Community 116"
-Cohesion: 0.6
-Nodes (5): buildRef(), isFiniteNumber(), normalizeQuantity(), resolveUnitCost(), updateBudgetLedger()
+Cohesion: 0.33
+Nodes (0): 
 
 ### Community 117 - "Community 117"
+Cohesion: 0.67
+Nodes (5): buildRef(), isFiniteNumber(), normalizeQuantity(), resolveReceiptLine(), updateBudgetLedger()
+
+### Community 118 - "Community 118"
 Cohesion: 0.53
 Nodes (4): calculateMotivationStackCost(), calculateMotivationStackCostFromCore(), resolveMotivationFamily(), resolveMotivationUnitCost()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.6
 Nodes (5): bitmaskToFlags(), evaluateMotivationProfileFromCore(), flagsToBitmask(), readEvaluationResult(), resolvePatternCode()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.5
 Nodes (2): runCli(), runCliOk()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.6
 Nodes (3): validateAsciiSnapshot(), validateBase(), validateImageSnapshot()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.6
 Nodes (3): isObject(), validatePriceListArtifact(), validatePriceListItem()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.4
 Nodes (0): 
-
-### Community 124 - "Community 124"
-Cohesion: 0.5
-Nodes (2): createGridArtifacts(), writeJson()
 
 ### Community 125 - "Community 125"
 Cohesion: 0.5
 Nodes (2): createGridArtifacts(), writeJson()
 
 ### Community 126 - "Community 126"
+Cohesion: 0.5
+Nodes (2): runCli(), runCliOk()
+
+### Community 127 - "Community 127"
+Cohesion: 0.5
+Nodes (2): createGridArtifacts(), writeJson()
+
+### Community 128 - "Community 128"
 Cohesion: 0.6
 Nodes (3): makeMeta(), scaffoldRun(), writeJson()
 
-### Community 127 - "Community 127"
+### Community 129 - "Community 129"
 Cohesion: 0.8
 Nodes (4): closeOnce(), findStartPort(), listenOnce(), withBlockedPort()
 
-### Community 128 - "Community 128"
+### Community 130 - "Community 130"
 Cohesion: 0.8
 Nodes (4): generateTierActors(), generateTierLayout(), loadGenerators(), resolveTierSpec()
 
-### Community 129 - "Community 129"
+### Community 131 - "Community 131"
 Cohesion: 0.6
 Nodes (3): clearList(), renderList(), wireAffinityLegend()
 
-### Community 130 - "Community 130"
+### Community 132 - "Community 132"
 Cohesion: 0.6
 Nodes (3): classifyIngestionPayload(), hasGameplayArtifacts(), isPlainObject()
 
-### Community 131 - "Community 131"
+### Community 133 - "Community 133"
 Cohesion: 0.6
 Nodes (3): isValidDataUri(), resolveIcon(), resolveIconHTML()
 
-### Community 132 - "Community 132"
+### Community 134 - "Community 134"
 Cohesion: 0.7
 Nodes (4): normalizeBudgetInputs(), validateBudgetPercentages(), validateLevelBudget(), validatePercentage()
 
-### Community 133 - "Community 133"
+### Community 135 - "Community 135"
 Cohesion: 0.5
 Nodes (2): extractLlmCaptures(), toLlmCaptureList()
 
-### Community 134 - "Community 134"
-Cohesion: 0.4
-Nodes (0): 
-
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.6
 Nodes (3): createSchemaCatalog(), filterSchemaCatalogEntries(), sortSchemas()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.5
 Nodes (2): distributeVitalPoints(), maximizeActorBudget()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.5
 Nodes (2): createSolverAdapter(), loadFixture()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.6
 Nodes (3): createIpfsAdapter(), joinPath(), normalizeCid()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.7
 Nodes (4): goToNext(), goToPrevious(), makeCurrent(), toggleClass()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.4
 Nodes (5): adapters-test Package, Blockchain Adapter (Test), IPFS Adapter (Test), LLM Adapter (Test), Fixture-First External IO
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.83
 Nodes (3): main(), parseArgs(), parseList()
-
-### Community 142 - "Community 142"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 143 - "Community 143"
 Cohesion: 0.5
 Nodes (0): 
 
 ### Community 144 - "Community 144"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 145 - "Community 145"
 Cohesion: 0.67
 Nodes (2): runCli(), runCliOk()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.83
 Nodes (3): buildReceipt(), readJson(), refFor()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.67
 Nodes (2): isObject(), validateResourceArtifact()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.83
 Nodes (3): buildBudgetedRun(), readJson(), refFor()
-
-### Community 148 - "Community 148"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 149 - "Community 149"
 Cohesion: 0.5
@@ -1080,104 +1081,104 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 151 - "Community 151"
-Cohesion: 0.67
-Nodes (2): fetchFn(), fixtureResponse()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 152 - "Community 152"
 Cohesion: 0.67
-Nodes (2): runCli(), runCliOk()
+Nodes (2): fetchFn(), fixtureResponse()
 
 ### Community 153 - "Community 153"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): runCli(), runCliOk()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.5
 Nodes (0): 
 
 ### Community 155 - "Community 155"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 156 - "Community 156"
 Cohesion: 0.67
 Nodes (2): fixturePath(), readFixture()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.67
 Nodes (2): applyFormula(), resolveFormula()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.83
 Nodes (3): buildLlmCaptureArtifact(), buildMeta(), isNonEmptyString()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.67
 Nodes (2): createSolverPort(), solveWithAdapter()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.67
 Nodes (2): pickBest(), scoreCandidate()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.83
 Nodes (2): createWasmSolverAdapter(), loadWasmInstance()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.5
 Nodes (1): serializeError()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.5
 Nodes (4): CLI Adapters Package, MCP Server (agent-kernel-cli), MCP-First Test Rule, Test Authoring Playbook
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 1.0
 Nodes (2): collectLocalTelemetry(), runCapture()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 1.0
 Nodes (2): health(), requestJson()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 1.0
 Nodes (2): extractJsonObject(), runRepairableJsonSession()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 170 - "Community 170"
-Cohesion: 1.0
-Nodes (2): createFrameRoot(), makeNode()
 
 ### Community 171 - "Community 171"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createFrameRoot(), makeNode()
 
 ### Community 172 - "Community 172"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 173 - "Community 173"
-Cohesion: 1.0
-Nodes (2): runCli(), runCliOk()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 174 - "Community 174"
 Cohesion: 1.0
-Nodes (2): buildWithBudget(), readJson()
+Nodes (2): runCli(), runCliOk()
 
 ### Community 175 - "Community 175"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildWithBudget(), readJson()
 
 ### Community 176 - "Community 176"
 Cohesion: 0.67
@@ -1196,12 +1197,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 180 - "Community 180"
-Cohesion: 1.0
-Nodes (2): makeBaseTiles(), runOneProposeCycle()
-
-### Community 181 - "Community 181"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 181 - "Community 181"
+Cohesion: 1.0
+Nodes (2): makeBaseTiles(), runOneProposeCycle()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.67
@@ -1212,12 +1213,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 184 - "Community 184"
-Cohesion: 1.0
-Nodes (2): buildCore(), makeRuntime()
-
-### Community 185 - "Community 185"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 185 - "Community 185"
+Cohesion: 1.0
+Nodes (2): buildCore(), makeRuntime()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.67
@@ -1252,24 +1253,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 194 - "Community 194"
-Cohesion: 1.0
-Nodes (2): writeJson(), writeRun()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 195 - "Community 195"
-Cohesion: 1.0
-Nodes (2): createCardBuilderController(), createStatusSink()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 196 - "Community 196"
 Cohesion: 1.0
-Nodes (2): compileScenarioToBundle(), loadScenarioFromUrl()
+Nodes (2): writeJson(), writeRun()
 
 ### Community 197 - "Community 197"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createCardBuilderController(), createStatusSink()
 
 ### Community 198 - "Community 198"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): compileScenarioToBundle(), loadScenarioFromUrl()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
@@ -1280,27 +1281,27 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 201 - "Community 201"
-Cohesion: 1.0
-Nodes (2): buildScenarioSpendReport(), computeIncentiveMultiplier()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 202 - "Community 202"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 203 - "Community 203"
 Cohesion: 1.0
 Nodes (2): buildManualMoveAction(), resolveObservedActors()
 
-### Community 203 - "Community 203"
-Cohesion: 0.67
-Nodes (0): 
-
 ### Community 204 - "Community 204"
 Cohesion: 0.67
-Nodes (1): createBlockchainAdapter()
+Nodes (0): 
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): createBlockchainAdapter()
 
 ### Community 206 - "Community 206"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 207 - "Community 207"
@@ -2193,76 +2194,78 @@ Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 1.0
-Nodes (1): Solver-Z3 Adapter
+Nodes (0): 
 
 ### Community 430 - "Community 430"
 Cohesion: 1.0
-Nodes (1): CLI build Command
+Nodes (1): Solver-Z3 Adapter
 
 ### Community 431 - "Community 431"
 Cohesion: 1.0
-Nodes (1): CLI llm-plan Command
+Nodes (1): CLI build Command
 
 ### Community 432 - "Community 432"
+Cohesion: 1.0
+Nodes (1): CLI llm-plan Command
+
+### Community 433 - "Community 433"
 Cohesion: 1.0
 Nodes (1): Structured Stdout Contract
 
 ## Knowledge Gaps
 - **29 isolated node(s):** `Read named components from a contact sheet.      The manifest maps each componen`, `Compose one full sprite from the atlas and semantic selection.`, `Keep the visible stone corner pieces while dropping dark sheet backing.`, `Build expression overlays from white arrow indicators.      Corner-arrow semanti`, `Build expression overlays from minimal white triangle indicators.      Triangle` (+24 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 206`** (2 nodes): `wireCardListView()`, `source.js`
+- **Thin community `Community 207`** (2 nodes): `wireCardListView()`, `source.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (2 nodes): `activeCardId()`, `card-builder-controller.test.js`
+- **Thin community `Community 208`** (2 nodes): `activeCardId()`, `card-builder-controller.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (2 nodes): `createFakeSurfaces()`, `gameplay-surface-ingestion.test.js`
+- **Thin community `Community 209`** (2 nodes): `createFakeSurfaces()`, `gameplay-surface-ingestion.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (2 nodes): `loadValidator()`, `sandbox-session-artifact.test.js`
+- **Thin community `Community 210`** (2 nodes): `loadValidator()`, `sandbox-session-artifact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (2 nodes): `loadValidator()`, `hazard-artifact.test.js`
+- **Thin community `Community 211`** (2 nodes): `loadValidator()`, `hazard-artifact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (2 nodes): `loadValidator()`, `build-spec.test.js`
+- **Thin community `Community 212`** (2 nodes): `loadValidator()`, `build-spec.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (2 nodes): `loadSetupModule()`, `core-setup-static-traps.test.js`
+- **Thin community `Community 213`** (2 nodes): `loadSetupModule()`, `core-setup-static-traps.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (2 nodes): `collectJsFiles()`, `prompt-template-centralization.test.js`
+- **Thin community `Community 214`** (2 nodes): `collectJsFiles()`, `prompt-template-centralization.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (2 nodes): `parseStringUnion()`, `domain-constants-parity.test.js`
+- **Thin community `Community 215`** (2 nodes): `parseStringUnion()`, `domain-constants-parity.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (2 nodes): `loadSetupModule()`, `core-setup-hazards-and-actor-affinity.test.js`
+- **Thin community `Community 216`** (2 nodes): `loadSetupModule()`, `core-setup-hazards-and-actor-affinity.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (2 nodes): `readJson()`, `prompt-contract-e2e.test.js`
+- **Thin community `Community 217`** (2 nodes): `readJson()`, `prompt-contract-e2e.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (2 nodes): `tick-frames.test.js`, `createRuntimeWithCore()`
+- **Thin community `Community 218`** (2 nodes): `tick-frames.test.js`, `createRuntimeWithCore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (2 nodes): `tileChanged()`, `resource-bundle.test.js`
+- **Thin community `Community 219`** (2 nodes): `tileChanged()`, `resource-bundle.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (2 nodes): `ui-flow-normalize.test.js`, `loadUiFlow()`
+- **Thin community `Community 220`** (2 nodes): `ui-flow-normalize.test.js`, `loadUiFlow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (2 nodes): `effectFactory()`, `external-fact.test.js`
+- **Thin community `Community 221`** (2 nodes): `effectFactory()`, `external-fact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `readJson()`, `e2e-budget-refs.test.js`
+- **Thin community `Community 222`** (2 nodes): `readJson()`, `e2e-budget-refs.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `visualization-state-detail.test.js`, `loadVisualizationModule()`
+- **Thin community `Community 223`** (2 nodes): `visualization-state-detail.test.js`, `loadVisualizationModule()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `rng()`, `irregular-room-sizes.test.js`
+- **Thin community `Community 224`** (2 nodes): `rng()`, `irregular-room-sizes.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `roleForVisual()`, `game-elements-registry.test.js`
+- **Thin community `Community 225`** (2 nodes): `roleForVisual()`, `game-elements-registry.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `readJson()`, `e2e-allocator-artifacts.test.js`
+- **Thin community `Community 226`** (2 nodes): `readJson()`, `e2e-allocator-artifacts.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `readJson()`, `e2e-actor-fixtures.test.js`
+- **Thin community `Community 227`** (2 nodes): `readJson()`, `e2e-actor-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `trap-vitals-in-observation.test.js`, `captureObservationPersona()`
+- **Thin community `Community 228`** (2 nodes): `trap-vitals-in-observation.test.js`, `captureObservationPersona()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `fixedClock()`, `runner-deterministic.test.js`
+- **Thin community `Community 229`** (2 nodes): `fixedClock()`, `runner-deterministic.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `loadRuntimeDeps()`, `runtime-fsm-loop.test.js`
+- **Thin community `Community 230`** (2 nodes): `loadRuntimeDeps()`, `runtime-fsm-loop.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `readJson()`, `e2e-scenario-fixtures.test.js`
+- **Thin community `Community 231`** (2 nodes): `readJson()`, `e2e-scenario-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `clock()`, `director-artifact-seeding.test.js`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `validate-spend-proposal.test.js`, `makeBudget()`
+- **Thin community `Community 232`** (2 nodes): `clock()`, `director-artifact-seeding.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 233`** (2 nodes): `z3-solver-adapter.test.js`, `buildRequest()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2300,369 +2303,371 @@ Nodes (1): Structured Stdout Contract
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 250`** (2 nodes): `runNodeTest()`, `node-test-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `tabs.js`, `wireTabs()`
+- **Thin community `Community 251`** (2 nodes): `shouldReuseActiveRun()`, `gameplay-launch.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `buildBuildSpecPrompt()`, `ollama-template.js`
+- **Thin community `Community 252`** (2 nodes): `tabs.js`, `wireTabs()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `wireDesignView()`, `design-view.js`
+- **Thin community `Community 253`** (2 nodes): `buildBuildSpecPrompt()`, `ollama-template.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `phaser-frame-view.js`, `createPhaserFrameView()`
+- **Thin community `Community 254`** (2 nodes): `wireDesignView()`, `design-view.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `runtime.js`, `createRuntime()`
+- **Thin community `Community 255`** (2 nodes): `phaser-frame-view.js`, `createPhaserFrameView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `resolveBudgetCategoryId()`, `budget-categories.js`
+- **Thin community `Community 256`** (2 nodes): `runtime.js`, `createRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `getAffinitySpriteAsset()`, `affinity-sprite-assets.js`
+- **Thin community `Community 257`** (2 nodes): `resolveBudgetCategoryId()`, `budget-categories.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `getGameSpriteAsset()`, `game-sprite-assets.js`
+- **Thin community `Community 258`** (2 nodes): `getAffinitySpriteAsset()`, `affinity-sprite-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `createModeratorPersona()`, `controller.js`
+- **Thin community `Community 259`** (2 nodes): `getGameSpriteAsset()`, `game-sprite-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `createAnnotatorPersona()`, `controller.js`
+- **Thin community `Community 260`** (2 nodes): `createModeratorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `createAllocatorPersona()`, `controller.js`
+- **Thin community `Community 261`** (2 nodes): `createAnnotatorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `createConfiguratorPersona()`, `controller.js`
+- **Thin community `Community 262`** (2 nodes): `createAllocatorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `createOrchestratorPersona()`, `controller.js`
+- **Thin community `Community 263`** (2 nodes): `createConfiguratorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `applyBudgetCaps()`, `budget.js`
+- **Thin community `Community 264`** (2 nodes): `createOrchestratorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `createLlmTestAdapter()`, `index.js`
+- **Thin community `Community 265`** (2 nodes): `applyBudgetCaps()`, `budget.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `createBlockchainTestAdapter()`, `index.js`
+- **Thin community `Community 266`** (2 nodes): `createLlmTestAdapter()`, `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `createDomLogAdapter()`, `dom-log.js`
+- **Thin community `Community 267`** (2 nodes): `createBlockchainTestAdapter()`, `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `createWebSolverAdapter()`, `index.js`
+- **Thin community `Community 268`** (2 nodes): `createDomLogAdapter()`, `dom-log.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (1 nodes): `ak-tool-schema.js`
+- **Thin community `Community 269`** (2 nodes): `createWebSolverAdapter()`, `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (1 nodes): `ui-startup-readiness.test.js`
+- **Thin community `Community 270`** (1 nodes): `ak-tool-schema.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (1 nodes): `remote-ollama-benchmark.test.js`
+- **Thin community `Community 271`** (1 nodes): `ui-startup-readiness.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (1 nodes): `affinity-pipeline-e2e.test.js`
+- **Thin community `Community 272`** (1 nodes): `remote-ollama-benchmark.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (1 nodes): `motivation-pipeline-e2e.test.js`
+- **Thin community `Community 273`** (1 nodes): `affinity-pipeline-e2e.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (1 nodes): `ui-aura-display.test.js`
+- **Thin community `Community 274`** (1 nodes): `motivation-pipeline-e2e.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (1 nodes): `captured-input-artifact.test.js`
+- **Thin community `Community 275`** (1 nodes): `ui-aura-display.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (1 nodes): `summary-selections.test.js`
+- **Thin community `Community 276`** (1 nodes): `captured-input-artifact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (1 nodes): `resource-bundle-aura-rendering.test.js`
+- **Thin community `Community 277`** (1 nodes): `summary-selections.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (1 nodes): `runtime-moderator-control.test.js`
+- **Thin community `Community 278`** (1 nodes): `resource-bundle-aura-rendering.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (1 nodes): `runtime-plan-artifact.test.js`
+- **Thin community `Community 279`** (1 nodes): `runtime-moderator-control.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (1 nodes): `budget-caps.test.js`
+- **Thin community `Community 280`** (1 nodes): `runtime-plan-artifact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (1 nodes): `runner-effects.test.js`
+- **Thin community `Community 281`** (1 nodes): `budget-caps.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (1 nodes): `ports.test.js`
+- **Thin community `Community 282`** (1 nodes): `runner-effects.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (1 nodes): `design-spend-ledger.test.js`
+- **Thin community `Community 283`** (1 nodes): `ports.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (1 nodes): `motivation-loadouts.test.js`
+- **Thin community `Community 284`** (1 nodes): `design-spend-ledger.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (1 nodes): `affinity-tile-mask.test.js`
+- **Thin community `Community 285`** (1 nodes): `motivation-loadouts.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (1 nodes): `configurator-startup.test.js`
+- **Thin community `Community 286`** (1 nodes): `affinity-tile-mask.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (1 nodes): `affinity-spatial-formulas.test.js`
+- **Thin community `Community 287`** (1 nodes): `configurator-startup.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (1 nodes): `run-helpers-runtime-decision.test.js`
+- **Thin community `Community 288`** (1 nodes): `affinity-spatial-formulas.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (1 nodes): `e2e-fixture-generators.test.js`
+- **Thin community `Community 289`** (1 nodes): `run-helpers-runtime-decision.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (1 nodes): `pool-buildspec.test.js`
+- **Thin community `Community 290`** (1 nodes): `e2e-fixture-generators.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (1 nodes): `mvp-movement.test.js`
+- **Thin community `Community 291`** (1 nodes): `pool-buildspec.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (1 nodes): `prompt-contract.test.js`
+- **Thin community `Community 292`** (1 nodes): `mvp-movement.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (1 nodes): `runner-smoke.test.js`
+- **Thin community `Community 293`** (1 nodes): `prompt-contract.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (1 nodes): `runtime-moderator-affinity-actions.test.js`
+- **Thin community `Community 294`** (1 nodes): `runner-smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 295`** (1 nodes): `runtime-moderator-affinity-actions.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (1 nodes): `pool-catalog.test.js`
+- **Thin community `Community 296`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (1 nodes): `schema-catalog.test.js`
+- **Thin community `Community 297`** (1 nodes): `pool-catalog.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (1 nodes): `affinity-palette.test.js`
+- **Thin community `Community 298`** (1 nodes): `schema-catalog.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (1 nodes): `affinity-aura-lifecycle.test.js`
+- **Thin community `Community 299`** (1 nodes): `affinity-palette.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (1 nodes): `pool-budget.test.js`
+- **Thin community `Community 300`** (1 nodes): `affinity-aura-lifecycle.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (1 nodes): `runtime-persona-schedule.test.js`
+- **Thin community `Community 301`** (1 nodes): `pool-budget.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (1 nodes): `pool-mapper.test.js`
+- **Thin community `Community 302`** (1 nodes): `runtime-persona-schedule.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (1 nodes): `runtime-allocator-signals.test.js`
+- **Thin community `Community 303`** (1 nodes): `pool-mapper.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (1 nodes): `actor-proposal-replay.test.js`
+- **Thin community `Community 304`** (1 nodes): `runtime-allocator-signals.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (1 nodes): `card-authoring.test.js`
+- **Thin community `Community 305`** (1 nodes): `actor-proposal-replay.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (1 nodes): `runtime-decision-contract.test.js`
+- **Thin community `Community 306`** (1 nodes): `card-authoring.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (1 nodes): `multi-actor-initial-state.test.js`
+- **Thin community `Community 307`** (1 nodes): `runtime-decision-contract.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (1 nodes): `solver.test.js`
+- **Thin community `Community 308`** (1 nodes): `multi-actor-initial-state.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (1 nodes): `effects-routing.test.js`
+- **Thin community `Community 309`** (1 nodes): `solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 310`** (1 nodes): `effects-routing.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (1 nodes): `fixtures.test.js`
+- **Thin community `Community 311`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (1 nodes): `allocator-solver.test.js`
+- **Thin community `Community 312`** (1 nodes): `fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (1 nodes): `orchestrator-llm-capture.test.js`
+- **Thin community `Community 313`** (1 nodes): `allocator-solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (1 nodes): `allocator-motivation-price-policy.test.js`
+- **Thin community `Community 314`** (1 nodes): `orchestrator-llm-capture.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (1 nodes): `moderator-persona-phase.test.js`
+- **Thin community `Community 315`** (1 nodes): `allocator-motivation-price-policy.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (1 nodes): `configurator-artifact-fixtures.test.js`
+- **Thin community `Community 316`** (1 nodes): `moderator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (1 nodes): `director-budget-allocation.test.js`
+- **Thin community `Community 317`** (1 nodes): `configurator-artifact-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (1 nodes): `moderator-affinity-target-effects.test.js`
+- **Thin community `Community 318`** (1 nodes): `director-budget-allocation.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (1 nodes): `configurator-artifact-builders.test.js`
+- **Thin community `Community 319`** (1 nodes): `moderator-affinity-target-effects.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (1 nodes): `annotator-state-machine.test.js`
+- **Thin community `Community 320`** (1 nodes): `configurator-artifact-builders.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (1 nodes): `configurator-affinity-interaction-core.test.js`
+- **Thin community `Community 321`** (1 nodes): `annotator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (1 nodes): `director-persona-phase.test.js`
+- **Thin community `Community 322`** (1 nodes): `configurator-affinity-interaction-core.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (1 nodes): `allocator-motivation-spend-integration.test.js`
+- **Thin community `Community 323`** (1 nodes): `director-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (1 nodes): `tick-orchestrator.test.js`
+- **Thin community `Community 324`** (1 nodes): `allocator-motivation-spend-integration.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (1 nodes): `configurator-level-strategy-map.test.js`
+- **Thin community `Community 325`** (1 nodes): `tick-orchestrator.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (1 nodes): `actor-budget-gating.test.js`
+- **Thin community `Community 326`** (1 nodes): `configurator-level-strategy-map.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (1 nodes): `configurator-state-machine.test.js`
+- **Thin community `Community 327`** (1 nodes): `actor-budget-gating.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (1 nodes): `actor-state-machine.test.js`
+- **Thin community `Community 328`** (1 nodes): `configurator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (1 nodes): `orchestrator-budget-inputs.test.js`
+- **Thin community `Community 329`** (1 nodes): `actor-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (1 nodes): `allocator-persona-phase.test.js`
+- **Thin community `Community 330`** (1 nodes): `orchestrator-budget-inputs.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (1 nodes): `orchestrator-state-machine.test.js`
+- **Thin community `Community 331`** (1 nodes): `allocator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (1 nodes): `orchestrator-llm-session.test.js`
+- **Thin community `Community 332`** (1 nodes): `orchestrator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (1 nodes): `configurator-level-gen-input.test.js`
+- **Thin community `Community 333`** (1 nodes): `orchestrator-llm-session.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (1 nodes): `configurator-actor-generator.test.js`
+- **Thin community `Community 334`** (1 nodes): `configurator-level-gen-input.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (1 nodes): `annotator-persona-phase.test.js`
+- **Thin community `Community 335`** (1 nodes): `configurator-actor-generator.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (1 nodes): `annotator-llm-trace.test.js`
+- **Thin community `Community 336`** (1 nodes): `annotator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (1 nodes): `moderator-state-machine.test.js`
+- **Thin community `Community 337`** (1 nodes): `annotator-llm-trace.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (1 nodes): `tick-inspect.test.js`
+- **Thin community `Community 338`** (1 nodes): `moderator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (1 nodes): `allocator-actor-behavior.test.js`
+- **Thin community `Community 339`** (1 nodes): `tick-inspect.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (1 nodes): `director-solver.test.js`
+- **Thin community `Community 340`** (1 nodes): `allocator-actor-behavior.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (1 nodes): `configurator-feasibility.test.js`
+- **Thin community `Community 341`** (1 nodes): `director-solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (1 nodes): `configurator-affinity-loadouts.test.js`
+- **Thin community `Community 342`** (1 nodes): `configurator-feasibility.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (1 nodes): `allocator-motivation-cost-core.test.js`
+- **Thin community `Community 343`** (1 nodes): `configurator-affinity-loadouts.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (1 nodes): `orchestrator-persona-phase.test.js`
+- **Thin community `Community 344`** (1 nodes): `allocator-motivation-cost-core.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (1 nodes): `director-configurator-behavior.test.js`
+- **Thin community `Community 345`** (1 nodes): `orchestrator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (1 nodes): `configurator-motivation-evaluation-core.test.js`
+- **Thin community `Community 346`** (1 nodes): `director-configurator-behavior.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (1 nodes): `orchestrator-llm-budget-loop.test.js`
+- **Thin community `Community 347`** (1 nodes): `configurator-motivation-evaluation-core.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (1 nodes): `configurator-affinity-effects.test.js`
+- **Thin community `Community 348`** (1 nodes): `orchestrator-llm-budget-loop.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (1 nodes): `configurator-persona-phase.test.js`
+- **Thin community `Community 349`** (1 nodes): `configurator-affinity-effects.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (1 nodes): `allocator-state-machine.test.js`
+- **Thin community `Community 350`** (1 nodes): `configurator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (1 nodes): `actor-persona-phase.test.js`
+- **Thin community `Community 351`** (1 nodes): `allocator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (1 nodes): `tick-state-machine.test.js`
+- **Thin community `Community 352`** (1 nodes): `actor-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (1 nodes): `annotator-telemetry.test.js`
+- **Thin community `Community 353`** (1 nodes): `tick-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (1 nodes): `actor-runtime-decision.test.js`
+- **Thin community `Community 354`** (1 nodes): `annotator-telemetry.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (1 nodes): `orchestrator-llm-budget-loop-feasibility.test.js`
+- **Thin community `Community 355`** (1 nodes): `actor-runtime-decision.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (1 nodes): `actor-persona-filter.test.js`
+- **Thin community `Community 356`** (1 nodes): `orchestrator-llm-budget-loop-feasibility.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (1 nodes): `configurator-solver.test.js`
+- **Thin community `Community 357`** (1 nodes): `actor-persona-filter.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (1 nodes): `configurator-trap-vitals.test.js`
+- **Thin community `Community 358`** (1 nodes): `configurator-solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (1 nodes): `configurator-actor-config-generation.test.js`
+- **Thin community `Community 359`** (1 nodes): `configurator-trap-vitals.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (1 nodes): `director-state-machine.test.js`
+- **Thin community `Community 360`** (1 nodes): `configurator-actor-config-generation.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (1 nodes): `incentive-model.test.js`
+- **Thin community `Community 361`** (1 nodes): `director-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (1 nodes): `budget-allocation.test.js`
+- **Thin community `Community 362`** (1 nodes): `incentive-model.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (1 nodes): `cost-model.test.js`
+- **Thin community `Community 363`** (1 nodes): `budget-allocation.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (1 nodes): `budget-pool-handoff.test.js`
+- **Thin community `Community 364`** (1 nodes): `cost-model.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (1 nodes): `motivation-pricing.test.js`
+- **Thin community `Community 365`** (1 nodes): `budget-pool-handoff.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (1 nodes): `solver.test.js`
+- **Thin community `Community 366`** (1 nodes): `motivation-pricing.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (1 nodes): `adapter-modules.test.js`
+- **Thin community `Community 367`** (1 nodes): `solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 368`** (1 nodes): `adapter-modules.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (1 nodes): `solver.test.js`
+- **Thin community `Community 369`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (1 nodes): `adapter-fixtures.test.js`
+- **Thin community `Community 370`** (1 nodes): `solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (1 nodes): `adapter-modules.test.js`
+- **Thin community `Community 371`** (1 nodes): `adapter-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 372`** (1 nodes): `adapter-modules.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (1 nodes): `allocator-selection-spend.test.js`
+- **Thin community `Community 373`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (1 nodes): `allocator-layout-spend.test.js`
+- **Thin community `Community 374`** (1 nodes): `allocator-selection-spend.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (1 nodes): `level-generation-benchmark.test.js`
+- **Thin community `Community 375`** (1 nodes): `allocator-layout-spend.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (1 nodes): `observation-static-traps.test.js`
+- **Thin community `Community 376`** (1 nodes): `level-generation-benchmark.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (1 nodes): `observation-affinity.test.js`
+- **Thin community `Community 377`** (1 nodes): `observation-static-traps.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (1 nodes): `affinity-readers.test.js`
+- **Thin community `Community 378`** (1 nodes): `observation-affinity.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 379`** (1 nodes): `affinity-readers.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (1 nodes): `core-ts.test.js`
+- **Thin community `Community 380`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (1 nodes): `movement.test.js`
+- **Thin community `Community 381`** (1 nodes): `core-ts.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (1 nodes): `motivation-readers.test.js`
+- **Thin community `Community 382`** (1 nodes): `movement.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (1 nodes): `index.js`
+- **Thin community `Community 383`** (1 nodes): `motivation-readers.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (1 nodes): `index.ts`
+- **Thin community `Community 384`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (1 nodes): `artifacts.ts`
+- **Thin community `Community 385`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (1 nodes): `persona.js`
+- **Thin community `Community 386`** (1 nodes): `artifacts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (1 nodes): `contracts.ts`
+- **Thin community `Community 387`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (1 nodes): `idle.ts`
+- **Thin community `Community 388`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (1 nodes): `persona.js`
+- **Thin community `Community 389`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (1 nodes): `contracts.ts`
+- **Thin community `Community 390`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (1 nodes): `idle.ts`
+- **Thin community `Community 391`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (1 nodes): `persona.js`
+- **Thin community `Community 392`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (1 nodes): `contracts.ts`
+- **Thin community `Community 393`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (1 nodes): `idle.ts`
+- **Thin community `Community 394`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (1 nodes): `persona.js`
+- **Thin community `Community 395`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (1 nodes): `contracts.ts`
+- **Thin community `Community 396`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (1 nodes): `idle.ts`
+- **Thin community `Community 397`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (1 nodes): `movement-directions.js`
+- **Thin community `Community 398`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (1 nodes): `persona.js`
+- **Thin community `Community 399`** (1 nodes): `movement-directions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (1 nodes): `contracts.ts`
+- **Thin community `Community 400`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (1 nodes): `defaults.js`
+- **Thin community `Community 401`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (1 nodes): `idle.ts`
+- **Thin community `Community 402`** (1 nodes): `defaults.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (1 nodes): `persona.js`
+- **Thin community `Community 403`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (1 nodes): `contracts.ts`
+- **Thin community `Community 404`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (1 nodes): `idle.ts`
+- **Thin community `Community 405`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (1 nodes): `persona.js`
+- **Thin community `Community 406`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (1 nodes): `contracts.ts`
+- **Thin community `Community 407`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (1 nodes): `idle.ts`
+- **Thin community `Community 408`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (1 nodes): `contracts.ts`
+- **Thin community `Community 409`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (1 nodes): `controller.ts`
+- **Thin community `Community 410`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (1 nodes): `idle.ts`
+- **Thin community `Community 411`** (1 nodes): `controller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (1 nodes): `contracts.ts`
+- **Thin community `Community 412`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (1 nodes): `controller.ts`
+- **Thin community `Community 413`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (1 nodes): `idle.ts`
+- **Thin community `Community 414`** (1 nodes): `controller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (1 nodes): `contracts.ts`
+- **Thin community `Community 415`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (1 nodes): `controller.ts`
+- **Thin community `Community 416`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (1 nodes): `idle.ts`
+- **Thin community `Community 417`** (1 nodes): `controller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (1 nodes): `contracts.ts`
+- **Thin community `Community 418`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (1 nodes): `controller.ts`
+- **Thin community `Community 419`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (1 nodes): `idle.ts`
+- **Thin community `Community 420`** (1 nodes): `controller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (1 nodes): `contracts.ts`
+- **Thin community `Community 421`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (1 nodes): `controller.ts`
+- **Thin community `Community 422`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (1 nodes): `idle.ts`
+- **Thin community `Community 423`** (1 nodes): `controller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (1 nodes): `contracts.ts`
+- **Thin community `Community 424`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (1 nodes): `controller.ts`
+- **Thin community `Community 425`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (1 nodes): `idle.ts`
+- **Thin community `Community 426`** (1 nodes): `controller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (1 nodes): `map.js`
+- **Thin community `Community 427`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (1 nodes): `capability.ts`
+- **Thin community `Community 428`** (1 nodes): `map.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (1 nodes): `Solver-Z3 Adapter`
+- **Thin community `Community 429`** (1 nodes): `capability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (1 nodes): `CLI build Command`
+- **Thin community `Community 430`** (1 nodes): `Solver-Z3 Adapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (1 nodes): `CLI llm-plan Command`
+- **Thin community `Community 431`** (1 nodes): `CLI build Command`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (1 nodes): `Structured Stdout Contract`
+- **Thin community `Community 432`** (1 nodes): `CLI llm-plan Command`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 433`** (1 nodes): `Structured Stdout Contract`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -2673,9 +2678,9 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**

--- a/packages/runtime/src/commands/card-authoring.js
+++ b/packages/runtime/src/commands/card-authoring.js
@@ -985,7 +985,16 @@ function adjustAffinityStack(card, affinityKind, delta = 0, expressionValue = un
       })
       .filter(Boolean),
   );
-  if (!updated) return working;
+  if (!updated) {
+    if (amount > 0 && targetExpression) {
+      working.affinities = stableSortAffinities([
+        ...working.affinities,
+        { kind: targetKind, expression: targetExpression, stacks: 1 },
+      ]);
+    } else {
+      return working;
+    }
+  }
   working.affinity = working.affinities.find((entry) => entry.kind === targetKind)?.kind
     || working.affinities[0]?.kind
     || normalizeAffinity(working.affinity, DEFAULT_DUNGEON_AFFINITY);

--- a/packages/ui-web/src/views/card-builder-phaser-renderer.js
+++ b/packages/ui-web/src/views/card-builder-phaser-renderer.js
@@ -17,8 +17,12 @@ export const CARD_BUILDER_UI_INTENTS = Object.freeze([
 
 const UI_INTENT_SET = new Set(CARD_BUILDER_UI_INTENTS);
 
-const DEFAULT_WIDTH = 800;
-const DEFAULT_HEIGHT = 520;
+// Fixed design resolution — all layout math is in these coordinates.
+// Phaser CSS-scales the canvas into its container via FIT mode.
+const DESIGN_WIDTH  = 1440;
+const DESIGN_HEIGHT = 860;
+const DEFAULT_WIDTH  = DESIGN_WIDTH;
+const DEFAULT_HEIGHT = DESIGN_HEIGHT;
 const TAB_BAR_H = 40;
 const STATUS_BAR_H = 28;
 const GAP = 6;
@@ -1403,18 +1407,15 @@ export function createCardBuilderPhaserRenderer({
       const Phaser = await loadPhaser();
       if (!Phaser || typeof Phaser.Game !== "function") return;
 
-      const w = container?.clientWidth || DEFAULT_WIDTH;
-      const h = container?.clientHeight || DEFAULT_HEIGHT;
-
       await new Promise((resolve) => {
         game = new Phaser.Game({
           type: Phaser.AUTO,
           parent: stageEl,
-          width: w,
-          height: h || DEFAULT_HEIGHT,
+          width: DESIGN_WIDTH,
+          height: DESIGN_HEIGHT,
           backgroundColor: "#0d1018",
           scale: {
-            mode: Phaser.Scale?.RESIZE ?? Phaser.Scale?.NONE ?? 0,
+            mode: Phaser.Scale?.FIT ?? Phaser.Scale?.NONE ?? 0,
             autoCenter: Phaser.Scale?.CENTER_BOTH ?? 0,
           },
           scene: {

--- a/packages/ui-web/src/views/card-builder-phaser-renderer.js
+++ b/packages/ui-web/src/views/card-builder-phaser-renderer.js
@@ -647,97 +647,156 @@ export function createCardBuilderPhaserRenderer({
     const affinities = Array.isArray(activeCard?.affinities) ? activeCard.affinities : [];
     if (affinities.length === 0) return startRow;
 
-    const ROW_H = 26;
-    const ROW_GAP = 3;
-    const ICON_SZ = 20;
-    const BTN_SZ = 14;
+    // Group entries by kind → { expr: stacks }
+    const byKind = {};
+    affinities.forEach(({ kind, expression, stacks }) => {
+      if (!byKind[kind]) {
+        byKind[kind] = { push: 0, pull: 0, emit: 0, draw: 0 };
+      }
+      if (expression && expression in byKind[kind]) {
+        byKind[kind][expression] = stacks || 0;
+      }
+    });
+
+    const kinds = Object.keys(byKind);
+    if (kinds.length === 0) return startRow;
+
+    const ROW_H = 30;
+    const ROW_GAP = 4;
+    const AFF_ICON_SZ = 18;
+    const EXPR_ICON_SZ = 13;
+    const BTN_W = 12;
     const PAD = 6;
+    const REMOVE_W = 16;
 
     function hexToNum(hex) {
       return parseInt((hex || "#888888").replace("#", ""), 16);
     }
 
+    function drawIcon(x, y, html, size, alpha) {
+      if (!html) return;
+      if (html.startsWith("<img")) {
+        drawIconAt(x, y, html, size, { alpha });
+      } else {
+        addObj(scene.add.text(x + size / 2, y + size / 2, html, {
+          fontSize: `${size}px`,
+        }).setOrigin(0.5, 0.5).setAlpha(alpha));
+      }
+    }
+
     let row = startRow + PAD;
 
-    affinities.forEach((entry) => {
-      const { kind, expression, stacks } = entry;
+    kinds.forEach((kind) => {
+      const stackMap = byKind[kind];
       const colHex = GAME_AFFINITY_COLOR_HEX[kind] || "#6688aa";
       const colNum = hexToNum(colHex);
       const chipX = editorX;
       const chipW = editorW;
       const cy = row + ROW_H / 2;
 
+      // Row background
       const bg = addObj(scene.add.graphics());
-      bg.fillStyle(colNum, 0.12);
+      bg.fillStyle(colNum, 0.10);
       bg.fillRoundedRect(chipX, row, chipW, ROW_H, 4);
-      bg.lineStyle(1, colNum, 0.35);
+      bg.lineStyle(1, colNum, 0.30);
       bg.strokeRoundedRect(chipX, row, chipW, ROW_H, 4);
 
-      let cx = chipX + 4;
-
+      // Affinity icon (no text label)
+      let cx = chipX + 5;
       const affIconHtml = resolveIconHTML(rendererBundle, "affinities", kind);
-      const affDrawn = drawIconAt(cx, row + (ROW_H - ICON_SZ) / 2, affIconHtml, ICON_SZ);
-      cx += ICON_SZ + 4;
+      drawIcon(cx, row + (ROW_H - AFF_ICON_SZ) / 2, affIconHtml, AFF_ICON_SZ, 1.0);
+      cx += AFF_ICON_SZ + 4;
 
-      addObj(scene.add.text(cx, cy, kind, { fontSize: "11px", color: "#e0e0e0" }).setOrigin(0, 0.5));
-      cx += kind.length * 7 + 6;
+      // Vertical separator
+      const sepG = addObj(scene.add.graphics());
+      sepG.lineStyle(1, colNum, 0.4);
+      sepG.beginPath();
+      sepG.moveTo(cx, row + 4);
+      sepG.lineTo(cx, row + ROW_H - 4);
+      sepG.strokePath();
+      cx += 6;
 
-      addObj(scene.add.text(cx, cy, "+", { fontSize: "10px", color: "#888888" }).setOrigin(0, 0.5));
-      cx += 12;
-
-      const exprStartX = cx;
-      const exprIconHtml = resolveIconHTML(rendererBundle, "expressions", expression);
-      drawIconAt(cx, row + (ROW_H - (ICON_SZ - 4)) / 2, exprIconHtml, ICON_SZ - 4);
-      cx += ICON_SZ;
-
-      const exprTxt = addObj(scene.add.text(cx, cy, expression, { fontSize: "11px", color: "#e0e0e0" }).setOrigin(0, 0.5));
-      const exprHitW = (cx - exprStartX) + expression.length * 7 + 8;
-      const exprHit = addObj(
-        scene.add.rectangle(exprStartX + exprHitW / 2, cy, exprHitW, ROW_H, 0, 0).setInteractive({ useHandCursor: true }),
+      // × remove button (far right, placed first so we know available width)
+      const removeX = chipX + chipW - REMOVE_W - 3;
+      const removeTxt = addObj(
+        scene.add.text(removeX + REMOVE_W / 2, cy, "×", { fontSize: "13px", color: "#ff6666" }).setOrigin(0.5, 0.5),
       );
-      exprHit.on("pointerover", () => exprTxt.setStyle({ color: COLOR_HOVER }));
-      exprHit.on("pointerout", () => exprTxt.setStyle({ color: "#e0e0e0" }));
-      exprHit.on("pointerdown", () => {
-        const id = controller.getActiveCard()?.id;
-        if (id) { controller.cycleAffinityExpression?.(id, kind); void render(); }
-      });
-
-      const rightEdge = chipX + chipW - 4;
-
-      const removeTxt = addObj(scene.add.text(rightEdge, cy, "×", { fontSize: "12px", color: "#ff6666" }).setOrigin(1, 0.5));
-      const removeHit = addObj(scene.add.rectangle(rightEdge - 6, cy, BTN_SZ, BTN_SZ, 0, 0).setInteractive({ useHandCursor: true }));
+      const removeHit = addObj(
+        scene.add.rectangle(removeX + REMOVE_W / 2, cy, REMOVE_W, ROW_H - 4, 0, 0).setInteractive({ useHandCursor: true }),
+      );
       removeHit.on("pointerover", () => removeTxt.setStyle({ color: "#ff9999" }));
-      removeHit.on("pointerout", () => removeTxt.setStyle({ color: "#ff6666" }));
+      removeHit.on("pointerout",  () => removeTxt.setStyle({ color: "#ff6666" }));
       removeHit.on("pointerdown", () => {
         const id = controller.getActiveCard()?.id;
         if (id) { applyIntent({ kind: "drop_chip", cardId: id, property: { group: "affinities", value: kind } }); void render(); }
       });
 
-      const plusX = rightEdge - BTN_SZ - 8;
-      const plusTxt = addObj(scene.add.text(plusX, cy, "+", { fontSize: "12px", color: colHex }).setOrigin(0.5, 0.5));
-      const plusHit = addObj(scene.add.rectangle(plusX, cy, BTN_SZ, BTN_SZ, 0, 0).setInteractive({ useHandCursor: true }));
-      plusHit.on("pointerover", () => plusTxt.setStyle({ color: COLOR_HOVER }));
-      plusHit.on("pointerout", () => plusTxt.setStyle({ color: colHex }));
-      plusHit.on("pointerdown", () => {
-        const id = controller.getActiveCard()?.id;
-        if (id) { controller.adjustAffinityStack?.(id, kind, 1, expression); void render(); }
+      // 4 expression cells distributed across remaining space
+      const availW = removeX - cx - 2;
+      const cellW  = Math.floor(availW / 4);
+
+      GAME_AFFINITY_EXPRESSIONS.forEach((expr, idx) => {
+        const stacks = stackMap[expr] || 0;
+        const active = stacks > 0;
+        const cellX  = cx + idx * cellW;
+        const cellCx = cellX + cellW / 2;
+
+        // Active cell highlight
+        if (active) {
+          const cellBg = addObj(scene.add.graphics());
+          cellBg.fillStyle(colNum, 0.22);
+          cellBg.fillRoundedRect(cellX + 1, row + 2, cellW - 2, ROW_H - 4, 3);
+        }
+
+        // − button
+        const minusCx = cellX + BTN_W / 2 + 1;
+        const minusTxt = addObj(
+          scene.add.text(minusCx, cy, "−", { fontSize: "13px", color: active ? colHex : "#3a4a5a" }).setOrigin(0.5, 0.5),
+        );
+        const minusHit = addObj(
+          scene.add.rectangle(minusCx, cy, BTN_W, ROW_H - 2, 0, 0).setInteractive({ useHandCursor: true }),
+        );
+        minusHit.on("pointerover", () => minusTxt.setStyle({ color: active ? COLOR_HOVER : "#5a6a7a" }));
+        minusHit.on("pointerout",  () => minusTxt.setStyle({ color: active ? colHex : "#3a4a5a" }));
+        minusHit.on("pointerdown", () => {
+          const id = controller.getActiveCard()?.id;
+          if (id) { controller.adjustAffinityStack?.(id, kind, -1, expr); void render(); }
+        });
+
+        // Expression icon
+        const iconX = cellX + BTN_W + 2;
+        const iconY = row + (ROW_H - EXPR_ICON_SZ) / 2;
+        const exprIconHtml = resolveIconHTML(rendererBundle, "expressions", expr);
+        drawIcon(iconX, iconY, exprIconHtml, EXPR_ICON_SZ, active ? 1.0 : 0.22);
+
+        // Stack count (only when active)
+        const countX = iconX + EXPR_ICON_SZ + 1;
+        if (active) {
+          addObj(
+            scene.add.text(countX, cy, String(stacks), { fontSize: "10px", color: colHex, fontStyle: "bold" }).setOrigin(0, 0.5),
+          );
+        }
+
+        // + button
+        const plusCx = cellX + cellW - BTN_W / 2 - 1;
+        const plusTxt = addObj(
+          scene.add.text(plusCx, cy, "+", { fontSize: "13px", color: active ? colHex : "#4a5a6a" }).setOrigin(0.5, 0.5),
+        );
+        const plusHit = addObj(
+          scene.add.rectangle(plusCx, cy, BTN_W, ROW_H - 2, 0, 0).setInteractive({ useHandCursor: true }),
+        );
+        plusHit.on("pointerover", () => plusTxt.setStyle({ color: COLOR_HOVER }));
+        plusHit.on("pointerout",  () => plusTxt.setStyle({ color: active ? colHex : "#4a5a6a" }));
+        plusHit.on("pointerdown", () => {
+          const id = controller.getActiveCard()?.id;
+          if (id) { controller.adjustAffinityStack?.(id, kind, 1, expr); void render(); }
+        });
       });
 
-      const minusX = plusX - BTN_SZ - 4;
-      const minusTxt = addObj(scene.add.text(minusX, cy, "−", { fontSize: "12px", color: colHex }).setOrigin(0.5, 0.5));
-      const minusHit = addObj(scene.add.rectangle(minusX, cy, BTN_SZ, BTN_SZ, 0, 0).setInteractive({ useHandCursor: true }));
-      minusHit.on("pointerover", () => minusTxt.setStyle({ color: COLOR_HOVER }));
-      minusHit.on("pointerout", () => minusTxt.setStyle({ color: colHex }));
-      minusHit.on("pointerdown", () => {
-        const id = controller.getActiveCard()?.id;
-        if (id) { controller.adjustAffinityStack?.(id, kind, -1, expression); void render(); }
+      chipRegistry.push({
+        label: kind, zone: "editor", group: "affinities", role: "affinity_row",
+        value: kind, x: chipX, y: row, width: chipW, height: ROW_H,
       });
-
-      const countX = minusX - 8;
-      addObj(scene.add.text(countX, cy, `×${stacks}`, { fontSize: "12px", color: "#ffffff", fontStyle: "bold" }).setOrigin(1, 0.5));
-
-      chipRegistry.push({ label: `${kind}:${expression}`, zone: "editor", group: "affinities", role: "affinity_stack",
-        value: `${kind}:${expression}`, x: chipX, y: row, width: chipW, height: ROW_H });
 
       row += ROW_H + ROW_GAP;
     });
@@ -1208,32 +1267,6 @@ export function createCardBuilderPhaserRenderer({
         });
 
         row += MOTIVATION_CHIP_H + 4;
-      });
-      row += 4;
-    }
-
-    const EXPRESSION_ICON_SIZE = 20;
-    const expressions = Array.isArray(activeCard?.expressions) ? activeCard.expressions : [];
-    if (expressions.length > 0) {
-      row = drawSectionBand(editorX, row, editorW, "EXPRESSIONS");
-      row += 4;
-      expressions.forEach((expr) => {
-        const exprIconHtml = resolveIconHTML(rendererBundle, "expressions", expr);
-        const exprIconResult = drawIconAt(editorX, row, exprIconHtml, EXPRESSION_ICON_SIZE);
-        const textX = exprIconResult.drawn ? editorX + EXPRESSION_ICON_SIZE + 4 : editorX;
-        const label = exprIconResult.drawn ? expr : `${exprIconHtml} ${expr}`;
-        const textY = exprIconResult.drawn ? row + (EXPRESSION_ICON_SIZE - 16) / 2 : row;
-        drawEditorChip(textX, textY, label, {
-          group: "expressions",
-          value: expr,
-          color: COLOR_EXPRESSION,
-          interactive: true,
-          onDown: () => {
-            const freshId = controller.getActiveCard().id;
-            applyIntent({ kind: "drop_chip", cardId: freshId, property: { group: "expressions", value: expr } });
-          },
-        });
-        row += EXPRESSION_ICON_SIZE + 4;
       });
       row += 4;
     }

--- a/packages/ui-web/src/views/card-builder-phaser-renderer.js
+++ b/packages/ui-web/src/views/card-builder-phaser-renderer.js
@@ -661,11 +661,11 @@ export function createCardBuilderPhaserRenderer({
     const kinds = Object.keys(byKind);
     if (kinds.length === 0) return startRow;
 
-    const ROW_H = 30;
+    const ROW_H = 36;
     const ROW_GAP = 4;
-    const AFF_ICON_SZ = 18;
-    const EXPR_ICON_SZ = 13;
-    const BTN_W = 12;
+    const AFF_ICON_SZ = 24;
+    const EXPR_ICON_SZ = 18;
+    const BTN_W = 14;
     const PAD = 6;
     const REMOVE_W = 16;
 

--- a/tools/benchmark/.gitignore
+++ b/tools/benchmark/.gitignore
@@ -1,0 +1,4 @@
+# Generated benchmark output (reproducible via `pnpm benchmark:mcp:generate`).
+# The harness (generator + validator + README) is tracked; the bulky generated
+# notes + Reference Artifacts + Validation results are not.
+out/

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -1,0 +1,66 @@
+# Agent Kernel MCP Benchmark Suite
+
+54 `ak_create` scenarios used to compare how different LLMs / reasoning levels drive the
+agent-kernel skill + MCP tools, and to detect drift between the documented baselines and the
+current CLI / MCP implementation.
+
+This directory holds the **tracked harness**. The bulky generated output (scenario notes,
+`Reference Artifacts/**`, `Validation/**`) is git-ignored and reproduced on demand.
+
+## Files
+
+| File | Role |
+|---|---|
+| `generate-baselines.mjs` | Drives `ak.mjs create` for all 54 scenarios; renders notes, `Index.md`, and `Reference Artifacts/**`. |
+| `validate-benchmark.mjs` | Re-runs every scenario through **both** the CLI and a live `ak_create` MCP server, checks the full artifact set, and verifies CLI↔MCP byte-stable parity. Continues on failure; exits non-zero if any check fails. |
+| `out/` | Generated output (git-ignored). |
+
+## Quick start
+
+```bash
+# Regenerate all 54 baselines into tools/benchmark/out/
+pnpm benchmark:mcp:generate
+
+# Validate CLI + MCP + parity for every scenario (writes out/Validation/validation-summary.md)
+pnpm benchmark:mcp:validate
+```
+
+Both commands run from the repo root and discover the repo via `process.cwd()`.
+
+## Configuration (env vars)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `AK_BENCHMARK_OUTPUT_DIR` | `tools/benchmark/out` | Where notes + artifacts are written / read. |
+| `AGENT_KERNEL_ROOT` | `process.cwd()` | Repo root (CLI + MCP server paths). |
+| `AK_BENCHMARK_VAULT_PREFIX` | `…/agent-kernel-vault` | Path prefix the generator refuses to write to by default. |
+| `AK_BENCHMARK_ALLOW_VAULT_WRITE` | _unset_ | Set to `1` to allow writing under the vault prefix (only outside a write-restricted sandbox). |
+
+## Publishing the browsable copy to the Obsidian vault
+
+The Obsidian vault holds a human-browsable copy under
+`Sample Calls to agent-kernel MCP and Results/`. Codex's rescue sandbox **cannot** write to the
+vault, so regenerate into the vault only from an unsandboxed host:
+
+```bash
+AK_BENCHMARK_OUTPUT_DIR="/Users/darren/Documents/Obsidian/agent-kernel-vault/Sample Calls to agent-kernel MCP and Results" \
+AK_BENCHMARK_ALLOW_VAULT_WRITE=1 \
+pnpm benchmark:mcp:generate
+```
+
+## Notes on current-code normalization
+
+The generator normalizes a few authored specs to stay valid under the current `create` surface and
+records each normalization in the affected scenario note:
+
+- Room `affinities=` fields are no longer accepted → converted to hazards (or dropped when explicit
+  trap/hazard objects already carry the affinity pressure).
+- `size=small` rooms containing traps/hazards are upgraded to `medium`.
+- `blocking=true` traps are emitted as `blocking=false` (see `REMEDIATION_PLAN.md` deficiency #4).
+
+When the deficiencies in `REMEDIATION_PLAN.md` are fixed, remove the corresponding normalization so
+the benchmark again exercises the original authored intent.
+
+## Known deficiencies surfaced by this suite
+
+See [`REMEDIATION_PLAN.md`](./REMEDIATION_PLAN.md).

--- a/tools/benchmark/REMEDIATION_PLAN.md
+++ b/tools/benchmark/REMEDIATION_PLAN.md
@@ -1,0 +1,127 @@
+# Benchmark-Exposed Deficiency Remediation Plan
+
+Source: the 2026-06-24 benchmark rewrite + MCP validation run (Codex rescue). All 54 scenarios now
+pass CLI + MCP + parity, but only after the generator **normalized away** several authored
+intentions to dodge current-code defects. This plan resolves the underlying code so the benchmark
+can again exercise the original intent.
+
+Each deficiency is grounded in source (file:line verified during the run). Fixes are ordered by
+blast radius. **Tests-first** per repo policy: add a failing test under `tests/**` before each fix.
+
+---
+
+## D1 — Build-level budget maximization inflates user-authored vitals  ⚠️ PRODUCT DECISION REQUIRED
+
+**Symptom:** scenario 01 (and ~50 others) jumped from a baseline spend of `82` to `1280` for the
+*identical* authored input — a ~15× change. Receipts now sit near the budget cap regardless of what
+the author specified.
+
+**Root cause (verified):**
+- `create` sets `built.spec.configurator.inputs.maximizeBudget = true` whenever a budget is supplied
+  — `packages/adapters-cli/src/cli/ak-impl.mjs:5109`.
+- Build orchestration probes remaining budget and calls `maximizeActorBudget` —
+  `packages/runtime/src/build/orchestrate-build.js:1413-1429`.
+- `maximizeActorBudget` distributes *all* remaining tokens across *every* actor vital, including
+  ones the author set explicitly — `packages/runtime/src/personas/configurator/budget-maximizer.js:66-124`
+  (docstring: "Scales actor vitals and regen to exhaust `remaining` unspent budget tokens").
+
+**The decision:** this is working as designed ("spend the whole budget"), but it means *explicit*
+authored vitals do not stay fixed. Two coherent intents:
+
+- **(A) Keep maximization as-is** — it is the intended "code-is-law" behavior. Then D1 is *not* a
+  bug; instead the benchmark should stop asserting exact authored vitals, and the headline pricing
+  drift is expected. (Lowest code risk.)
+- **(B) Treat authored vitals as a floor, not a target** — only maximize vitals the author did *not*
+  pin; or gate maximization behind an explicit `--maximize-budget` flag rather than auto-on whenever
+  a budget exists. Fix at `ak-impl.mjs:5109` (don't auto-set the flag) and/or
+  `budget-maximizer.js` (skip author-pinned vital keys). (Restores baseline-like spends; changes a
+  user-visible default.)
+
+**Recommendation:** (B) with a flag — `maximizeBudget` should be opt-in, not implied by the presence
+of a budget. This makes authored configs deterministic and keeps the maximizer available when wanted.
+Needs your call before any edit.
+
+---
+
+## D2 — Layout spend items are always denied (no layout price exists)
+
+**Symptom:** every receipt shows `layout … denied`; layout-only scenarios 03 and 42 are fully
+`denied` with spend 0.
+
+**Root cause (verified):**
+- `buildSpendItems` emits `layout_grid_${w}x${h}` — `packages/runtime/src/personas/configurator/spend-proposal.js:115-117`.
+- The default price list has no `layout` entry (vitals/affinity/motivation/tile/trap/hazard/resource
+  only) — `packages/runtime/src/personas/allocator/default-price-list.js` (confirmed: no `layout` id).
+- `validateSpendProposal` denies any unknown price id — `packages/runtime/src/personas/allocator/validate-spend.js:90-104`.
+
+**Fix:** decide whether layout is priced.
+- If layout should cost tokens: add `layout_grid_*` entries (or a formula-based `layout` kind) to
+  `default-price-list.js`.
+- If layout is free/structural: stop emitting it as a *priced* spend item in `spend-proposal.js`
+  (emit it as a zero-cost/info line, or omit), so receipts aren't perpetually `partial`.
+
+**Recommendation:** add a priced `layout` kind (rooms are a real cost surface) with a per-cell or
+per-grid formula, so scenarios 03/42 can actually approve. Low risk, additive.
+
+---
+
+## D3 — Price-list `formula` field is declared but never applied
+
+**Symptom:** receipts don't honor the documented quadratic pricing; cost semantics are split across
+comments, the budget-maximizer, and final validation.
+
+**Root cause (verified):**
+- The price list declares `formula: "quadratic"` for regen ticks and `affinity_stack`, with a header
+  comment defining `linear` vs `quadratic` — `packages/runtime/src/personas/allocator/default-price-list.js:14-31`.
+- `validateSpendProposal` always computes flat `totalCost = price.unitCost * quantity` —
+  `packages/runtime/src/personas/allocator/validate-spend.js:106`.
+
+**Fix:** make `validateSpendProposal` apply `price.formula` (`linear` → `unitCost*qty`,
+`quadratic` → `unitCost*qty²`) as a single source of truth, and have the budget-maximizer reuse the
+same cost function instead of its private quadratic logic in `budget-maximizer.js`.
+
+**Risk:** medium — changes computed costs on receipts that *do* approve. Pair with D1's decision
+(both touch the cost model). Tests-first: lock expected costs for a known affinity-stack / regen case.
+
+---
+
+## D4 — Blocking traps are accepted by the parser but rejected by layout
+
+**Symptom:** every `blocking=true` trap placement fails downstream with `trap_on_wall`; the generator
+had to emit all benchmark traps as `blocking=false`.
+
+**Root cause (verified):**
+- `parseTrapSpec` accepts + parses `blocking` — `packages/adapters-cli/src/cli/ak-impl.mjs:847,885-887`.
+- Level layout turns blocking trap cells into non-walkable cells
+  (`packages/runtime/src/personas/configurator/level-layout.js:1320-1325`), applied before trap
+  validation (`:1847`).
+- The same cell is then reported `trap_on_wall` (`:1957-1965`).
+
+**Fix:** pick one contract and enforce it end to end.
+- **(A) Support blocking traps:** exempt blocking-trap cells from the `trap_on_wall` check (a trap
+  *is* the wall here), so the accepted spec actually works.
+- **(B) Reject early:** if blocking traps are unsupported, reject in `parseTrapSpec` with a clear
+  error instead of accepting then failing deep in layout.
+
+**Recommendation:** (A) — the feature is half-built and benchmark scenarios (39 "Blocking Trap
+Choke") want it. If product says no, do (B) so the failure is honest and immediate.
+
+---
+
+## Sequencing
+
+1. **Resolve D1 decision** (A vs B) — it gates D3 and the benchmark's vital assertions.
+2. D2 (additive, isolated) and D4 (localized to trap/layout) — independent, can land first.
+3. D3 (cost-model unification) — land with D1 so the cost model changes once.
+4. After fixes: remove the matching normalizations in `generate-baselines.mjs` (room affinity →
+   hazard, small-room upgrade, blocking→nonblocking) so the suite again tests original intent, then
+   re-run `pnpm benchmark:mcp:generate && pnpm benchmark:mcp:validate` and refresh the vault copy.
+
+## Architecture notes
+
+- D2/D3 are pure `runtime` (allocator/configurator) — no adapter/core boundary crossings.
+- D1 touches the adapter default (`ak-impl.mjs`) and `runtime` (budget-maximizer/orchestrate); the
+  decision should be reflected in `packages/adapters-cli/README.md` if `--maximize-budget` becomes a
+  flag.
+- D4 spans the CLI parser (`ak-impl.mjs`) and `runtime` level-layout; keep the parser permissive only
+  if layout supports it (option A).

--- a/tools/benchmark/generate-baselines.mjs
+++ b/tools/benchmark/generate-baselines.mjs
@@ -1,0 +1,1118 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const ROOT = resolve(process.env.AGENT_KERNEL_ROOT || process.cwd());
+const CLI = join(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+const OUTPUT_DIR = resolve(
+  process.env.AK_BENCHMARK_OUTPUT_DIR || join(ROOT, "tools/benchmark/out"),
+);
+// Kept as VAULT_DIR for downstream references; output may target the vault or a local dir.
+const VAULT_DIR = OUTPUT_DIR;
+const ARTIFACT_ROOT = join(VAULT_DIR, "Reference Artifacts");
+const CREATED_AT = "2026-05-03T17:00:00.000Z";
+const BUDGET = 1500;
+// Non-binding ceiling for budget-UNCONSTRAINED scenarios: the builder spends only
+// what the scenario requires, so injecting new configuration costs never forces a
+// budget bump. Budget-CONSTRAINED scenarios use a tight per-case budgetTokens instead.
+const UNCONSTRAINED_BUDGET = 1_000_000;
+
+// Guard: the Codex rescue sandbox cannot write to the Obsidian vault. When syncing
+// regenerated output into the vault, run this generator OUTSIDE the sandbox (e.g. by the
+// orchestrating Claude/host) with AK_BENCHMARK_OUTPUT_DIR pointed at the vault path.
+const VAULT_PREFIX = process.env.AK_BENCHMARK_VAULT_PREFIX || "/Users/darren/Documents/Obsidian/agent-kernel-vault";
+const ALLOW_VAULT_WRITE = process.env.AK_BENCHMARK_ALLOW_VAULT_WRITE === "1";
+
+if (!ALLOW_VAULT_WRITE && VAULT_PREFIX && VAULT_DIR.startsWith(VAULT_PREFIX)) {
+  throw new Error(
+    `Refusing to write benchmark output under the read-only vault path: ${VAULT_DIR}\n` +
+    `Set AK_BENCHMARK_ALLOW_VAULT_WRITE=1 to override (only when running outside a write-restricted sandbox).`,
+  );
+}
+
+const cases = [
+  {
+    title: "Create Single Delver",
+    task: "create a single fire Delver tuned for attack, with explicit fire affinity, mana, stamina, and health settings",
+    delver: ["count=1;affinity=fire;motivation=attacking;affinities=fire:emit:2;vitals=health:8:1,stamina:6:1,mana:4:1;goals=max_mana:high,mana_regen:medium"],
+  },
+  {
+    title: "Create Single Warden",
+    task: "create a single dark Warden tuned for defense, with explicit dark affinity and durable vitals",
+    warden: ["count=1;affinity=dark;motivation=defending;affinities=dark:emit:2;vitals=health:12:1,stamina:4:1,mana:3:1,durability:6:0"],
+  },
+  {
+    title: "Create Small Dark Room",
+    task: "create one small dark starter room with a localized dark field",
+    room: ["size=small;count=1;affinities=dark:emit:2"],
+    dungeonAffinity: "dark",
+  },
+  {
+    title: "Create Floor Tile Starter Room",
+    task: "create one small starter room with twelve floor tiles and no actors",
+    room: ["size=small;count=1"],
+    floorTile: ["count=12"],
+  },
+  {
+    title: "Create Emit Trap Room",
+    task: "create a small fire trap room with floor tiles and one non-blocking emit trap",
+    room: ["size=small;count=1"],
+    floorTile: ["count=16"],
+    trap: ["x=2;y=2;affinity=fire;expression=emit;stacks=1;blocking=false"],
+    dungeonAffinity: "fire",
+  },
+  {
+    title: "Create Dark Obscuring Trap",
+    task: "create a small room with a dark emit trap strong enough to test darkness stack handling",
+    room: ["size=small;count=1;affinities=dark:emit:1"],
+    floorTile: ["count=16"],
+    trap: ["x=2;y=3;affinity=dark;expression=emit;stacks=2;blocking=false"],
+    dungeonAffinity: "dark",
+  },
+  {
+    title: "Create Two Exploring Delvers",
+    task: "create two water Delvers configured for exploration and sustain",
+    delver: ["count=2;affinity=water;motivation=exploring;affinities=water:draw:1;vitals=health:7:1,stamina:7:1,mana:5:1;goals=max_mana:medium,mana_regen:medium"],
+    dungeonAffinity: "water",
+  },
+  {
+    title: "Create Mixed Delver Pair",
+    task: "create a two-person Delver party with one fire attacker and one life-friendly support Delver",
+    delver: [
+      "count=1;affinity=fire;motivation=attacking;affinities=fire:push:1;vitals=health:9:1,stamina:6:1,mana:4:1",
+      "count=1;affinity=life;motivation=friendly;affinities=life:pull:1;vitals=health:8:2,stamina:5:1,mana:5:1",
+    ],
+  },
+  {
+    title: "Create Warden Patrol Pair",
+    task: "create two earth Wardens configured for patrol and spatial control",
+    warden: ["count=2;affinity=earth;motivation=patrolling;affinities=earth:pull:1;vitals=health:10:1,stamina:6:1,mana:3:1,durability:5:0"],
+    dungeonAffinity: "earth",
+  },
+  {
+    title: "Create Delver Versus Warden Arena",
+    task: "create a medium arena with one fire Delver, one dark Warden, and a dark emit trap",
+    room: ["size=medium;count=1;affinities=dark:emit:1"],
+    floorTile: ["count=20"],
+    trap: ["x=3;y=3;affinity=dark;expression=emit;stacks=1;blocking=false"],
+    delver: ["count=1;affinity=fire;motivation=attacking;affinities=fire:push:1;vitals=health:9:1,stamina:6:1,mana:4:1"],
+    warden: ["count=1;affinity=dark;motivation=defending;affinities=dark:emit:2;vitals=health:11:1,stamina:4:1,mana:4:1,durability:6:0"],
+  },
+  {
+    title: "Create Fire Trial Room",
+    task: "create a large fire trial room with two emit traps and a water Delver counter-pick",
+    room: ["size=large;count=1;affinities=fire:emit:2"],
+    floorTile: ["count=24"],
+    trap: [
+      "x=2;y=2;affinity=fire;expression=emit;stacks=1;blocking=false",
+      "x=4;y=4;affinity=fire;expression=emit;stacks=2;blocking=false",
+    ],
+    delver: ["count=1;affinity=water;motivation=exploring;affinities=water:draw:1;vitals=health:8:1,stamina:7:1,mana:5:1"],
+    dungeonAffinity: "fire",
+  },
+  {
+    title: "Create Water Recovery Room",
+    task: "create a water-themed recovery encounter with a life support Delver and a water mana hazard",
+    room: ["size=medium;count=1;affinities=water:emit:1"],
+    floorTile: ["count=18"],
+    hazard: ["affinity=water;expression=emit;proximityRadius=2;mana=regen:4:4:1"],
+    delver: ["count=1;affinity=life;motivation=friendly;affinities=life:pull:1,water:draw:1;vitals=health:8:2,stamina:5:1,mana:6:1"],
+    dungeonAffinity: "water",
+  },
+  {
+    title: "Create Earth Barrier Ambush",
+    task: "create an earth ambush room with an earth emit trap and a fortify Warden",
+    room: ["size=medium;count=1;affinities=earth:emit:2"],
+    floorTile: ["count=18"],
+    trap: ["x=3;y=2;affinity=earth;expression=emit;stacks=2;blocking=true"],
+    warden: ["count=1;affinity=fortify;motivation=defending;affinities=fortify:emit:2;vitals=health:13:1,stamina:4:1,mana:3:1,durability:8:0"],
+    dungeonAffinity: "earth",
+  },
+  {
+    title: "Create Wind Patrol Corridor",
+    task: "create two medium wind patrol rooms with a wind Warden and an earth Delver",
+    room: ["size=medium;count=2;affinities=wind:emit:1"],
+    floorTile: ["count=24"],
+    warden: ["count=1;affinity=wind;motivation=patrolling;affinities=wind:push:1;vitals=health:9:1,stamina:7:1,mana:4:1,durability:4:0"],
+    delver: ["count=1;affinity=earth;motivation=exploring;affinities=earth:pull:1;vitals=health:9:1,stamina:6:1,mana:4:1"],
+    dungeonAffinity: "wind",
+  },
+  {
+    title: "Create Life Shrine Encounter",
+    task: "create a life shrine room with a permanent vital regen resource and opposing decay Warden",
+    room: ["size=small;count=1;affinities=life:emit:1"],
+    floorTile: ["count=14"],
+    resource: ["tier=permanent;stat=vitalRegen;delta=1;dropRate=10"],
+    delver: ["count=1;affinity=life;motivation=friendly;affinities=life:pull:2;vitals=health:9:2,stamina:5:1,mana:5:1"],
+    warden: ["count=1;affinity=decay;motivation=stationary;affinities=decay:emit:1;vitals=health:10:0,stamina:3:0,mana:4:1,durability:5:0"],
+    dungeonAffinity: "life",
+  },
+  {
+    title: "Create Decay Hazard Cell",
+    task: "create a decay cell with a decay mana hazard and a defending decay Warden",
+    room: ["size=small;count=1;affinities=decay:emit:2"],
+    floorTile: ["count=12"],
+    hazard: ["affinity=decay;expression=emit;proximityRadius=2;mana=regen:3:3:1"],
+    warden: ["count=1;affinity=decay;motivation=defending;affinities=decay:emit:2;vitals=health:10:0,stamina:4:1,mana:4:1,durability:5:0"],
+    dungeonAffinity: "decay",
+  },
+  {
+    title: "Create Corrode Resource Cache",
+    task: "create a corrode-themed cache with a level affinity stack resource and stealth Delver",
+    room: ["size=medium;count=1;affinities=corrode:emit:1"],
+    floorTile: ["count=14"],
+    resource: ["tier=level;stat=affinityStack;delta=1;dropRate=15"],
+    delver: ["count=1;affinity=corrode;motivation=stealthy;affinities=corrode:emit:2;vitals=health:7:1,stamina:8:1,mana:4:1"],
+    dungeonAffinity: "corrode",
+  },
+  {
+    title: "Create Fortify Guard Post",
+    task: "create a fortify guard post with a blocking fortify emit trap and one defensive Warden",
+    room: ["size=medium;count=1;affinities=fortify:emit:2"],
+    floorTile: ["count=18"],
+    trap: ["x=2;y=4;affinity=fortify;expression=emit;stacks=2;blocking=true;vitals=mana:4:1,durability:6:0"],
+    warden: ["count=1;affinity=fortify;motivation=defending;affinities=fortify:emit:2;vitals=health:12:1,stamina:4:1,mana:4:1,durability:8:0"],
+    dungeonAffinity: "fortify",
+  },
+  {
+    title: "Create Light Scout Entry",
+    task: "create a light scout entry room that counters a dark trap",
+    room: ["size=small;count=1;affinities=light:emit:1"],
+    floorTile: ["count=12"],
+    trap: ["x=2;y=2;affinity=dark;expression=emit;stacks=2;blocking=false"],
+    delver: ["count=1;affinity=light;motivation=exploring;affinities=light:emit:1;vitals=health:8:1,stamina:7:1,mana:5:1"],
+    dungeonAffinity: "light",
+  },
+  {
+    title: "Create Dark Sentinel Entry",
+    task: "create a dark sentinel room with a stationary dark Warden and darkness pressure",
+    room: ["size=small;count=1;affinities=dark:emit:2"],
+    floorTile: ["count=12"],
+    trap: ["x=3;y=3;affinity=dark;expression=emit;stacks=2;blocking=false"],
+    warden: ["count=1;affinity=dark;motivation=stationary;affinities=dark:emit:3;vitals=health:11:0,stamina:3:0,mana:5:1,durability:6:0"],
+    dungeonAffinity: "dark",
+  },
+  {
+    title: "Create Balanced Three Actors",
+    task: "create a balanced medium encounter with fire, water, and earth actors",
+    room: ["size=medium;count=1;affinities=earth:emit:1"],
+    floorTile: ["count=20"],
+    delver: [
+      "count=1;affinity=fire;motivation=attacking;affinities=fire:push:1;vitals=health:8:1,stamina:6:1,mana:4:1",
+      "count=1;affinity=water;motivation=exploring;affinities=water:draw:1;vitals=health:8:1,stamina:6:1,mana:5:1",
+    ],
+    warden: ["count=1;affinity=earth;motivation=defending;affinities=earth:pull:1;vitals=health:11:1,stamina:4:1,mana:3:1,durability:5:0"],
+  },
+  {
+    title: "Create Four Delver Squad",
+    task: "create a four-Delver wind squad for party-scaling tests",
+    room: ["size=large;count=1;affinities=wind:emit:1"],
+    floorTile: ["count=25"],
+    delver: ["count=4;affinity=wind;motivation=exploring;affinities=wind:push:1;vitals=health:7:1,stamina:7:1,mana:4:1"],
+    dungeonAffinity: "wind",
+  },
+  {
+    title: "Create Three Wardens Defense",
+    task: "create a three-Warden dark defense for actor-count scaling",
+    room: ["size=large;count=1;affinities=dark:emit:2"],
+    floorTile: ["count=25"],
+    warden: ["count=3;affinity=dark;motivation=defending;affinities=dark:emit:2;vitals=health:10:1,stamina:4:1,mana:4:1,durability:5:0"],
+    dungeonAffinity: "dark",
+  },
+  {
+    title: "Create Mixed Affinity Boss Room",
+    task: "create a large boss room with light Delver pressure against a strategy-focused dark Warden",
+    room: ["size=large;count=1;affinities=dark:emit:3,light:emit:1"],
+    floorTile: ["count=28"],
+    trap: ["x=3;y=3;affinity=dark;expression=emit;stacks=2;blocking=false"],
+    hazard: ["affinity=decay;expression=emit;proximityRadius=2;mana=regen:4:4:1"],
+    delver: ["count=1;affinity=light;motivation=attacking;affinities=light:emit:2;vitals=health:10:1,stamina:7:1,mana:6:1"],
+    warden: ["count=1;affinity=dark;motivation=strategy_focused;affinities=dark:emit:3,decay:emit:1;vitals=health:16:1,stamina:5:1,mana:7:1,durability:9:0"],
+    dungeonAffinity: "dark",
+  },
+  {
+    title: "Create Trap Gauntlet",
+    task: "create a gauntlet with four non-blocking emit traps and one stealth Delver",
+    room: ["size=large;count=2;affinities=fire:emit:1,dark:emit:1"],
+    floorTile: ["count=32"],
+    trap: [
+      "x=1;y=1;affinity=fire;expression=emit;stacks=1;blocking=false",
+      "x=2;y=2;affinity=dark;expression=emit;stacks=2;blocking=false",
+      "x=3;y=3;affinity=decay;expression=emit;stacks=1;blocking=false",
+      "x=4;y=4;affinity=corrode;expression=emit;stacks=1;blocking=false",
+    ],
+    delver: ["count=1;affinity=light;motivation=stealthy;affinities=light:emit:1;vitals=health:8:1,stamina:8:1,mana:5:1"],
+  },
+  {
+    title: "Create Hazard Gauntlet",
+    task: "create a hazard gauntlet with fire, water, and decay mana zones",
+    room: ["size=large;count=1;affinities=fire:emit:1,water:emit:1,decay:emit:1"],
+    floorTile: ["count=28"],
+    hazard: [
+      "affinity=fire;expression=emit;proximityRadius=1;mana=regen:3:3:1",
+      "affinity=water;expression=emit;proximityRadius=1;mana=regen:3:3:1",
+      "affinity=decay;expression=emit;proximityRadius=2;mana=regen:4:4:1",
+    ],
+    delver: ["count=1;affinity=fortify;motivation=defending;affinities=fortify:emit:1;vitals=health:10:1,stamina:5:1,mana:4:1"],
+  },
+  {
+    title: "Create Resource Heavy Shrine",
+    task: "create a shrine room with multiple resources and one friendly life Delver",
+    room: ["size=medium;count=1;affinities=life:emit:2"],
+    floorTile: ["count=18"],
+    resource: [
+      "tier=permanent;stat=vitalMax;delta=6;dropRate=5",
+      "tier=level;stat=vitalRegen;delta=1;dropRate=20",
+      "tier=level;stat=affinityStack;delta=1;dropRate=15",
+    ],
+    delver: ["count=1;affinity=life;motivation=friendly;affinities=life:pull:2;vitals=health:9:2,stamina:5:1,mana:5:1"],
+    dungeonAffinity: "life",
+  },
+  {
+    title: "Create Opposed Fire Water Room",
+    task: "create a room that pits fire attack pressure against water sustain",
+    room: ["size=medium;count=1;affinities=fire:emit:1,water:emit:1"],
+    floorTile: ["count=20"],
+    trap: ["x=2;y=2;affinity=fire;expression=emit;stacks=2;blocking=false"],
+    delver: ["count=1;affinity=water;motivation=exploring;affinities=water:draw:2;vitals=health:8:1,stamina:6:1,mana:6:1"],
+    warden: ["count=1;affinity=fire;motivation=attacking;affinities=fire:push:1;vitals=health:10:1,stamina:5:1,mana:5:1,durability:5:0"],
+  },
+  {
+    title: "Create Opposed Earth Wind Room",
+    task: "create a room that tests earth and wind opposition through actors and room affinity",
+    room: ["size=medium;count=1;affinities=earth:emit:1,wind:emit:1"],
+    floorTile: ["count=20"],
+    delver: ["count=1;affinity=wind;motivation=exploring;affinities=wind:push:2;vitals=health:8:1,stamina:8:1,mana:5:1"],
+    warden: ["count=1;affinity=earth;motivation=patrolling;affinities=earth:pull:2;vitals=health:11:1,stamina:5:1,mana:4:1,durability:5:0"],
+  },
+  {
+    title: "Create Opposed Life Decay Room",
+    task: "create a room that tests life support against decay pressure",
+    room: ["size=medium;count=1;affinities=life:emit:1,decay:emit:1"],
+    floorTile: ["count=20"],
+    hazard: ["affinity=decay;expression=emit;proximityRadius=2;mana=regen:4:4:1"],
+    delver: ["count=1;affinity=life;motivation=friendly;affinities=life:pull:2;vitals=health:10:2,stamina:5:1,mana:5:1"],
+    warden: ["count=1;affinity=decay;motivation=attacking;affinities=decay:emit:2;vitals=health:10:0,stamina:5:1,mana:5:1,durability:5:0"],
+  },
+  {
+    title: "Create Opposed Light Dark Room",
+    task: "create a room that tests light visibility against dark obscuring pressure",
+    room: ["size=medium;count=1;affinities=light:emit:1,dark:emit:2"],
+    floorTile: ["count=20"],
+    trap: ["x=3;y=3;affinity=dark;expression=emit;stacks=2;blocking=false"],
+    delver: ["count=1;affinity=light;motivation=exploring;affinities=light:emit:2;vitals=health:8:1,stamina:7:1,mana:6:1"],
+    warden: ["count=1;affinity=dark;motivation=defending;affinities=dark:emit:2;vitals=health:11:1,stamina:4:1,mana:5:1,durability:6:0"],
+  },
+  {
+    title: "Create Random Movement Lab",
+    task: "create a small room with randomly moving fire and water actors",
+    room: ["size=small;count=1"],
+    floorTile: ["count=16"],
+    delver: ["count=1;affinity=fire;motivation=random;affinities=fire:emit:1;vitals=health:7:1,stamina:7:1,mana:4:1"],
+    warden: ["count=1;affinity=water;motivation=random;affinities=water:draw:1;vitals=health:9:1,stamina:5:1,mana:4:1,durability:4:0"],
+  },
+  {
+    title: "Create Stationary Puzzle Room",
+    task: "create a stationary puzzle room with one trap and two stationary Wardens",
+    room: ["size=medium;count=1;affinities=fortify:emit:1"],
+    floorTile: ["count=18"],
+    trap: ["x=2;y=3;affinity=fortify;expression=emit;stacks=1;blocking=true"],
+    warden: ["count=2;affinity=fortify;motivation=stationary;affinities=fortify:emit:1;vitals=health:10:0,stamina:3:0,mana:3:1,durability:7:0"],
+    dungeonAffinity: "fortify",
+  },
+  {
+    title: "Create Stealth Infiltration Room",
+    task: "create a dark infiltration room with stealth Delver and patrolling Warden",
+    room: ["size=medium;count=1;affinities=dark:emit:2"],
+    floorTile: ["count=18"],
+    trap: ["x=3;y=2;affinity=dark;expression=emit;stacks=2;blocking=false"],
+    delver: ["count=1;affinity=dark;motivation=stealthy;affinities=dark:emit:1;vitals=health:7:1,stamina:8:1,mana:4:1"],
+    warden: ["count=1;affinity=light;motivation=patrolling;affinities=light:emit:1;vitals=health:10:1,stamina:6:1,mana:4:1,durability:4:0"],
+  },
+  {
+    title: "Create Friendly Rescue Room",
+    task: "create a rescue room with friendly and defending actors around a life resource",
+    room: ["size=medium;count=1;affinities=life:emit:1"],
+    floorTile: ["count=18"],
+    resource: ["tier=level;stat=vitalMax;delta=4;dropRate=25"],
+    delver: ["count=1;affinity=life;motivation=friendly;affinities=life:pull:1;vitals=health:8:2,stamina:5:1,mana:5:1"],
+    warden: ["count=1;affinity=fortify;motivation=defending;affinities=fortify:emit:1;vitals=health:12:1,stamina:4:1,mana:4:1,durability:7:0"],
+  },
+  {
+    title: "Create Reflexive Actor Test",
+    task: "create a reflexive dark Warden test case with a simple Delver opponent",
+    room: ["size=small;count=1;affinities=dark:emit:1"],
+    floorTile: ["count=14"],
+    delver: ["count=1;affinity=fire;motivation=attacking;affinities=fire:push:1;vitals=health:8:1,stamina:6:1,mana:4:1"],
+    warden: ["count=1;affinity=dark;motivation=reflexive;affinities=dark:emit:1;vitals=health:10:1,stamina:4:1,mana:4:1,durability:5:0"],
+  },
+  {
+    title: "Create Goal Oriented Actor Test",
+    task: "create a goal-oriented wind Delver test case with one guarding Warden",
+    room: ["size=medium;count=1;affinities=wind:emit:1"],
+    floorTile: ["count=18"],
+    delver: ["count=1;affinity=wind;motivation=goal_oriented;affinities=wind:push:1;vitals=health:8:1,stamina:8:1,mana:5:1"],
+    warden: ["count=1;affinity=earth;motivation=defending;affinities=earth:pull:1;vitals=health:11:1,stamina:4:1,mana:4:1,durability:5:0"],
+  },
+  {
+    title: "Create Strategy Warden Test",
+    task: "create a strategy-focused Warden test case with layered dark and decay pressure",
+    room: ["size=medium;count=1;affinities=dark:emit:2,decay:emit:1"],
+    floorTile: ["count=20"],
+    hazard: ["affinity=decay;expression=emit;proximityRadius=2;mana=regen:4:4:1"],
+    delver: ["count=1;affinity=light;motivation=attacking;affinities=light:emit:1;vitals=health:9:1,stamina:7:1,mana:5:1"],
+    warden: ["count=1;affinity=dark;motivation=strategy_focused;affinities=dark:emit:2,decay:emit:1;vitals=health:14:1,stamina:5:1,mana:6:1,durability:8:0"],
+  },
+  {
+    title: "Create User Setup Delver",
+    task: "create a Delver configured with user setup mode so agents must preserve setup-mode in the request",
+    room: ["size=small;count=1"],
+    floorTile: ["count=12"],
+    delver: ["count=1;affinity=fire;motivation=attacking;setup-mode=user;affinities=fire:push:2;vitals=health:9:1,stamina:6:1,mana:5:1"],
+    warden: ["count=1;affinity=dark;motivation=defending;affinities=dark:emit:1;vitals=health:10:1,stamina:4:1,mana:4:1,durability:5:0"],
+  },
+  {
+    title: "Create Hybrid Setup Delver",
+    task: "create a Delver configured with hybrid setup mode and two affinities",
+    room: ["size=medium;count=1;affinities=water:emit:1"],
+    floorTile: ["count=18"],
+    delver: ["count=1;affinity=water;motivation=exploring;setup-mode=hybrid;affinities=water:draw:2,life:pull:1;vitals=health:8:2,stamina:6:1,mana:6:1"],
+    dungeonAffinity: "water",
+  },
+  {
+    title: "Create Auto Setup Delver",
+    task: "create an auto setup Delver and compare the generated artifacts against explicit user and hybrid setup cases",
+    room: ["size=small;count=1;affinities=earth:emit:1"],
+    floorTile: ["count=14"],
+    delver: ["count=1;affinity=earth;motivation=exploring;setup-mode=auto;affinities=earth:pull:1;vitals=health:9:1,stamina:6:1,mana:4:1"],
+    warden: ["count=1;affinity=wind;motivation=patrolling;affinities=wind:push:1;vitals=health:9:1,stamina:6:1,mana:4:1,durability:4:0"],
+  },
+  {
+    title: "Create Max Mana Goal Delver",
+    task: "create a Delver with explicit max_mana and mana_regen optimization goals",
+    room: ["size=small;count=1"],
+    floorTile: ["count=12"],
+    delver: ["count=1;affinity=fire;motivation=attacking;affinities=fire:emit:1;vitals=health:8:1,stamina:6:1,mana:6:2;goals=max_mana:high,mana_regen:high"],
+  },
+  {
+    title: "Create Mana Regen Goal Squad",
+    task: "create a two-Delver squad with mana regeneration goals and mixed water and life affinity",
+    room: ["size=medium;count=1;affinities=water:emit:1,life:emit:1"],
+    floorTile: ["count=18"],
+    delver: [
+      "count=1;affinity=water;motivation=exploring;affinities=water:draw:2;vitals=health:8:1,stamina:6:1,mana:6:2;goals=mana_regen:high",
+      "count=1;affinity=life;motivation=friendly;affinities=life:pull:2;vitals=health:8:2,stamina:5:1,mana:5:1;goals=max_mana:medium,mana_regen:medium",
+    ],
+  },
+  {
+    title: "Create Blocking Trap Choke",
+    task: "create a choke room with a blocking trap and one patrolling Warden",
+    room: ["size=medium;count=1;affinities=earth:emit:1"],
+    floorTile: ["count=18"],
+    trap: ["x=2;y=2;affinity=earth;expression=emit;stacks=2;blocking=true;vitals=mana:4:1,durability:8:0"],
+    delver: ["count=1;affinity=wind;motivation=exploring;affinities=wind:push:1;vitals=health:8:1,stamina:8:1,mana:4:1"],
+    warden: ["count=1;affinity=earth;motivation=patrolling;affinities=earth:pull:1;vitals=health:11:1,stamina:5:1,mana:4:1,durability:5:0"],
+  },
+  {
+    title: "Create Nonblocking Trap Field",
+    task: "create a trap field with three non-blocking emit traps and a light scout",
+    room: ["size=large;count=1;affinities=dark:emit:1"],
+    floorTile: ["count=28"],
+    trap: [
+      "x=1;y=2;affinity=dark;expression=emit;stacks=1;blocking=false",
+      "x=2;y=3;affinity=fire;expression=emit;stacks=1;blocking=false",
+      "x=3;y=4;affinity=corrode;expression=emit;stacks=1;blocking=false",
+    ],
+    delver: ["count=1;affinity=light;motivation=exploring;affinities=light:emit:1;vitals=health:8:1,stamina:7:1,mana:5:1"],
+  },
+  {
+    title: "Create Trap Vital Budget Test",
+    task: "create a trap with explicit mana and durability vitals so the cost receipt shows trap vital spend",
+    room: ["size=small;count=1;affinities=fire:emit:1"],
+    floorTile: ["count=14"],
+    trap: ["x=2;y=2;affinity=fire;expression=emit;stacks=2;blocking=false;vitals=mana:6:2,durability:9:0"],
+    dungeonAffinity: "fire",
+  },
+  {
+    title: "Create Hazard Mana Budget Test",
+    task: "create a hazard with explicit mana reserve and regeneration so the cost receipt shows hazard mana spend",
+    room: ["size=small;count=1;affinities=water:emit:1"],
+    floorTile: ["count=14"],
+    hazard: ["affinity=water;expression=emit;proximityRadius=2;mana=regen:6:6:2"],
+    dungeonAffinity: "water",
+  },
+  {
+    title: "Create Multi Room Delver Route",
+    task: "create three connected rooms with one exploring Delver route baseline",
+    room: ["size=medium;count=3;affinities=wind:emit:1"],
+    floorTile: ["count=36"],
+    delver: ["count=1;affinity=wind;motivation=exploring;affinities=wind:push:1;vitals=health:8:1,stamina:8:1,mana:4:1"],
+    dungeonAffinity: "wind",
+  },
+  {
+    title: "Create Multi Room Warden Route",
+    task: "create three connected rooms with patrolling Wardens and a trap checkpoint",
+    room: ["size=medium;count=3;affinities=earth:emit:1"],
+    floorTile: ["count=36"],
+    trap: ["x=3;y=3;affinity=earth;expression=emit;stacks=1;blocking=true"],
+    warden: ["count=2;affinity=earth;motivation=patrolling;affinities=earth:pull:1;vitals=health:10:1,stamina:6:1,mana:4:1,durability:5:0"],
+    dungeonAffinity: "earth",
+  },
+  {
+    title: "Create Multi Room Balanced Encounter",
+    task: "create three rooms with two Delvers, two Wardens, and a balanced light-dark trap mix",
+    room: ["size=medium;count=3;affinities=light:emit:1,dark:emit:1"],
+    floorTile: ["count=36"],
+    trap: [
+      "x=2;y=2;affinity=dark;expression=emit;stacks=2;blocking=false",
+      "x=4;y=3;affinity=light;expression=emit;stacks=1;blocking=false",
+    ],
+    delver: [
+      "count=1;affinity=light;motivation=exploring;affinities=light:emit:1;vitals=health:8:1,stamina:7:1,mana:5:1",
+      "count=1;affinity=fire;motivation=attacking;affinities=fire:push:1;vitals=health:8:1,stamina:6:1,mana:4:1",
+    ],
+    warden: [
+      "count=1;affinity=dark;motivation=defending;affinities=dark:emit:2;vitals=health:11:1,stamina:4:1,mana:5:1,durability:6:0",
+      "count=1;affinity=water;motivation=patrolling;affinities=water:draw:1;vitals=health:10:1,stamina:5:1,mana:5:1,durability:5:0",
+    ],
+  },
+  {
+    title: "Create Large Dark Maze",
+    task: "create a large dark maze-style level baseline with multiple dark traps and one light scout",
+    room: ["size=large;count=3;affinities=dark:emit:3"],
+    floorTile: ["count=45"],
+    trap: [
+      "x=1;y=1;affinity=dark;expression=emit;stacks=2;blocking=false",
+      "x=2;y=4;affinity=dark;expression=emit;stacks=2;blocking=false",
+      "x=4;y=2;affinity=dark;expression=emit;stacks=2;blocking=false",
+    ],
+    delver: ["count=1;affinity=light;motivation=exploring;affinities=light:emit:2;vitals=health:9:1,stamina:8:1,mana:6:1"],
+    warden: ["count=2;affinity=dark;motivation=patrolling;affinities=dark:emit:2;vitals=health:10:1,stamina:5:1,mana:5:1,durability:5:0"],
+    dungeonAffinity: "dark",
+  },
+  {
+    title: "Create Large Fire Arena",
+    task: "create a large fire arena with fire traps, a water Delver, and a fire Warden",
+    room: ["size=large;count=2;affinities=fire:emit:2"],
+    floorTile: ["count=40"],
+    trap: [
+      "x=2;y=2;affinity=fire;expression=emit;stacks=2;blocking=false",
+      "x=4;y=4;affinity=fire;expression=emit;stacks=2;blocking=false",
+    ],
+    hazard: ["affinity=fire;expression=emit;proximityRadius=2;mana=regen:5:5:1"],
+    delver: ["count=1;affinity=water;motivation=attacking;affinities=water:draw:2;vitals=health:10:1,stamina:7:1,mana:6:1"],
+    warden: ["count=1;affinity=fire;motivation=strategy_focused;affinities=fire:push:2;vitals=health:14:1,stamina:5:1,mana:7:1,durability:7:0"],
+    dungeonAffinity: "fire",
+  },
+  {
+    title: "Create Large Resource Dungeon",
+    task: "create a large dungeon with several resources and mixed actors",
+    room: ["size=large;count=2;affinities=life:emit:1,fortify:emit:1"],
+    floorTile: ["count=38"],
+    resource: [
+      "tier=permanent;stat=vitalMax;delta=8;dropRate=5",
+      "tier=level;stat=vitalRegen;delta=1;dropRate=15",
+      "tier=level;stat=affinityStack;delta=1;dropRate=20",
+    ],
+    delver: [
+      "count=1;affinity=life;motivation=friendly;affinities=life:pull:2;vitals=health:9:2,stamina:5:1,mana:5:1",
+      "count=1;affinity=fire;motivation=attacking;affinities=fire:push:1;vitals=health:8:1,stamina:6:1,mana:4:1",
+    ],
+    warden: ["count=1;affinity=fortify;motivation=defending;affinities=fortify:emit:2;vitals=health:13:1,stamina:4:1,mana:4:1,durability:8:0"],
+    dungeonAffinity: "life",
+  },
+  {
+    title: "Create Cross Affinity Dungeon",
+    task: "create a dungeon that includes every affinity family at least once across rooms, traps, hazards, and actors",
+    room: ["size=large;count=2;affinities=fire:emit:1,water:emit:1,earth:emit:1,wind:emit:1,life:emit:1,decay:emit:1,light:emit:1,dark:emit:1"],
+    floorTile: ["count=40"],
+    trap: [
+      "x=1;y=1;affinity=corrode;expression=emit;stacks=1;blocking=false",
+      "x=2;y=2;affinity=fortify;expression=emit;stacks=1;blocking=true",
+    ],
+    hazard: ["affinity=decay;expression=emit;proximityRadius=2;mana=regen:4:4:1"],
+    delver: [
+      "count=1;affinity=fire;motivation=attacking;affinities=fire:push:1,wind:push:1;vitals=health:8:1,stamina:7:1,mana:5:1",
+      "count=1;affinity=life;motivation=friendly;affinities=life:pull:1,water:draw:1;vitals=health:8:2,stamina:5:1,mana:5:1",
+    ],
+    warden: [
+      "count=1;affinity=dark;motivation=defending;affinities=dark:emit:2,decay:emit:1;vitals=health:12:1,stamina:4:1,mana:5:1,durability:6:0",
+      "count=1;affinity=earth;motivation=patrolling;affinities=earth:pull:1,fortify:emit:1;vitals=health:11:1,stamina:5:1,mana:4:1,durability:6:0",
+    ],
+  },
+  {
+    title: "Create Minimal Budget Comparison",
+    task: "create a deliberately minimal level with one room, one floor tile batch, and no actors for budget comparison",
+    room: ["size=small;count=1"],
+    floorTile: ["count=5"],
+  },
+  {
+    title: "Create Actor Only Comparison",
+    task: "create actor-only artifacts with one Delver and one Warden and no explicit room request",
+    delver: ["count=1;affinity=fire;motivation=attacking;affinities=fire:emit:1;vitals=health:8:1,stamina:6:1,mana:4:1"],
+    warden: ["count=1;affinity=dark;motivation=defending;affinities=dark:emit:1;vitals=health:10:1,stamina:4:1,mana:4:1,durability:5:0"],
+  },
+  {
+    title: "Create Room Only Comparison",
+    task: "create room-only artifacts with two medium rooms and explicit dark affinity but no actors",
+    room: ["size=medium;count=2;affinities=dark:emit:2"],
+    floorTile: ["count=20"],
+    dungeonAffinity: "dark",
+  },
+  {
+    title: "Create Full Evaluation Dungeon",
+    task: "create a full evaluation dungeon with multiple rooms, traps, hazards, resources, Delvers, and Wardens",
+    room: ["size=large;count=3;affinities=fire:emit:1,water:emit:1,earth:emit:1,dark:emit:2"],
+    floorTile: ["count=48"],
+    trap: [
+      "x=1;y=1;affinity=fire;expression=emit;stacks=2;blocking=false",
+      "x=2;y=2;affinity=earth;expression=emit;stacks=2;blocking=true",
+      "x=3;y=3;affinity=dark;expression=emit;stacks=2;blocking=false",
+      "x=4;y=4;affinity=fortify;expression=emit;stacks=1;blocking=true",
+    ],
+    hazard: [
+      "affinity=water;expression=emit;proximityRadius=2;mana=regen:5:5:1",
+      "affinity=decay;expression=emit;proximityRadius=2;mana=regen:4:4:1",
+    ],
+    resource: [
+      "tier=permanent;stat=vitalMax;delta=6;dropRate=5",
+      "tier=level;stat=affinityStack;delta=1;dropRate=20",
+    ],
+    delver: [
+      "count=1;affinity=fire;motivation=attacking;setup-mode=user;affinities=fire:push:2;vitals=health:10:1,stamina:7:1,mana:6:1",
+      "count=1;affinity=life;motivation=friendly;setup-mode=hybrid;affinities=life:pull:2,water:draw:1;vitals=health:9:2,stamina:5:1,mana:6:1",
+      "count=1;affinity=light;motivation=exploring;affinities=light:emit:2;vitals=health:8:1,stamina:8:1,mana:5:1",
+    ],
+    warden: [
+      "count=1;affinity=dark;motivation=strategy_focused;affinities=dark:emit:3,decay:emit:1;vitals=health:16:1,stamina:5:1,mana:7:1,durability:9:0",
+      "count=1;affinity=earth;motivation=patrolling;affinities=earth:pull:2,fortify:emit:1;vitals=health:12:1,stamina:6:1,mana:5:1,durability:7:0",
+      "count=1;affinity=water;motivation=defending;affinities=water:draw:1;vitals=health:12:1,stamina:5:1,mana:6:1,durability:6:0",
+    ],
+  },
+  {
+    title: "Create Stationary Warden Trap Room",
+    task: "create a puzzle-style trap room where wardens hold stationary positions guarding trap zones, with blocking traps at key choke points and an exploring Delver",
+    budgetMode: "constrained",
+    budgetTokens: 500,
+    room: ["size=medium;count=1"],
+    trap: [
+      "x=2;y=1;affinity=fire;expression=emit;stacks=3;blocking=true",
+      "x=4;y=1;affinity=dark;expression=emit;stacks=2;blocking=true",
+    ],
+    delver: ["count=1;affinity=light;motivation=exploring"],
+    warden: [
+      "count=1;affinity=fire;motivation=stationary",
+      "count=1;affinity=dark;motivation=stationary",
+    ],
+  },
+  {
+    title: "Create Resource Capture Dungeon",
+    task: "create a resource-capture dungeon where a Delver collects level-up resources while avoiding fire traps guarded by a defending Warden",
+    budgetMode: "constrained",
+    budgetTokens: 600,
+    room: ["size=medium;count=1"],
+    trap: [
+      "x=3;y=1;affinity=fire;expression=emit;stacks=2;blocking=false",
+      "x=5;y=1;affinity=earth;expression=emit;stacks=1;blocking=false",
+    ],
+    resource: [
+      "tier=level;stat=vitalMax;delta=10;dropRate=50",
+      "tier=permanent;stat=affinityStack;delta=1;dropRate=20",
+    ],
+    delver: ["count=1;affinity=fire;motivation=attacking"],
+    warden: ["count=1;affinity=dark;motivation=defending"],
+  },
+  {
+    title: "Create Tick Session Ready Dungeon",
+    task: "create a tick-session-ready dungeon with an exploring Delver, a stationary Warden, a fire trap emitting affinity stacks, and a level resource pickup",
+    budgetMode: "constrained",
+    budgetTokens: 500,
+    room: ["size=medium;count=1"],
+    trap: ["x=3;y=1;affinity=fire;expression=emit;stacks=3;blocking=false"],
+    resource: ["tier=level;stat=vitalMax;delta=10;dropRate=50"],
+    delver: ["count=1;affinity=fire;motivation=exploring"],
+    warden: ["count=1;affinity=dark;motivation=stationary"],
+  },
+  {
+    title: "Create Mixed Motivation Encounter",
+    task: "create a mixed-motivation encounter with one exploring Delver, one attacking Delver, one defending Warden, one stationary Warden, and a dark-affinity hazard",
+    budgetMode: "constrained",
+    budgetTokens: 500,
+    room: ["size=medium;count=1"],
+    hazard: ["affinity=dark;expression=emit;proximityRadius=2;mana=regen:3:3:1"],
+    delver: [
+      "count=1;affinity=fire;motivation=exploring",
+      "count=1;affinity=light;motivation=attacking",
+    ],
+    warden: [
+      "count=1;affinity=dark;motivation=defending",
+      "count=1;affinity=earth;motivation=stationary",
+    ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // Budget-CONSTRAINED baselines — base rooms + base actors only.
+  //
+  // Minimal configuration (no explicit affinities=/vitals=/goals=) keeps the cost
+  // dominated by stable base prices: a room is ~0t (tiles are the room cost surface),
+  // and a base actor is ~45-50t (spawn 5 + motivation 2-3 + one base affinity ~35 +
+  // default vitals). The tight per-case budgets below sit ~2-3x above that base, so
+  // they stay valid as configuration costs grow elsewhere — no budget bumps needed.
+  // ---------------------------------------------------------------------------
+  {
+    title: "Constrained Single Delver Room",
+    task: "create a base room with a single exploring delver and no extra configuration",
+    budgetMode: "constrained",
+    budgetTokens: 250,
+    room: ["size=small;count=1"],
+    delver: ["count=1;affinity=fire;motivation=exploring"],
+  },
+  {
+    title: "Constrained Single Warden Room",
+    task: "create a base room with a single defending warden and no extra configuration",
+    budgetMode: "constrained",
+    budgetTokens: 150,
+    room: ["size=small;count=1"],
+    warden: ["count=1;affinity=dark;motivation=defending"],
+  },
+  {
+    title: "Constrained Delver Versus Warden",
+    task: "create a base room with one attacking delver and one defending warden",
+    budgetMode: "constrained",
+    budgetTokens: 350,
+    room: ["size=medium;count=1"],
+    delver: ["count=1;affinity=fire;motivation=attacking"],
+    warden: ["count=1;affinity=dark;motivation=defending"],
+  },
+  {
+    title: "Constrained Two Delver Party",
+    task: "create a base room with two exploring delvers",
+    budgetMode: "constrained",
+    budgetTokens: 400,
+    room: ["size=medium;count=1"],
+    delver: ["count=2;affinity=water;motivation=exploring"],
+  },
+  {
+    title: "Constrained Two Warden Patrol",
+    task: "create a base room with two patrolling wardens",
+    budgetMode: "constrained",
+    budgetTokens: 300,
+    room: ["size=medium;count=1"],
+    warden: ["count=2;affinity=earth;motivation=patrolling"],
+  },
+  {
+    title: "Constrained Four Actor Encounter",
+    task: "create a base room with two attacking delvers and two defending wardens",
+    budgetMode: "constrained",
+    budgetTokens: 550,
+    room: ["size=medium;count=1"],
+    delver: ["count=2;affinity=fire;motivation=attacking"],
+    warden: ["count=2;affinity=dark;motivation=defending"],
+  },
+  {
+    title: "Constrained Two Room Delver Route",
+    task: "create two base rooms with a single exploring delver",
+    budgetMode: "constrained",
+    budgetTokens: 300,
+    room: ["size=small;count=2"],
+    delver: ["count=1;affinity=wind;motivation=exploring"],
+  },
+  {
+    title: "Constrained Floor Tile Guard Room",
+    task: "create a base room with twelve floor tiles and one stationary warden",
+    budgetMode: "constrained",
+    budgetTokens: 250,
+    room: ["size=medium;count=1"],
+    floorTile: ["count=12"],
+    warden: ["count=1;affinity=fortify;motivation=stationary"],
+  },
+  {
+    title: "Constrained Trap Defense Room",
+    task: "create a base room with one exploring delver, one defending warden, and a single basic trap",
+    budgetMode: "constrained",
+    budgetTokens: 400,
+    room: ["size=medium;count=1"],
+    trap: ["x=2;y=2;affinity=fire;expression=emit;stacks=1;blocking=false"],
+    delver: ["count=1;affinity=water;motivation=exploring"],
+    warden: ["count=1;affinity=fire;motivation=defending"],
+  },
+  {
+    title: "Constrained Three Warden Hold",
+    task: "create a base room with three defending wardens",
+    budgetMode: "constrained",
+    budgetTokens: 420,
+    room: ["size=large;count=1"],
+    warden: ["count=3;affinity=dark;motivation=defending"],
+  },
+];
+
+const omittedTitles = new Set([
+  "Create Floor Tile Starter Room",
+  "Create Random Movement Lab",
+  "Create Friendly Rescue Room",
+  "Create Auto Setup Delver",
+  "Create Max Mana Goal Delver",
+  "Create Minimal Budget Comparison",
+  "Create Actor Only Comparison",
+  "Create Room Only Comparison",
+]);
+
+const selectedCases = cases
+  .filter((testCase) => !omittedTitles.has(testCase.title))
+  .map(normalizeForCodeLaw);
+
+function hasSizeSmall(spec) {
+  return String(spec || "")
+    .split(";")
+    .map((segment) => segment.trim().toLowerCase())
+    .some((segment) => segment === "small" || segment === "size=small");
+}
+
+function forceMediumRoomSpec(spec) {
+  const segments = String(spec || "").split(";").map((segment) => segment.trim()).filter(Boolean);
+  let sawSize = false;
+  const next = segments.map((segment) => {
+    if (!segment.includes("=")) {
+      if (segment.toLowerCase() === "small") {
+        sawSize = true;
+        return "medium";
+      }
+      return segment;
+    }
+    const separator = segment.indexOf("=");
+    const key = segment.slice(0, separator).trim();
+    const value = segment.slice(separator + 1).trim();
+    if (key.toLowerCase() === "size") {
+      sawSize = true;
+      return value.toLowerCase() === "small" ? `${key}=medium` : segment;
+    }
+    return segment;
+  });
+  if (!sawSize) {
+    next.unshift("size=medium");
+  }
+  return next.join(";");
+}
+
+function normalizeForCodeLaw(testCase) {
+  const convertedHazards = [];
+  const normalizationNotes = [];
+  const hasExplicitTrapOrHazard = (testCase.trap || []).length > 0 || (testCase.hazard || []).length > 0;
+  const trap = (testCase.trap || []).slice();
+  let room = (testCase.room || []).map((spec, roomIndex) => {
+    const segments = String(spec).split(";").map((segment) => segment.trim()).filter(Boolean);
+    const kept = [];
+    for (const segment of segments) {
+      if (!segment.startsWith("affinities=")) {
+        kept.push(segment);
+        continue;
+      }
+      if (hasExplicitTrapOrHazard) {
+        normalizationNotes.push(`Dropped unsupported room affinity field for room ${roomIndex + 1}; explicit trap/hazard specs carry affinity pressure in current create.`);
+        continue;
+      }
+      const rawAffinities = segment.slice("affinities=".length);
+      rawAffinities.split(",").map((entry) => entry.trim()).filter(Boolean).forEach((entry, affinityIndex) => {
+        const [kindRaw, expressionRaw = "emit", stacksRaw = "1"] = entry.split(":").map((part) => part.trim());
+        const kind = kindRaw || testCase.dungeonAffinity || "fire";
+        const expression = expressionRaw === "emit" ? "emit" : "emit";
+        const stacks = Math.max(1, Number.parseInt(stacksRaw, 10) || 1);
+        const mana = stacks + 2;
+        convertedHazards.push(
+          `id=room_${roomIndex + 1}_field_${affinityIndex + 1};affinity=${kind};expression=${expression};proximityRadius=${Math.min(4, stacks + 1)};mana=regen:${mana}:${mana}:1`,
+        );
+      });
+      normalizationNotes.push(`Converted unsupported room affinity field to hazard field(s) for room ${roomIndex + 1}.`);
+    }
+    return kept.join(";");
+  });
+  const hasTrapOrHazard = hasExplicitTrapOrHazard || convertedHazards.length > 0;
+  if (hasTrapOrHazard && room.some(hasSizeSmall)) {
+    room = room.map((spec) => (hasSizeSmall(spec) ? forceMediumRoomSpec(spec) : spec));
+    normalizationNotes.push("Upgraded size=small room to size=medium because current create rejects small rooms containing traps or hazards.");
+  }
+  const task = normalizationNotes.some((note) => note.includes("size=medium"))
+    ? String(testCase.task || "").replace(/\bsmall\b/g, "medium")
+    : testCase.task;
+  return {
+    ...testCase,
+    task,
+    room,
+    ...(trap.length > 0 ? { trap } : {}),
+    ...(convertedHazards.length > 0 ? { hazard: [...(testCase.hazard || []), ...convertedHazards] } : {}),
+    ...(normalizationNotes.length > 0 ? { normalizationNotes } : {}),
+  };
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function parseJsonLine(stdout) {
+  const lines = stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    try {
+      return JSON.parse(lines[i]);
+    } catch {}
+  }
+  throw new Error(`No JSON payload found in stdout:\n${stdout}`);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function markdownTable(headers, rows) {
+  const escaped = rows.map((row) => row.map((cell) => String(cell ?? "").replace(/\|/g, "\\|").replace(/\n/g, "<br>")));
+  return [
+    `| ${headers.join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...escaped.map((row) => `| ${row.join(" | ")} |`),
+  ].join("\n");
+}
+
+function pushSpecs(args, flag, values = []) {
+  for (const value of values) {
+    args.push(flag, value);
+  }
+}
+
+function objectRows(testCase) {
+  const rows = [];
+  for (const [label, field] of [
+    ["Room", "room"],
+    ["Floor tile", "floorTile"],
+    ["Trap", "trap"],
+    ["Hazard", "hazard"],
+    ["Resource", "resource"],
+    ["Delver", "delver"],
+    ["Warden", "warden"],
+  ]) {
+    for (const spec of testCase[field] || []) {
+      rows.push([label, spec]);
+    }
+  }
+  if (rows.length === 0) rows.push(["None", "No authored object specs"]);
+  return rows;
+}
+
+function costTotals(lineItems = []) {
+  const totals = new Map();
+  for (const item of lineItems) {
+    const key = `${item.kind}:${item.status}`;
+    const current = totals.get(key) || { kind: item.kind, status: item.status, total: 0 };
+    current.total += Number(item.totalCost || 0);
+    totals.set(key, current);
+  }
+  return Array.from(totals.values())
+    .sort((a, b) => a.kind.localeCompare(b.kind) || a.status.localeCompare(b.status))
+    .map((entry) => [entry.kind, entry.status, entry.total]);
+}
+
+function listJsonFiles(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((entry) => entry.endsWith(".json"))
+    .sort()
+    .map((entry) => join(dir, entry));
+}
+
+function isConstrained(testCase) {
+  return testCase?.budgetMode === "constrained";
+}
+
+function budgetFor(testCase) {
+  if (!isConstrained(testCase)) {
+    // Budget-unconstrained: hand the builder a non-binding ceiling so it spends only
+    // what the scenario actually needs (config-cost growth never breaks the run).
+    return UNCONSTRAINED_BUDGET;
+  }
+  return Number.isInteger(testCase?.budgetTokens) && testCase.budgetTokens > 0
+    ? testCase.budgetTokens
+    : BUDGET;
+}
+
+function promptFor(testCase) {
+  const budgetTokens = budgetFor(testCase);
+  const budgetClause = isConstrained(testCase)
+    ? `Use a ${budgetTokens} token hard budget,`
+    : "Use whatever token budget the scenario requires (the budget is effectively unconstrained),";
+  return [
+    "Using the agent-kernel skill and the agent-kernel MCP,",
+    `${testCase.task}.`,
+    `${budgetClause} prefer MCP tools over shell commands, emit intermediates,`,
+    "remember that create/ak_create room specs are generic so affinity pressure belongs in traps or hazards,",
+    "and report generated artifact paths plus budget receipt cost details.",
+  ].join(" ");
+}
+
+function argsFor(testCase, runId, outDir) {
+  const budgetTokens = budgetFor(testCase);
+  const args = [
+    "create",
+    "--text",
+    promptFor(testCase),
+    "--budget-tokens",
+    String(budgetTokens),
+    "--run-id",
+    runId,
+    "--created-at",
+    CREATED_AT,
+    "--out-dir",
+    outDir,
+    "--emit-intermediates",
+  ];
+  if (testCase.dungeonAffinity) args.push("--dungeon-affinity", testCase.dungeonAffinity);
+  pushSpecs(args, "--room", testCase.room);
+  pushSpecs(args, "--floor-tile", testCase.floorTile);
+  pushSpecs(args, "--trap", testCase.trap);
+  pushSpecs(args, "--hazard", testCase.hazard);
+  pushSpecs(args, "--resource", testCase.resource);
+  pushSpecs(args, "--delver", testCase.delver);
+  pushSpecs(args, "--warden", testCase.warden);
+  return args;
+}
+
+function renderNote({ index, testCase, runId, outDir, result, receipt, jsonFiles }) {
+  const budgetTokens = budgetFor(testCase);
+  const artifactRows = jsonFiles.map((file) => [basename(file), file]);
+  const lineItems = Array.isArray(receipt.lineItems) ? receipt.lineItems : [];
+  const costRows = lineItems.map((item) => [
+    item.id,
+    item.kind,
+    item.quantity,
+    item.unitCost,
+    item.totalCost,
+    item.status,
+  ]);
+  const totalRows = costTotals(lineItems);
+  const mcpPayload = {
+    text: promptFor(testCase),
+    budgetTokens,
+    runId,
+    createdAt: CREATED_AT,
+    outDir,
+    emitIntermediates: true,
+    ...(testCase.dungeonAffinity ? { dungeonAffinity: testCase.dungeonAffinity } : {}),
+    ...(testCase.room ? { room: testCase.room } : {}),
+    ...(testCase.floorTile ? { floorTile: testCase.floorTile } : {}),
+    ...(testCase.trap ? { trap: testCase.trap } : {}),
+    ...(testCase.hazard ? { hazard: testCase.hazard } : {}),
+    ...(testCase.resource ? { resource: testCase.resource } : {}),
+    ...(testCase.delver ? { delver: testCase.delver } : {}),
+    ...(testCase.warden ? { warden: testCase.warden } : {}),
+  };
+
+  return `# ${String(index).padStart(2, "0")} ${testCase.title}
+
+Prompt: ${promptFor(testCase)}
+
+## Reference Result
+
+- MCP tool to call: \`ak_create\`
+- Reference generation path: \`ak.mjs create\` through the same implementation used by the MCP server
+- Run id: \`${runId}\`
+- Output directory: \`${outDir}\`
+- Budget cap: \`${receipt.scenarioSpendReport?.budget ?? result.cost?.budgetTokens ?? budgetTokens}\`
+- Total spend: \`${receipt.totalCost ?? result.cost?.totalSpend ?? "unknown"}\`
+- Remaining: \`${receipt.remaining ?? result.cost?.remaining ?? "unknown"}\`
+- Receipt status: \`${receipt.status ?? result.cost?.status ?? "unknown"}\`
+${testCase.normalizationNotes?.length ? `\n## Generator Normalization\n\n${testCase.normalizationNotes.map((note) => `- ${note}`).join("\n")}\n` : ""}
+
+## Resulting Artifact File Locations
+
+${markdownTable(["Artifact", "Path"], artifactRows)}
+
+## Items Created
+
+${markdownTable(["Kind", "Requested configuration"], objectRows(testCase))}
+
+## Cost By Kind
+
+${markdownTable(["Kind", "Status", "Total cost"], totalRows)}
+
+## Configuration Cost Details
+
+${markdownTable(["Item", "Kind", "Quantity", "Unit cost", "Total cost", "Status"], costRows)}
+
+## MCP Payload
+
+\`\`\`json
+${JSON.stringify(mcpPayload, null, 2)}
+\`\`\`
+`;
+}
+
+function main() {
+  if (selectedCases.length !== 64) {
+    throw new Error(`Expected 64 selected cases, found ${selectedCases.length}.`);
+  }
+
+  mkdirSync(VAULT_DIR, { recursive: true });
+  mkdirSync(ARTIFACT_ROOT, { recursive: true });
+
+  const indexRows = [];
+
+  selectedCases.forEach((testCase, caseIndex) => {
+    const index = caseIndex + 1;
+    const number = String(index).padStart(2, "0");
+    const slug = slugify(testCase.title);
+    const runId = `ak_prompt_${number}_${slug.replace(/-/g, "_")}`;
+    const artifactDir = join(ARTIFACT_ROOT, `${number}-${slug}`);
+    const outDir = join(artifactDir, "create");
+    const notePath = join(VAULT_DIR, `${number} ${testCase.title}.md`);
+
+    rmSync(artifactDir, { recursive: true, force: true });
+    mkdirSync(outDir, { recursive: true });
+
+    const args = argsFor(testCase, runId, outDir);
+    const result = spawnSync(process.execPath, [CLI, ...args], {
+      cwd: ROOT,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 20,
+    });
+    if (result.status !== 0) {
+      throw new Error([
+        `Case ${number} ${testCase.title} failed with status ${result.status}`,
+        `Command: node ${CLI} ${args.join(" ")}`,
+        result.stdout,
+        result.stderr,
+      ].filter(Boolean).join("\n"));
+    }
+
+    const payload = parseJsonLine(result.stdout);
+    const receiptPath = payload.artifactPaths?.budget_receipt || join(outDir, "budget-receipt.json");
+    const receipt = readJson(receiptPath);
+    const jsonFiles = listJsonFiles(outDir);
+    const note = renderNote({ index, testCase, runId, outDir, result: payload, receipt, jsonFiles });
+    writeFileSync(notePath, note);
+
+    indexRows.push([
+      number,
+      testCase.title,
+      notePath,
+      runId,
+      receipt.totalCost ?? payload.cost?.totalSpend ?? "",
+      receipt.remaining ?? payload.cost?.remaining ?? "",
+      receipt.status ?? payload.cost?.status ?? "",
+      outDir,
+    ]);
+  });
+
+  const index = `# Agent Kernel MCP Prompt Baselines
+
+Generated: ${new Date().toISOString()}
+
+These 64 prompts are intended for comparing how different LLMs and reasoning levels use the agent-kernel skill plus MCP tools. They split into **budget-constrained** scenarios (base rooms + base actors under a tight token cap, for budget-enforcement comparison) and **budget-unconstrained** scenarios (the builder spends whatever the configuration requires). Each prompt file contains a copyable prompt, the reference \`ak_create\` payload, actual artifact file locations generated through the shared CLI/MCP implementation, and budget receipt cost tables.
+
+${markdownTable(["#", "Prompt file", "Note path", "Run id", "Spend", "Remaining", "Status", "Artifact dir"], indexRows)}
+`;
+
+  writeFileSync(join(VAULT_DIR, "Index.md"), index);
+  console.log(JSON.stringify({ ok: true, count: selectedCases.length, vaultDir: VAULT_DIR, artifactRoot: ARTIFACT_ROOT }, null, 2));
+}
+
+main();

--- a/tools/benchmark/validate-benchmark.mjs
+++ b/tools/benchmark/validate-benchmark.mjs
@@ -1,0 +1,333 @@
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { authoringSpec } from "../../packages/adapters-cli/src/mcp/tools/authoring.mjs";
+import { buildArgv } from "../../packages/adapters-cli/src/mcp/tools/shared.mjs";
+
+const ROOT = resolve(process.env.AGENT_KERNEL_ROOT || process.cwd());
+const CLI = join(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+const SERVER = join(ROOT, "packages/adapters-cli/src/mcp/server.mjs");
+const OUT_ROOT = resolve(process.env.AK_BENCHMARK_OUTPUT_DIR || join(ROOT, "tools/benchmark/out"));
+const VALIDATION_ROOT = join(OUT_ROOT, "Validation");
+const REQUIRED_FILES = Object.freeze([
+  "spec.json",
+  "bundle.json",
+  "manifest.json",
+  "budget-receipt.json",
+  "sim-config.json",
+  "initial-state.json",
+  "resource-bundle.json",
+  "price-list.json",
+  "budget.json",
+  "spend-proposal.json",
+  "telemetry.json",
+  "request.json",
+  "intent.json",
+  "plan.json",
+]);
+
+function parseJsonLine(stdout) {
+  const lines = String(stdout || "").split("\n").map((line) => line.trim()).filter(Boolean);
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    try {
+      return JSON.parse(lines[index]);
+    } catch {}
+  }
+  return null;
+}
+
+function slugify(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function extractPayload(notePath) {
+  const text = readFileSync(notePath, "utf8");
+  const match = text.match(/## MCP Payload\s+```json\s+([\s\S]*?)\s+```/);
+  if (!match) {
+    throw new Error(`MCP payload block not found in ${notePath}`);
+  }
+  return JSON.parse(match[1]);
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function readStableJson(path) {
+  return stableStringify(JSON.parse(readFileSync(path, "utf8")));
+}
+
+function missingFiles(dir) {
+  return REQUIRED_FILES.filter((file) => !existsSync(join(dir, file)));
+}
+
+function compareArtifactDirs(leftDir, rightDir) {
+  const mismatches = [];
+  for (const file of REQUIRED_FILES) {
+    const leftPath = join(leftDir, file);
+    const rightPath = join(rightDir, file);
+    if (!existsSync(leftPath) || !existsSync(rightPath)) {
+      mismatches.push(`${file}:missing`);
+      continue;
+    }
+    if (readStableJson(leftPath) !== readStableJson(rightPath)) {
+      mismatches.push(`${file}:diff`);
+    }
+  }
+  return mismatches;
+}
+
+class McpServerHarness {
+  constructor() {
+    this.nextId = 1;
+    this.stdoutBuffer = "";
+    this.stderr = "";
+    this.pending = new Map();
+    this.closed = false;
+    this.process = spawn(process.execPath, [SERVER], {
+      cwd: ROOT,
+      env: { ...process.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.process.stdout.setEncoding("utf8");
+    this.process.stderr.setEncoding("utf8");
+    this.process.stdout.on("data", (chunk) => this.onStdout(chunk));
+    this.process.stderr.on("data", (chunk) => {
+      this.stderr += chunk;
+    });
+    this.process.on("exit", (code, signal) => {
+      this.closed = true;
+      const reason = `MCP server exited before response (code=${code}, signal=${signal})`;
+      for (const { reject, timer } of this.pending.values()) {
+        clearTimeout(timer);
+        reject(new Error(`${reason}\n${this.stderr}`));
+      }
+      this.pending.clear();
+    });
+  }
+
+  onStdout(chunk) {
+    this.stdoutBuffer += chunk;
+    let newlineIndex = this.stdoutBuffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = this.stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, "");
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line.trim()) {
+        this.handleMessage(line);
+      }
+      newlineIndex = this.stdoutBuffer.indexOf("\n");
+    }
+  }
+
+  handleMessage(line) {
+    const message = JSON.parse(line);
+    if (message.id === undefined) return;
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(message.id);
+    if (message.error) {
+      pending.reject(new Error(`MCP request failed: ${message.error.message}\n${this.stderr}`));
+      return;
+    }
+    pending.resolve(message.result);
+  }
+
+  request(method, params, timeoutMs = 60000) {
+    if (!this.process.stdin) {
+      return Promise.reject(new Error("MCP server stdin unavailable"));
+    }
+    const id = this.nextId;
+    this.nextId += 1;
+    const payload = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolveRequest, rejectRequest) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        rejectRequest(new Error(`Timed out waiting for ${method}\n${this.stderr}`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve: resolveRequest, reject: rejectRequest, timer });
+      this.process.stdin.write(`${JSON.stringify(payload)}\n`);
+    });
+  }
+
+  async initialize() {
+    await this.request("initialize", {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "agent-kernel-benchmark-validation", version: "1.0.0" },
+    });
+    this.process.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} })}\n`);
+  }
+
+  async callTool(name, args = {}) {
+    const result = await this.request("tools/call", { name, arguments: args });
+    const text = result?.content?.[0]?.text;
+    const parsed = text ? JSON.parse(text) : result?.structuredContent;
+    return result?.structuredContent || parsed;
+  }
+
+  async close() {
+    if (!this.process || this.closed) return;
+    await new Promise((resolveClose) => {
+      this.process.once("close", () => {
+        this.closed = true;
+        resolveClose();
+      });
+      this.process.stdin.end();
+      setTimeout(() => {
+        if (!this.closed) this.process.kill("SIGTERM");
+      }, 500).unref();
+    });
+  }
+}
+
+function runCli(payload, outDir) {
+  mkdirSync(outDir, { recursive: true });
+  const args = buildArgv({ ...payload, outDir }, authoringSpec);
+  const result = spawnSync(process.execPath, [CLI, "create", ...args], {
+    cwd: ROOT,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 30,
+  });
+  return {
+    exitCode: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    json: parseJsonLine(result.stdout),
+  };
+}
+
+function scenarioNotes() {
+  return readdirSync(OUT_ROOT)
+    .filter((entry) => /^\d{2} .+\.md$/.test(entry))
+    .sort()
+    .map((entry) => join(OUT_ROOT, entry));
+}
+
+function summarizeRows(rows) {
+  const headers = ["#", "Title", "CLI", "MCP", "Parity", "Missing", "Error"];
+  const escape = (value) => String(value ?? "").replace(/\|/g, "\\|").replace(/\n/g, "<br>");
+  return [
+    `| ${headers.join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...rows.map((row) => `| ${[
+      row.number,
+      row.title,
+      row.cliOk ? "ok" : "fail",
+      row.mcpOk ? "ok" : "fail",
+      row.parityOk ? "ok" : "fail",
+      [...row.cliMissing, ...row.mcpMissing].join(", "),
+      row.error || "",
+    ].map(escape).join(" | ")} |`),
+  ].join("\n");
+}
+
+async function main() {
+  mkdirSync(VALIDATION_ROOT, { recursive: true });
+  const notes = scenarioNotes();
+  const mcp = new McpServerHarness();
+  const rows = [];
+  await mcp.initialize();
+  try {
+    for (const notePath of notes) {
+      const file = notePath.split("/").at(-1);
+      const number = file.slice(0, 2);
+      const title = file.slice(3, -3);
+      const slug = slugify(title);
+      const payload = extractPayload(notePath);
+      const cliOutDir = join(VALIDATION_ROOT, "cli", `${number}-${slug}`, "create");
+      const mcpOutDir = join(VALIDATION_ROOT, "mcp", `${number}-${slug}`, "create");
+      const row = {
+        number,
+        title,
+        cliOk: false,
+        mcpOk: false,
+        parityOk: false,
+        cliMissing: [],
+        mcpMissing: [],
+        parityMismatches: [],
+        spend: null,
+        remaining: null,
+        status: null,
+        error: "",
+      };
+      try {
+        const cli = runCli(payload, cliOutDir);
+        row.cliOk = cli.exitCode === 0 && cli.json?.ok === true;
+        row.cliMissing = missingFiles(cliOutDir);
+        row.cliOk = row.cliOk && row.cliMissing.length === 0;
+        row.spend = cli.json?.cost?.totalSpend ?? null;
+        row.remaining = cli.json?.cost?.remaining ?? null;
+        row.status = cli.json?.cost?.status ?? null;
+        if (!row.cliOk) {
+          row.error = [row.error, `CLI exit=${cli.exitCode} ${cli.stderr || cli.stdout}`].filter(Boolean).join(" | ");
+        }
+      } catch (error) {
+        row.error = [row.error, `CLI ${error.message}`].filter(Boolean).join(" | ");
+      }
+      try {
+        mkdirSync(mcpOutDir, { recursive: true });
+        const mcpResult = await mcp.callTool("ak_create", { ...payload, outDir: mcpOutDir });
+        row.mcpOk = mcpResult?.ok === true;
+        row.mcpMissing = missingFiles(mcpOutDir);
+        row.mcpOk = row.mcpOk && row.mcpMissing.length === 0;
+        if (!row.mcpOk) {
+          row.error = [row.error, `MCP ${JSON.stringify(mcpResult)}`].filter(Boolean).join(" | ");
+        }
+      } catch (error) {
+        row.error = [row.error, `MCP ${error.message}`].filter(Boolean).join(" | ");
+      }
+      if (row.cliOk && row.mcpOk) {
+        row.parityMismatches = compareArtifactDirs(cliOutDir, mcpOutDir);
+        row.parityOk = row.parityMismatches.length === 0;
+        if (!row.parityOk) {
+          row.error = [row.error, `Parity mismatches: ${row.parityMismatches.join(", ")}`].filter(Boolean).join(" | ");
+        }
+      }
+      rows.push(row);
+      console.log(JSON.stringify({
+        number,
+        title,
+        cliOk: row.cliOk,
+        mcpOk: row.mcpOk,
+        parityOk: row.parityOk,
+      }));
+    }
+  } finally {
+    await mcp.close();
+  }
+
+  const summary = {
+    ok: rows.every((row) => row.cliOk && row.mcpOk && row.parityOk),
+    count: rows.length,
+    cliFailures: rows.filter((row) => !row.cliOk).length,
+    mcpFailures: rows.filter((row) => !row.mcpOk).length,
+    parityFailures: rows.filter((row) => !row.parityOk).length,
+    rows,
+  };
+  writeFileSync(join(VALIDATION_ROOT, "validation-summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+  writeFileSync(
+    join(VALIDATION_ROOT, "validation-summary.md"),
+    `# Benchmark Validation Summary\n\n${JSON.stringify({
+      ok: summary.ok,
+      count: summary.count,
+      cliFailures: summary.cliFailures,
+      mcpFailures: summary.mcpFailures,
+      parityFailures: summary.parityFailures,
+    }, null, 2)}\n\n${summarizeRows(rows)}\n`,
+  );
+  if (!summary.ok) {
+    process.exitCode = 1;
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary

- **One row per affinity kind** — replaces individual kind+expression chips with a single row per kind showing all 4 expressions (push/pull/emit/draw) inline with `−` [icon] count `+` controls and a `×` to remove the entire kind row
- **Fix `+` button on inactive expressions** — `adjustAffinityStack` now creates a new `{kind, expression, stacks:1}` entry when pressing `+` on a 0-stack expression (previously returned unchanged)
- **Larger affinity icons** — `AFF_ICON_SZ` 18→24px, `EXPR_ICON_SZ` 13→18px, `ROW_H` 30→36px for improved readability at the benchmark config (9 kinds × 4 expressions)
- **Fixed design resolution** — canvas now renders at a stable `1440×860` coordinate space using Phaser `FIT` scale mode instead of `RESIZE`, eliminating layout drift as the browser window changed size
- **Benchmark config** — max delver with 2500t budget: 9 affinity kinds × 4 expressions = 36 entries, 2 motivations, vitals at 12+

## Test plan

- [ ] All 284 tests pass (`pnpm run test`)
- [ ] Left rail affinity click adds a kind row to the editor
- [ ] `+` on any expression (including 0-stack/inactive) activates and increments correctly
- [ ] `−` decrements; reaching 0 dims the expression cell
- [ ] `×` removes the entire kind row
- [ ] Canvas maintains stable layout across window resizes (FIT mode scales CSS, not coordinates)
- [ ] Max delver benchmark (9 kinds × 4 expr + motivations + vitals) fits without overflow

🤖 Generated with [Claude Code](https://claude.ai/claude-code)