### PR TITLE
Pair agent movement work back to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ test-results.txt
 /spec.json
 /telemetry.json
 /initial-state.json
+ollama-test-generation.log

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-06-30)
+# Graph Report - .  (2026-07-02)
 
 ## Corpus Check
-- 455 files · ~1,560,666 words
+- 457 files · ~1,602,066 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2561 nodes · 3932 edges · 434 communities detected
+- 2586 nodes · 3977 edges · 437 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS · INFERRED: 8 edges (avg confidence: 0.86)
 - Token cost: 0 input · 0 output
 
@@ -444,10 +444,13 @@
 - [[_COMMUNITY_Community 431|Community 431]]
 - [[_COMMUNITY_Community 432|Community 432]]
 - [[_COMMUNITY_Community 433|Community 433]]
+- [[_COMMUNITY_Community 434|Community 434]]
+- [[_COMMUNITY_Community 435|Community 435]]
+- [[_COMMUNITY_Community 436|Community 436]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `addError()` - 33 edges
-2. `createDesignCard()` - 32 edges
+2. `createDesignCard()` - 33 edges
 3. `generateGridLayout()` - 23 edges
 4. `isObject()` - 21 edges
 5. `main()` - 16 edges
@@ -481,16 +484,16 @@ Cohesion: 0.06
 Nodes (85): applyPatternOverlay(), applyTrapBlocking(), buildBackbonePath(), buildBlockingTrapIndex(), buildKinds(), buildLegend(), buildRoomIndex(), buildRoomSurfaceSlots() (+77 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.04
-Nodes (40): affinityExpressionAllowsEnvironmentMutation(), affinityExpressionAllowsTrapArming(), affinityExpressionIsPersistentField(), buildAffinityVitalMatrix(), getAffinityTargetVital(), getAffinityVitalEffect(), getAffinityVitalEffectBase(), getDefaultAffinityTargetType() (+32 more)
+Cohesion: 0.06
+Nodes (55): adler32(), alphaBlend(), base64FromBytes(), blitSprite(), buildFloorAffinityMap(), buildSpriteForSemantic(), buildTileAffinityProjectionMap(), bytesFromBase64() (+47 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.06
-Nodes (51): adler32(), alphaBlend(), base64FromBytes(), blitSprite(), buildFloorAffinityMap(), buildSpriteForSemantic(), buildTileAffinityProjectionMap(), bytesFromBase64() (+43 more)
+Cohesion: 0.05
+Nodes (28): affinityExpressionAllowsEnvironmentMutation(), affinityExpressionAllowsTrapArming(), affinityExpressionIsPersistentField(), buildAffinityVitalMatrix(), getAffinityTargetVital(), getAffinityVitalEffect(), getAffinityVitalEffectBase(), getDefaultAffinityTargetType() (+20 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.09
-Nodes (57): adjustAffinityStack(), adjustCardCount(), adjustCardVital(), adjustTrapManaVital(), applyAffinityDrop(), applyExpressionDrop(), applyMotivationDrop(), buildAffinityEntries() (+49 more)
+Nodes (58): adjustAffinityStack(), adjustCardCount(), adjustCardVital(), adjustTrapManaVital(), applyAffinityDrop(), applyExpressionDrop(), applyMotivationDrop(), buildAffinityEntries() (+50 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.14
@@ -501,12 +504,12 @@ Cohesion: 0.08
 Nodes (35): actorAffinityKinds(), actorMatchesCardAffinities(), buildInspectorModel(), buildTextBag(), cardAffinityKinds(), clearElement(), collectTemplateCards(), createDomElement() (+27 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.09
-Nodes (40): alpha_bbox(), brighten_vital_bar(), build_clean_frame_base(), build_demo_atlas(), build_expression_arrow_components(), build_expression_triangle_components(), center_alpha(), command_compose() (+32 more)
+Cohesion: 0.1
+Nodes (38): buildAdjacentMoveProposals(), buildArtifactRef(), buildCandidateActionId(), buildMotivatedProposals(), buildMoveProposal(), buildRandomMoveProposals(), buildRuntimeDecisionCandidateActions(), buildRuntimeDecisionConstraints() (+30 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.1
-Nodes (34): buildAdjacentMoveProposals(), buildArtifactRef(), buildCandidateActionId(), buildMotivatedProposals(), buildMoveProposal(), buildRuntimeDecisionCandidateActions(), buildRuntimeDecisionConstraints(), buildRuntimeDecisionEffect() (+26 more)
+Cohesion: 0.09
+Nodes (40): alpha_bbox(), brighten_vital_bar(), build_clean_frame_base(), build_demo_atlas(), build_expression_arrow_components(), build_expression_triangle_components(), center_alpha(), command_compose() (+32 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.17
@@ -589,63 +592,63 @@ Cohesion: 0.24
 Nodes (19): addSessionError(), applySummaryContentErrors(), buildCardModelFromLlmSummary(), buildRepairRequestOptions(), captureWithFallback(), extractJsonObject(), extractResponseText(), getNumPredict() (+11 more)
 
 ### Community 28 - "Community 28"
+Cohesion: 0.16
+Nodes (12): getDefaultMotivationPattern(), getMotivationDefaultDesignCost(), getMotivationDefaultFlagMask(), getMotivationDefaultUnitCost(), getMotivationExclusiveGroup(), getMotivationFamily(), getMotivationPatternCodeAt(), getMotivationPatternCount() (+4 more)
+
+### Community 29 - "Community 29"
 Cohesion: 0.22
 Nodes (18): buildActionFromEffect(), buildEnvironmentEffects(), buildVitalEffect(), findAdjacent(), isBarrierTile(), isFloorTile(), normalizeAffinityEntry(), normalizeAffinityTargetType() (+10 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.12
 Nodes (4): clearElement(), createFixtureAdapter(), normalizeFixtureResponses(), replaceChildren()
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.2
 Nodes (16): addAffinityStack(), addAffinityTargetStack(), applyPresetToVitals(), applyVitalModifier(), computeTrapVitals(), deriveAbilitiesFromEffects(), ensureVitalRecord(), ensureVitals() (+8 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.26
 Nodes (17): buildCommandResult(), cloneJson(), collectDirectoryArtifacts(), createBrowserKernelHost(), dirnamePath(), ensureDirectoryHref(), ensureLeadingSlash(), executeBrowserCommand() (+9 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.15
 Nodes (7): extractJsonObject(), extractResponseText(), isNotFound(), normalizeBaseUrl(), postJson(), requestLlmResponse(), unwrapCodeFence()
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.18
 Nodes (5): makeMeta(), makeTickFrame(), McpServerHarness, scaffoldRun(), writeJson()
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.2
 Nodes (4): makeTempDir(), McpServerHarness, runCliSync(), setupSandboxRun()
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.22
 Nodes (10): endpointFor(), expandHome(), hostForRoute(), loadConfig(), numberFrom(), parseEnvFile(), positiveIntegerFrom(), readJson() (+2 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.21
 Nodes (2): McpServerHarness, setupSessionWithDelver()
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.26
 Nodes (14): crop_affinity(), draw_delver(), draw_draw(), draw_emit(), draw_pull(), draw_push(), draw_warden(), main() (+6 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.18
 Nodes (6): findBundleAsset(), inferActorRole(), normalizeResourceAssets(), primaryAffinityKind(), resolveActorAssetId(), resolveSurfaceAsset()
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.28
 Nodes (12): buildActorsAndGroups(), buildBuildSpecFromSummary(), defaultMeta(), deriveLevelGen(), deriveLevelGenFromLayout(), deriveLevelSideForWalkableTiles(), deriveRoomCountFromRooms(), deriveRoomShapeFromDesign() (+4 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.36
 Nodes (13): clampNumber(), clampOptionalInt(), isInteger(), normalizeLevelGenInput(), normalizePatternType(), normalizeTrapList(), pushError(), pushWarning() (+5 more)
 
-### Community 41 - "Community 41"
-Cohesion: 0.21
-Nodes (1): McpServerHarness
-
 ### Community 42 - "Community 42"
-Cohesion: 0.22
+Cohesion: 0.21
 Nodes (1): McpServerHarness
 
 ### Community 43 - "Community 43"
@@ -653,520 +656,520 @@ Cohesion: 0.22
 Nodes (1): McpServerHarness
 
 ### Community 44 - "Community 44"
+Cohesion: 0.22
+Nodes (1): McpServerHarness
+
+### Community 45 - "Community 45"
 Cohesion: 0.19
 Nodes (6): indexToLineColumn(), loadState(), parseJsonWithDetails(), safeLocalStorage(), setOutput(), wireOllamaPromptPanel()
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.16
 Nodes (4): formatMissingCardTypes(), summarizeActor(), summarizeVitals(), validatePreviewLaunchBundle()
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.27
 Nodes (11): addSortIndicators(), enableUI(), getNthColumn(), getTable(), getTableBody(), getTableHeader(), loadColumns(), loadData() (+3 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.27
 Nodes (8): createBundleReviewElements(), createPreviewRoot(), createStorage(), makeButton(), makeCanvas(), makeElement(), makeInput(), withUiGlobals()
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.22
 Nodes (3): McpServerHarness, scaffoldRun(), writeJson()
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
+Cohesion: 0.23
+Nodes (6): findArtifact(), getBundleRunId(), loadGameplayBundle(), populateUIIcons(), syncBundleViews(), updateStatusRail()
+
+### Community 51 - "Community 51"
 Cohesion: 0.21
 Nodes (5): element(), getResourceBundleAssetSpecs(), ipfsUriForAssetId(), relativePathForGameAssetId(), specForVisual()
 
-### Community 50 - "Community 50"
+### Community 52 - "Community 52"
 Cohesion: 0.27
 Nodes (10): alphaBlend(), applyAuraMask(), clamp01(), conflictMask(), deterministicNoise(), drawMask(), emitMask(), layeredMask() (+2 more)
 
-### Community 51 - "Community 51"
+### Community 53 - "Community 53"
 Cohesion: 0.32
 Nodes (12): buildRoomDesignFromRoomCards(), deriveLayoutFromRoomCards(), deriveLevelGenFromRoomCards(), deriveLevelSideForWalkableTiles(), deriveRoomShapeFromRoomCards(), extractRoomCards(), isRoomCard(), normalizeCardCount() (+4 more)
 
-### Community 52 - "Community 52"
+### Community 54 - "Community 54"
 Cohesion: 0.24
 Nodes (1): McpServerHarness
 
-### Community 53 - "Community 53"
+### Community 55 - "Community 55"
 Cohesion: 0.35
 Nodes (11): color_mask(), component(), contact_sheet(), content_box(), main(), make_components(), new_mask(), normalize_source() (+3 more)
 
-### Community 54 - "Community 54"
+### Community 56 - "Community 56"
 Cohesion: 0.35
 Nodes (11): color_mask(), contact_sheet(), content_box(), main(), make_components(), new_mask(), normalize_source(), rectangle_mask() (+3 more)
 
-### Community 55 - "Community 55"
-Cohesion: 0.26
-Nodes (6): findArtifact(), getBundleRunId(), loadGameplayBundle(), populateUIIcons(), syncBundleViews(), updateStatusRail()
-
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.23
 Nodes (5): readSnapshot(), setOutput(), setStatus(), storageFor(), wireBuildOrchestrator()
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.38
 Nodes (11): computeEffectivePotency(), computeIntensity(), computeManaCost(), computePotency(), computeRadius(), computeStackAlphaMultiplier(), computeTileAlpha(), resolveMergedStacks() (+3 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.39
 Nodes (11): addError(), getConflictingMotivationKinds(), getMotivationExclusiveGroup(), normalizeFlags(), normalizeGoal(), normalizeGoalParams(), normalizeMotivation(), normalizeMotivationKind() (+3 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.35
 Nodes (9): addError(), isInteger(), isNumber(), isPlainObject(), normalizeAbility(), normalizeActorLoadoutCatalog(), normalizeAffinityPresetCatalog(), normalizeEffect() (+1 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.24
 Nodes (7): createCliWorkerAdapter(), createInProcessCliWorkerAdapter(), createInProcessLevelBuilderAdapter(), createLevelBuilderAdapter(), createLlmAdapter(), fetchWithTimeout(), resolvePositiveInt()
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.36
 Nodes (9): buildAllocationAudit(), buildAllocationRef(), buildPriceMap(), buildRef(), calculatePriceTotal(), isFiniteNumber(), normalizePriceItems(), normalizeQuantity() (+1 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.38
 Nodes (10): collectFloorPositions(), collectWalkablePositions(), deriveLevelGenFromCounts(), deriveLevelSideForWalkableTiles(), normalizeLayoutCount(), normalizeLayoutCounts(), positionKey(), pushError() (+2 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.35
 Nodes (9): addError(), addWarning(), buildPlacementGrid(), clampInt(), createRng(), generateActorSet(), isPositiveInt(), normalizeMenu() (+1 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.36
 Nodes (10): addBasePressure(), buildAmbientAffinityPressure(), buildZeroByKind(), collectRoomPressureSources(), collectTrapPressureSources(), normalizeAffinityExpression(), normalizeAffinitySourceEntry(), resolveAffinityExpressionProfile() (+2 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.35
 Nodes (8): a(), B(), D(), g(), i(), k(), Q(), y()
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.22
 Nodes (2): createBrowserAdapter(), createFixtureFetch()
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.29
 Nodes (6): indexToLineColumn(), parseJsonWithDetails(), readSnapshot(), setStatus(), storageFor(), wireBundleReview()
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.27
 Nodes (5): compileScenarioPlaybackBundle(), createPlaybackRuntime(), createRuntimeCore(), readCoreAffinityFieldRecords(), readCoreAffinityFieldRecordsFromArtifacts()
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.36
 Nodes (8): buildCategorySpend(), buildCategoryTargets(), buildLegacyCategorySpend(), buildPoolTargets(), buildScenarioSpendReport(), computeIncentiveMultiplier(), normalizeSpend(), sumLineItemsByCategory()
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.38
 Nodes (8): buildLayoutLineItems(), evaluateLayoutSpend(), evaluateRoomCardLayoutSpend(), isInteger(), normalizeLayoutCosts(), normalizeLayoutCounts(), normalizeTileCount(), resolveLayoutTileCosts()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.27
 Nodes (5): collectCoreStaticTraps(), mergeTrapLists(), readObservation(), renderBaseTiles(), renderFrameBuffer()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.33
 Nodes (6): announceReady(), connect(), connectSandboxBridge(), handleBundle(), scheduleReconnect(), sendJson()
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.36
 Nodes (5): collectBuildSpecCardSet(), deriveContentAwareSplit(), extractDesignStateFromBuildSpec(), mergeCardArrays(), normalizeBuildSpecForEditor()
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.44
 Nodes (8): assertCoreSupportsGrid(), directionFromDelta(), findChar(), isDiagonalStepAllowed(), isWalkable(), reconstructPath(), runMvpMovement(), shortestPath()
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.39
 Nodes (7): addCoordinateLegend(), buildActorDetails(), buildBlankGrid(), computeActorPositions(), createVisualizationSnapshot(), inferKind(), markPosition()
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.36
 Nodes (5): buildPlanArtifactFromIntent(), isNonEmptyString(), resolveIntentEnvelope(), resolveIntentRef(), resolvePlanArtifact()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.33
 Nodes (5): buildLlmTraceTelemetryRecord(), buildLlmTraceTurns(), isLlmCaptureArtifact(), isObject(), summarizeLlmTrace()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.36
 Nodes (6): addError(), buildActorCatalogFromAtoms(), buildActorCatalogFromConfig(), isPlainObject(), normalizeMeta(), normalizeTags()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.42
 Nodes (8): buildSpecFromSummaryFlow(), cloneJson(), normalizeAgentHints(), normalizeArrayField(), normalizeArtifactRef(), normalizeBuildSpecForUi(), normalizeRepeatableField(), runPoolFlow()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.43
 Nodes (6): extractMcpPayload(), extractPrompt(), loadScenarios(), parseIndexTable(), scenarioBudget(), scenarioTier()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.39
 Nodes (5): affinityByType(), countByType(), partialOverlap(), readJson(), scoreRun()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.32
 Nodes (3): buildRoomIndex(), countInternalBlocked(), hasGapAroundInternalBarrier()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.36
 Nodes (5): listCardSet(), listDelverCards(), listRoomCards(), runCli(), runCliOk()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.46
 Nodes (7): allocatePools(), applyResourceCap(), buildBudgetAllocation(), buildRef(), computeBudgetPools(), normalizePoolWeights(), normalizeReserveTokens()
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.52
 Nodes (6): getMcpBuildTools(), normalizeEntitySpec(), normalizeToolArgs(), pythonReprToJson(), runScenario(), toArray()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.52
 Nodes (6): displayCommand(), remoteCommand(), remoteCommandFor(), runRemote(), runRemoteScript(), sshBaseArgs()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
+Cohesion: 0.38
+Nodes (4): buildInitialState(), buildSimConfig(), makeFloorGrid(), makeVitals()
+
+### Community 89 - "Community 89"
 Cohesion: 0.38
 Nodes (4): isWalkable(), pickGreatestDeltaPair(), roomAnchor(), roomCenter()
 
-### Community 88 - "Community 88"
+### Community 90 - "Community 90"
 Cohesion: 0.38
 Nodes (3): createMeta(), createSimArtifacts(), writeJson()
 
-### Community 89 - "Community 89"
+### Community 91 - "Community 91"
 Cohesion: 0.43
 Nodes (4): createFrame(), createInitialState(), createMeta(), createSimConfig()
 
-### Community 90 - "Community 90"
+### Community 92 - "Community 92"
 Cohesion: 0.33
 Nodes (2): runCli(), runCliOk()
 
-### Community 91 - "Community 91"
+### Community 93 - "Community 93"
 Cohesion: 0.48
 Nodes (6): loadFixtureJson(), loadFixtureText(), runBlockchainDemo(), runIpfsDemo(), runLlmDemo(), runSolverDemo()
 
-### Community 92 - "Community 92"
+### Community 94 - "Community 94"
 Cohesion: 0.43
 Nodes (4): clearBundleCanvas(), ensureCanvas(), findArtifact(), renderBundleBoardToCanvas()
 
-### Community 93 - "Community 93"
+### Community 95 - "Community 95"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 94 - "Community 94"
+### Community 96 - "Community 96"
 Cohesion: 0.38
 Nodes (3): readArtifactFile(), readSchemaArtifact(), resolveBudgetTriplet()
 
-### Community 95 - "Community 95"
+### Community 97 - "Community 97"
 Cohesion: 0.48
 Nodes (4): buildBoardState(), buildEntityIndex(), findArtifact(), resolveHazards()
 
-### Community 96 - "Community 96"
+### Community 98 - "Community 98"
 Cohesion: 0.48
 Nodes (5): getAffinityRgba(), hexToRgba(), normalizeHex(), resolveAuraRgba(), resolveStackIntensity()
 
-### Community 97 - "Community 97"
+### Community 99 - "Community 99"
 Cohesion: 0.48
 Nodes (5): deriveSelectionCost(), deriveSelectionCount(), evaluateSelectionSpend(), isInteger(), resolveActorCostEntry()
 
-### Community 98 - "Community 98"
+### Community 100 - "Community 100"
 Cohesion: 0.43
 Nodes (5): buildInitialStateArtifact(), buildSimConfigArtifact(), cloneLayoutData(), isPlainObject(), sortedById()
 
-### Community 99 - "Community 99"
+### Community 101 - "Community 101"
 Cohesion: 0.57
 Nodes (6): applyLevelStrategy(), applyOverrides(), applyShapeOverrides(), collectTags(), normalizeTag(), resolveStrategyTag()
 
-### Community 100 - "Community 100"
+### Community 102 - "Community 102"
 Cohesion: 0.67
 Nodes (6): addError(), isNonEmptyString(), normalizeEntry(), normalizeMeta(), normalizePoolCatalog(), validateStringArray()
 
-### Community 101 - "Community 101"
+### Community 103 - "Community 103"
 Cohesion: 0.57
 Nodes (6): buildMeta(), ingestBudgetInputs(), isBudgetArtifact(), isPriceListArtifact(), normalizeBudgetInput(), normalizePriceListInput()
 
-### Community 102 - "Community 102"
+### Community 104 - "Community 104"
 Cohesion: 0.48
 Nodes (6): buildEffectFromCore(), buildEffectId(), buildRequestId(), decodeRequestPayload(), dispatchEffect(), normalizeKind()
 
-### Community 103 - "Community 103"
+### Community 105 - "Community 105"
 Cohesion: 0.53
 Nodes (4): makeMeta(), makeTickFrame(), scaffoldRun(), writeJson()
-
-### Community 104 - "Community 104"
-Cohesion: 0.33
-Nodes (0): 
-
-### Community 105 - "Community 105"
-Cohesion: 0.33
-Nodes (0): 
 
 ### Community 106 - "Community 106"
+Cohesion: 0.33
+Nodes (0): 
+
+### Community 107 - "Community 107"
+Cohesion: 0.47
+Nodes (3): cooldown(), oneProposeCycle(), runTrajectory()
+
+### Community 108 - "Community 108"
+Cohesion: 0.33
+Nodes (0): 
+
+### Community 109 - "Community 109"
 Cohesion: 0.53
 Nodes (4): makeMeta(), makeTickFrame(), scaffoldRun(), writeJson()
 
-### Community 107 - "Community 107"
-Cohesion: 0.4
-Nodes (2): runCli(), runCliOk()
-
-### Community 108 - "Community 108"
-Cohesion: 0.4
-Nodes (2): createGridArtifacts(), writeJson()
-
-### Community 109 - "Community 109"
-Cohesion: 0.4
-Nodes (2): runCli(), runCliOk()
-
 ### Community 110 - "Community 110"
-Cohesion: 0.53
-Nodes (4): buildTileAffinityVisualsFromBundle(), buildTileAffinityVisualsFromSandboxBundle(), findArtifact(), getCore()
+Cohesion: 0.4
+Nodes (2): runCli(), runCliOk()
 
 ### Community 111 - "Community 111"
 Cohesion: 0.4
-Nodes (2): findArtifact(), summarizeFixtureBundle()
+Nodes (2): createGridArtifacts(), writeJson()
 
 ### Community 112 - "Community 112"
+Cohesion: 0.4
+Nodes (2): runCli(), runCliOk()
+
+### Community 113 - "Community 113"
+Cohesion: 0.53
+Nodes (4): buildTileAffinityVisualsFromBundle(), buildTileAffinityVisualsFromSandboxBundle(), findArtifact(), getCore()
+
+### Community 114 - "Community 114"
+Cohesion: 0.4
+Nodes (2): findArtifact(), summarizeFixtureBundle()
+
+### Community 115 - "Community 115"
 Cohesion: 0.6
 Nodes (4): deriveFromFieldRecords(), deriveTileAffinityVisuals(), overlayKeyForKind(), resolveOverlayAssetId()
 
-### Community 113 - "Community 113"
+### Community 116 - "Community 116"
 Cohesion: 0.6
 Nodes (5): createActorMedallionTextureDescriptor(), normalizeActorMedallionTextureSize(), safeSegment(), shouldComposeActorMedallion(), vitalSegment()
 
-### Community 114 - "Community 114"
-Cohesion: 0.33
-Nodes (0): 
-
-### Community 115 - "Community 115"
-Cohesion: 0.53
-Nodes (5): chebyshevDistance(), computeAuraMap(), projectExpression(), resolveInteractionAtTile(), serializeAuraMap()
-
-### Community 116 - "Community 116"
-Cohesion: 0.33
-Nodes (0): 
-
 ### Community 117 - "Community 117"
-Cohesion: 0.67
-Nodes (5): buildRef(), isFiniteNumber(), normalizeQuantity(), resolveReceiptLine(), updateBudgetLedger()
+Cohesion: 0.33
+Nodes (0): 
 
 ### Community 118 - "Community 118"
 Cohesion: 0.53
-Nodes (4): calculateMotivationStackCost(), calculateMotivationStackCostFromCore(), resolveMotivationFamily(), resolveMotivationUnitCost()
+Nodes (5): chebyshevDistance(), computeAuraMap(), projectExpression(), resolveInteractionAtTile(), serializeAuraMap()
 
 ### Community 119 - "Community 119"
-Cohesion: 0.6
-Nodes (5): bitmaskToFlags(), evaluateMotivationProfileFromCore(), flagsToBitmask(), readEvaluationResult(), resolvePatternCode()
-
-### Community 120 - "Community 120"
-Cohesion: 0.4
+Cohesion: 0.33
 Nodes (0): 
 
+### Community 120 - "Community 120"
+Cohesion: 0.67
+Nodes (5): buildRef(), isFiniteNumber(), normalizeQuantity(), resolveReceiptLine(), updateBudgetLedger()
+
 ### Community 121 - "Community 121"
-Cohesion: 0.5
-Nodes (2): runCli(), runCliOk()
+Cohesion: 0.53
+Nodes (4): calculateMotivationStackCost(), calculateMotivationStackCostFromCore(), resolveMotivationFamily(), resolveMotivationUnitCost()
 
 ### Community 122 - "Community 122"
 Cohesion: 0.6
-Nodes (3): validateAsciiSnapshot(), validateBase(), validateImageSnapshot()
+Nodes (5): bitmaskToFlags(), evaluateMotivationProfileFromCore(), flagsToBitmask(), readEvaluationResult(), resolvePatternCode()
 
 ### Community 123 - "Community 123"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 124 - "Community 124"
+Cohesion: 0.5
+Nodes (2): runCli(), runCliOk()
+
+### Community 125 - "Community 125"
+Cohesion: 0.6
+Nodes (3): validateAsciiSnapshot(), validateBase(), validateImageSnapshot()
+
+### Community 126 - "Community 126"
 Cohesion: 0.6
 Nodes (3): isObject(), validatePriceListArtifact(), validatePriceListItem()
 
-### Community 124 - "Community 124"
+### Community 127 - "Community 127"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 125 - "Community 125"
+### Community 128 - "Community 128"
 Cohesion: 0.5
 Nodes (2): createGridArtifacts(), writeJson()
 
-### Community 126 - "Community 126"
+### Community 129 - "Community 129"
 Cohesion: 0.5
 Nodes (2): runCli(), runCliOk()
 
-### Community 127 - "Community 127"
+### Community 130 - "Community 130"
 Cohesion: 0.5
 Nodes (2): createGridArtifacts(), writeJson()
-
-### Community 128 - "Community 128"
-Cohesion: 0.6
-Nodes (3): makeMeta(), scaffoldRun(), writeJson()
-
-### Community 129 - "Community 129"
-Cohesion: 0.8
-Nodes (4): closeOnce(), findStartPort(), listenOnce(), withBlockedPort()
-
-### Community 130 - "Community 130"
-Cohesion: 0.8
-Nodes (4): generateTierActors(), generateTierLayout(), loadGenerators(), resolveTierSpec()
 
 ### Community 131 - "Community 131"
 Cohesion: 0.6
-Nodes (3): clearList(), renderList(), wireAffinityLegend()
+Nodes (3): makeMeta(), scaffoldRun(), writeJson()
 
 ### Community 132 - "Community 132"
+Cohesion: 0.8
+Nodes (4): closeOnce(), findStartPort(), listenOnce(), withBlockedPort()
+
+### Community 133 - "Community 133"
+Cohesion: 0.8
+Nodes (4): generateTierActors(), generateTierLayout(), loadGenerators(), resolveTierSpec()
+
+### Community 134 - "Community 134"
+Cohesion: 0.6
+Nodes (3): clearList(), renderList(), wireAffinityLegend()
+
+### Community 135 - "Community 135"
 Cohesion: 0.6
 Nodes (3): classifyIngestionPayload(), hasGameplayArtifacts(), isPlainObject()
 
-### Community 133 - "Community 133"
+### Community 136 - "Community 136"
 Cohesion: 0.6
 Nodes (3): isValidDataUri(), resolveIcon(), resolveIconHTML()
 
-### Community 134 - "Community 134"
+### Community 137 - "Community 137"
 Cohesion: 0.7
 Nodes (4): normalizeBudgetInputs(), validateBudgetPercentages(), validateLevelBudget(), validatePercentage()
 
-### Community 135 - "Community 135"
+### Community 138 - "Community 138"
 Cohesion: 0.5
 Nodes (2): extractLlmCaptures(), toLlmCaptureList()
 
-### Community 136 - "Community 136"
+### Community 139 - "Community 139"
 Cohesion: 0.6
 Nodes (3): createSchemaCatalog(), filterSchemaCatalogEntries(), sortSchemas()
 
-### Community 137 - "Community 137"
+### Community 140 - "Community 140"
 Cohesion: 0.5
 Nodes (2): distributeVitalPoints(), maximizeActorBudget()
 
-### Community 138 - "Community 138"
-Cohesion: 0.5
-Nodes (2): createSolverAdapter(), loadFixture()
-
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 0.6
 Nodes (3): createIpfsAdapter(), joinPath(), normalizeCid()
 
-### Community 140 - "Community 140"
+### Community 142 - "Community 142"
+Cohesion: 0.5
+Nodes (2): createSolverAdapter(), loadFixture()
+
+### Community 143 - "Community 143"
 Cohesion: 0.7
 Nodes (4): goToNext(), goToPrevious(), makeCurrent(), toggleClass()
 
-### Community 141 - "Community 141"
+### Community 144 - "Community 144"
 Cohesion: 0.4
 Nodes (5): adapters-test Package, Blockchain Adapter (Test), IPFS Adapter (Test), LLM Adapter (Test), Fixture-First External IO
 
-### Community 142 - "Community 142"
+### Community 145 - "Community 145"
 Cohesion: 0.83
 Nodes (3): main(), parseArgs(), parseList()
 
-### Community 143 - "Community 143"
+### Community 146 - "Community 146"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 144 - "Community 144"
+### Community 147 - "Community 147"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 145 - "Community 145"
+### Community 148 - "Community 148"
 Cohesion: 0.67
 Nodes (2): runCli(), runCliOk()
 
-### Community 146 - "Community 146"
+### Community 149 - "Community 149"
 Cohesion: 0.83
 Nodes (3): buildReceipt(), readJson(), refFor()
 
-### Community 147 - "Community 147"
+### Community 150 - "Community 150"
 Cohesion: 0.67
 Nodes (2): isObject(), validateResourceArtifact()
 
-### Community 148 - "Community 148"
+### Community 151 - "Community 151"
 Cohesion: 0.83
 Nodes (3): buildBudgetedRun(), readJson(), refFor()
 
-### Community 149 - "Community 149"
-Cohesion: 0.5
-Nodes (0): 
-
-### Community 150 - "Community 150"
-Cohesion: 0.5
-Nodes (0): 
-
-### Community 151 - "Community 151"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 152 - "Community 152"
-Cohesion: 0.67
-Nodes (2): fetchFn(), fixtureResponse()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 153 - "Community 153"
-Cohesion: 0.67
-Nodes (2): runCli(), runCliOk()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 154 - "Community 154"
 Cohesion: 0.5
 Nodes (0): 
 
 ### Community 155 - "Community 155"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): fetchFn(), fixtureResponse()
 
 ### Community 156 - "Community 156"
 Cohesion: 0.67
-Nodes (2): fixturePath(), readFixture()
+Nodes (2): runCli(), runCliOk()
 
 ### Community 157 - "Community 157"
 Cohesion: 0.5
 Nodes (0): 
 
 ### Community 158 - "Community 158"
-Cohesion: 0.67
-Nodes (2): applyFormula(), resolveFormula()
-
-### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (0): 
 
+### Community 159 - "Community 159"
+Cohesion: 0.67
+Nodes (2): fixturePath(), readFixture()
+
 ### Community 160 - "Community 160"
-Cohesion: 0.83
-Nodes (3): buildLlmCaptureArtifact(), buildMeta(), isNonEmptyString()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 161 - "Community 161"
 Cohesion: 0.67
-Nodes (2): createSolverPort(), solveWithAdapter()
+Nodes (2): applyFormula(), resolveFormula()
 
 ### Community 162 - "Community 162"
-Cohesion: 0.67
-Nodes (2): pickBest(), scoreCandidate()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 163 - "Community 163"
 Cohesion: 0.83
-Nodes (2): createWasmSolverAdapter(), loadWasmInstance()
+Nodes (3): buildLlmCaptureArtifact(), buildMeta(), isNonEmptyString()
 
 ### Community 164 - "Community 164"
+Cohesion: 0.67
+Nodes (2): createSolverPort(), solveWithAdapter()
+
+### Community 165 - "Community 165"
+Cohesion: 0.67
+Nodes (2): pickBest(), scoreCandidate()
+
+### Community 166 - "Community 166"
+Cohesion: 0.83
+Nodes (2): createWasmSolverAdapter(), loadWasmInstance()
+
+### Community 167 - "Community 167"
 Cohesion: 0.5
 Nodes (1): serializeError()
 
-### Community 165 - "Community 165"
+### Community 168 - "Community 168"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 166 - "Community 166"
+### Community 169 - "Community 169"
 Cohesion: 0.5
 Nodes (4): CLI Adapters Package, MCP Server (agent-kernel-cli), MCP-First Test Rule, Test Authoring Playbook
 
-### Community 167 - "Community 167"
+### Community 170 - "Community 170"
 Cohesion: 1.0
 Nodes (2): collectLocalTelemetry(), runCapture()
 
-### Community 168 - "Community 168"
+### Community 171 - "Community 171"
 Cohesion: 1.0
 Nodes (2): health(), requestJson()
 
-### Community 169 - "Community 169"
+### Community 172 - "Community 172"
 Cohesion: 1.0
 Nodes (2): extractJsonObject(), runRepairableJsonSession()
-
-### Community 170 - "Community 170"
-Cohesion: 0.67
-Nodes (0): 
-
-### Community 171 - "Community 171"
-Cohesion: 1.0
-Nodes (2): createFrameRoot(), makeNode()
-
-### Community 172 - "Community 172"
-Cohesion: 0.67
-Nodes (0): 
 
 ### Community 173 - "Community 173"
 Cohesion: 0.67
@@ -1174,23 +1177,23 @@ Nodes (0):
 
 ### Community 174 - "Community 174"
 Cohesion: 1.0
-Nodes (2): runCli(), runCliOk()
+Nodes (2): createFrameRoot(), makeNode()
 
 ### Community 175 - "Community 175"
-Cohesion: 1.0
-Nodes (2): buildWithBudget(), readJson()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 176 - "Community 176"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 177 - "Community 177"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): runCli(), runCliOk()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildWithBudget(), readJson()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.67
@@ -1201,8 +1204,8 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 181 - "Community 181"
-Cohesion: 1.0
-Nodes (2): makeBaseTiles(), runOneProposeCycle()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 182 - "Community 182"
 Cohesion: 0.67
@@ -1218,7 +1221,7 @@ Nodes (0):
 
 ### Community 185 - "Community 185"
 Cohesion: 1.0
-Nodes (2): buildCore(), makeRuntime()
+Nodes (2): makeBaseTiles(), runOneProposeCycle()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.67
@@ -1233,8 +1236,8 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 189 - "Community 189"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildCore(), makeRuntime()
 
 ### Community 190 - "Community 190"
 Cohesion: 0.67
@@ -1261,36 +1264,36 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 196 - "Community 196"
-Cohesion: 1.0
-Nodes (2): writeJson(), writeRun()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 197 - "Community 197"
-Cohesion: 1.0
-Nodes (2): createCardBuilderController(), createStatusSink()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 198 - "Community 198"
-Cohesion: 1.0
-Nodes (2): compileScenarioToBundle(), loadScenarioFromUrl()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 200 - "Community 200"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): writeJson(), writeRun()
 
 ### Community 201 - "Community 201"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createCardBuilderController(), createStatusSink()
 
 ### Community 202 - "Community 202"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): compileScenarioToBundle(), loadScenarioFromUrl()
 
 ### Community 203 - "Community 203"
-Cohesion: 1.0
-Nodes (2): buildManualMoveAction(), resolveObservedActors()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
@@ -1298,7 +1301,7 @@ Nodes (0):
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
-Nodes (1): createBlockchainAdapter()
+Nodes (0): 
 
 ### Community 206 - "Community 206"
 Cohesion: 0.67
@@ -1306,18 +1309,18 @@ Nodes (0):
 
 ### Community 207 - "Community 207"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): buildManualMoveAction(), resolveObservedActors()
 
 ### Community 208 - "Community 208"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 209 - "Community 209"
-Cohesion: 1.0
-Nodes (0): 
+Cohesion: 0.67
+Nodes (1): createBlockchainAdapter()
 
 ### Community 210 - "Community 210"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 211 - "Community 211"
@@ -2198,388 +2201,392 @@ Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 1.0
-Nodes (1): Solver-Z3 Adapter
+Nodes (0): 
 
 ### Community 431 - "Community 431"
 Cohesion: 1.0
-Nodes (1): CLI build Command
+Nodes (0): 
 
 ### Community 432 - "Community 432"
 Cohesion: 1.0
-Nodes (1): CLI llm-plan Command
+Nodes (0): 
 
 ### Community 433 - "Community 433"
+Cohesion: 1.0
+Nodes (1): Solver-Z3 Adapter
+
+### Community 434 - "Community 434"
+Cohesion: 1.0
+Nodes (1): CLI build Command
+
+### Community 435 - "Community 435"
+Cohesion: 1.0
+Nodes (1): CLI llm-plan Command
+
+### Community 436 - "Community 436"
 Cohesion: 1.0
 Nodes (1): Structured Stdout Contract
 
 ## Knowledge Gaps
 - **29 isolated node(s):** `Read named components from a contact sheet.      The manifest maps each componen`, `Compose one full sprite from the atlas and semantic selection.`, `Keep the visible stone corner pieces while dropping dark sheet backing.`, `Build expression overlays from white arrow indicators.      Corner-arrow semanti`, `Build expression overlays from minimal white triangle indicators.      Triangle` (+24 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 207`** (2 nodes): `wireCardListView()`, `source.js`
+- **Thin community `Community 211`** (2 nodes): `wireCardListView()`, `source.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (2 nodes): `activeCardId()`, `card-builder-controller.test.js`
+- **Thin community `Community 212`** (2 nodes): `activeCardId()`, `card-builder-controller.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (2 nodes): `createFakeSurfaces()`, `gameplay-surface-ingestion.test.js`
+- **Thin community `Community 213`** (2 nodes): `createFakeSurfaces()`, `gameplay-surface-ingestion.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (2 nodes): `loadValidator()`, `sandbox-session-artifact.test.js`
+- **Thin community `Community 214`** (2 nodes): `loadValidator()`, `sandbox-session-artifact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (2 nodes): `loadValidator()`, `hazard-artifact.test.js`
+- **Thin community `Community 215`** (2 nodes): `loadValidator()`, `hazard-artifact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (2 nodes): `loadValidator()`, `build-spec.test.js`
+- **Thin community `Community 216`** (2 nodes): `loadValidator()`, `build-spec.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (2 nodes): `loadSetupModule()`, `core-setup-static-traps.test.js`
+- **Thin community `Community 217`** (2 nodes): `loadSetupModule()`, `core-setup-static-traps.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (2 nodes): `collectJsFiles()`, `prompt-template-centralization.test.js`
+- **Thin community `Community 218`** (2 nodes): `collectJsFiles()`, `prompt-template-centralization.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (2 nodes): `parseStringUnion()`, `domain-constants-parity.test.js`
+- **Thin community `Community 219`** (2 nodes): `parseStringUnion()`, `domain-constants-parity.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (2 nodes): `loadSetupModule()`, `core-setup-hazards-and-actor-affinity.test.js`
+- **Thin community `Community 220`** (2 nodes): `loadSetupModule()`, `core-setup-hazards-and-actor-affinity.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (2 nodes): `readJson()`, `prompt-contract-e2e.test.js`
+- **Thin community `Community 221`** (2 nodes): `readJson()`, `prompt-contract-e2e.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (2 nodes): `tick-frames.test.js`, `createRuntimeWithCore()`
+- **Thin community `Community 222`** (2 nodes): `tick-frames.test.js`, `createRuntimeWithCore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (2 nodes): `tileChanged()`, `resource-bundle.test.js`
+- **Thin community `Community 223`** (2 nodes): `ui-flow-normalize.test.js`, `loadUiFlow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (2 nodes): `ui-flow-normalize.test.js`, `loadUiFlow()`
+- **Thin community `Community 224`** (2 nodes): `effectFactory()`, `external-fact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `effectFactory()`, `external-fact.test.js`
+- **Thin community `Community 225`** (2 nodes): `readJson()`, `e2e-budget-refs.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `readJson()`, `e2e-budget-refs.test.js`
+- **Thin community `Community 226`** (2 nodes): `visualization-state-detail.test.js`, `loadVisualizationModule()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `visualization-state-detail.test.js`, `loadVisualizationModule()`
+- **Thin community `Community 227`** (2 nodes): `rng()`, `irregular-room-sizes.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `rng()`, `irregular-room-sizes.test.js`
+- **Thin community `Community 228`** (2 nodes): `roleForVisual()`, `game-elements-registry.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `roleForVisual()`, `game-elements-registry.test.js`
+- **Thin community `Community 229`** (2 nodes): `readJson()`, `e2e-allocator-artifacts.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `readJson()`, `e2e-allocator-artifacts.test.js`
+- **Thin community `Community 230`** (2 nodes): `readJson()`, `e2e-actor-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `readJson()`, `e2e-actor-fixtures.test.js`
+- **Thin community `Community 231`** (2 nodes): `trap-vitals-in-observation.test.js`, `captureObservationPersona()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `trap-vitals-in-observation.test.js`, `captureObservationPersona()`
+- **Thin community `Community 232`** (2 nodes): `fixedClock()`, `runner-deterministic.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `fixedClock()`, `runner-deterministic.test.js`
+- **Thin community `Community 233`** (2 nodes): `loadRuntimeDeps()`, `runtime-fsm-loop.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `loadRuntimeDeps()`, `runtime-fsm-loop.test.js`
+- **Thin community `Community 234`** (2 nodes): `readJson()`, `e2e-scenario-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `readJson()`, `e2e-scenario-fixtures.test.js`
+- **Thin community `Community 235`** (2 nodes): `clock()`, `director-artifact-seeding.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `clock()`, `director-artifact-seeding.test.js`
+- **Thin community `Community 236`** (2 nodes): `z3-solver-adapter.test.js`, `buildRequest()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `z3-solver-adapter.test.js`, `buildRequest()`
+- **Thin community `Community 237`** (2 nodes): `baseTrap()`, `configurator-guidance-level-builder.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `baseTrap()`, `configurator-guidance-level-builder.test.js`
+- **Thin community `Community 238`** (2 nodes): `applyDirection()`, `actor-persona-movement.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `applyDirection()`, `actor-persona-movement.test.js`
+- **Thin community `Community 239`** (2 nodes): `clock()`, `director-hazard-seeding.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `clock()`, `director-hazard-seeding.test.js`
+- **Thin community `Community 240`** (2 nodes): `readAllocatorFixture()`, `configurator-spend-proposal.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `readAllocatorFixture()`, `configurator-spend-proposal.test.js`
+- **Thin community `Community 241`** (2 nodes): `runCli()`, `ak-scenario.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `runCli()`, `ak-scenario.test.js`
+- **Thin community `Community 242`** (2 nodes): `runCli()`, `ak-affinity-summary.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `runCli()`, `ak-affinity-summary.test.js`
+- **Thin community `Community 243`** (2 nodes): `readJson()`, `demo-smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (2 nodes): `readJson()`, `demo-smoke.test.js`
+- **Thin community `Community 244`** (2 nodes): `runCli()`, `ak-adapter-commands.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `runCli()`, `ak-adapter-commands.test.js`
+- **Thin community `Community 245`** (2 nodes): `loadMapper()`, `build-spec-map.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `loadMapper()`, `build-spec-map.test.js`
+- **Thin community `Community 246`** (2 nodes): `readAllocatorFixture()`, `budget-ledger.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `readAllocatorFixture()`, `budget-ledger.test.js`
+- **Thin community `Community 247`** (2 nodes): `readAllocatorFixture()`, `allocator-validation.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `readAllocatorFixture()`, `allocator-validation.test.js`
+- **Thin community `Community 248`** (2 nodes): `assertMissingField()`, `schema-validation.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `assertMissingField()`, `schema-validation.test.js`
+- **Thin community `Community 249`** (2 nodes): `readPlacementFixture()`, `actor-placement-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `readPlacementFixture()`, `actor-placement-fixtures.test.js`
+- **Thin community `Community 250`** (2 nodes): `roundTrip()`, `roundtrip.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `roundTrip()`, `roundtrip.test.js`
+- **Thin community `Community 251`** (2 nodes): `assertVitals()`, `actor-state-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `assertVitals()`, `actor-state-fixtures.test.js`
+- **Thin community `Community 252`** (2 nodes): `coordsEqual()`, `basic-mvp-actor-movement.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `coordsEqual()`, `basic-mvp-actor-movement.test.js`
+- **Thin community `Community 253`** (2 nodes): `runNodeTest()`, `node-test-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `runNodeTest()`, `node-test-runner.js`
+- **Thin community `Community 254`** (2 nodes): `shouldReuseActiveRun()`, `gameplay-launch.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `shouldReuseActiveRun()`, `gameplay-launch.js`
+- **Thin community `Community 255`** (2 nodes): `tabs.js`, `wireTabs()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `tabs.js`, `wireTabs()`
+- **Thin community `Community 256`** (2 nodes): `buildBuildSpecPrompt()`, `ollama-template.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `buildBuildSpecPrompt()`, `ollama-template.js`
+- **Thin community `Community 257`** (2 nodes): `wireDesignView()`, `design-view.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `wireDesignView()`, `design-view.js`
+- **Thin community `Community 258`** (2 nodes): `phaser-frame-view.js`, `createPhaserFrameView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `phaser-frame-view.js`, `createPhaserFrameView()`
+- **Thin community `Community 259`** (2 nodes): `runtime.js`, `createRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `runtime.js`, `createRuntime()`
+- **Thin community `Community 260`** (2 nodes): `resolveBudgetCategoryId()`, `budget-categories.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `resolveBudgetCategoryId()`, `budget-categories.js`
+- **Thin community `Community 261`** (2 nodes): `getAffinitySpriteAsset()`, `affinity-sprite-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `getAffinitySpriteAsset()`, `affinity-sprite-assets.js`
+- **Thin community `Community 262`** (2 nodes): `getGameSpriteAsset()`, `game-sprite-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `getGameSpriteAsset()`, `game-sprite-assets.js`
+- **Thin community `Community 263`** (2 nodes): `createModeratorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `createModeratorPersona()`, `controller.js`
+- **Thin community `Community 264`** (2 nodes): `createAnnotatorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `createAnnotatorPersona()`, `controller.js`
+- **Thin community `Community 265`** (2 nodes): `createAllocatorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `createAllocatorPersona()`, `controller.js`
+- **Thin community `Community 266`** (2 nodes): `createConfiguratorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `createConfiguratorPersona()`, `controller.js`
+- **Thin community `Community 267`** (2 nodes): `createOrchestratorPersona()`, `controller.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `createOrchestratorPersona()`, `controller.js`
+- **Thin community `Community 268`** (2 nodes): `applyBudgetCaps()`, `budget.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `applyBudgetCaps()`, `budget.js`
+- **Thin community `Community 269`** (2 nodes): `createLlmTestAdapter()`, `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `createLlmTestAdapter()`, `index.js`
+- **Thin community `Community 270`** (2 nodes): `createBlockchainTestAdapter()`, `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `createBlockchainTestAdapter()`, `index.js`
+- **Thin community `Community 271`** (2 nodes): `createDomLogAdapter()`, `dom-log.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `createDomLogAdapter()`, `dom-log.js`
+- **Thin community `Community 272`** (2 nodes): `createWebSolverAdapter()`, `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `createWebSolverAdapter()`, `index.js`
+- **Thin community `Community 273`** (1 nodes): `ak-tool-schema.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (1 nodes): `ak-tool-schema.js`
+- **Thin community `Community 274`** (1 nodes): `ui-startup-readiness.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (1 nodes): `ui-startup-readiness.test.js`
+- **Thin community `Community 275`** (1 nodes): `remote-ollama-benchmark.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (1 nodes): `remote-ollama-benchmark.test.js`
+- **Thin community `Community 276`** (1 nodes): `affinity-pipeline-e2e.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (1 nodes): `affinity-pipeline-e2e.test.js`
+- **Thin community `Community 277`** (1 nodes): `motivation-pipeline-e2e.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (1 nodes): `motivation-pipeline-e2e.test.js`
+- **Thin community `Community 278`** (1 nodes): `ui-aura-display.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (1 nodes): `ui-aura-display.test.js`
+- **Thin community `Community 279`** (1 nodes): `captured-input-artifact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (1 nodes): `captured-input-artifact.test.js`
+- **Thin community `Community 280`** (1 nodes): `summary-selections.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (1 nodes): `summary-selections.test.js`
+- **Thin community `Community 281`** (1 nodes): `resource-bundle-aura-rendering.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (1 nodes): `resource-bundle-aura-rendering.test.js`
+- **Thin community `Community 282`** (1 nodes): `runtime-moderator-control.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (1 nodes): `runtime-moderator-control.test.js`
+- **Thin community `Community 283`** (1 nodes): `runtime-plan-artifact.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (1 nodes): `runtime-plan-artifact.test.js`
+- **Thin community `Community 284`** (1 nodes): `budget-caps.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (1 nodes): `budget-caps.test.js`
+- **Thin community `Community 285`** (1 nodes): `runner-effects.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (1 nodes): `runner-effects.test.js`
+- **Thin community `Community 286`** (1 nodes): `ports.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (1 nodes): `ports.test.js`
+- **Thin community `Community 287`** (1 nodes): `design-spend-ledger.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (1 nodes): `design-spend-ledger.test.js`
+- **Thin community `Community 288`** (1 nodes): `motivation-loadouts.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (1 nodes): `motivation-loadouts.test.js`
+- **Thin community `Community 289`** (1 nodes): `affinity-tile-mask.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (1 nodes): `affinity-tile-mask.test.js`
+- **Thin community `Community 290`** (1 nodes): `configurator-startup.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (1 nodes): `configurator-startup.test.js`
+- **Thin community `Community 291`** (1 nodes): `affinity-spatial-formulas.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (1 nodes): `affinity-spatial-formulas.test.js`
+- **Thin community `Community 292`** (1 nodes): `run-helpers-runtime-decision.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (1 nodes): `run-helpers-runtime-decision.test.js`
+- **Thin community `Community 293`** (1 nodes): `e2e-fixture-generators.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (1 nodes): `e2e-fixture-generators.test.js`
+- **Thin community `Community 294`** (1 nodes): `pool-buildspec.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (1 nodes): `pool-buildspec.test.js`
+- **Thin community `Community 295`** (1 nodes): `mvp-movement.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (1 nodes): `mvp-movement.test.js`
+- **Thin community `Community 296`** (1 nodes): `prompt-contract.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (1 nodes): `prompt-contract.test.js`
+- **Thin community `Community 297`** (1 nodes): `runner-smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (1 nodes): `runner-smoke.test.js`
+- **Thin community `Community 298`** (1 nodes): `runtime-moderator-affinity-actions.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (1 nodes): `runtime-moderator-affinity-actions.test.js`
+- **Thin community `Community 299`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 300`** (1 nodes): `pool-catalog.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (1 nodes): `pool-catalog.test.js`
+- **Thin community `Community 301`** (1 nodes): `schema-catalog.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (1 nodes): `schema-catalog.test.js`
+- **Thin community `Community 302`** (1 nodes): `affinity-palette.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (1 nodes): `affinity-palette.test.js`
+- **Thin community `Community 303`** (1 nodes): `affinity-aura-lifecycle.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (1 nodes): `affinity-aura-lifecycle.test.js`
+- **Thin community `Community 304`** (1 nodes): `pool-budget.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (1 nodes): `pool-budget.test.js`
+- **Thin community `Community 305`** (1 nodes): `runtime-persona-schedule.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (1 nodes): `runtime-persona-schedule.test.js`
+- **Thin community `Community 306`** (1 nodes): `pool-mapper.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (1 nodes): `pool-mapper.test.js`
+- **Thin community `Community 307`** (1 nodes): `runtime-allocator-signals.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (1 nodes): `runtime-allocator-signals.test.js`
+- **Thin community `Community 308`** (1 nodes): `actor-proposal-replay.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (1 nodes): `actor-proposal-replay.test.js`
+- **Thin community `Community 309`** (1 nodes): `card-authoring.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (1 nodes): `card-authoring.test.js`
+- **Thin community `Community 310`** (1 nodes): `runtime-decision-contract.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (1 nodes): `runtime-decision-contract.test.js`
+- **Thin community `Community 311`** (1 nodes): `multi-actor-initial-state.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (1 nodes): `multi-actor-initial-state.test.js`
+- **Thin community `Community 312`** (1 nodes): `solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (1 nodes): `solver.test.js`
+- **Thin community `Community 313`** (1 nodes): `effects-routing.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (1 nodes): `effects-routing.test.js`
+- **Thin community `Community 314`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 315`** (1 nodes): `fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (1 nodes): `fixtures.test.js`
+- **Thin community `Community 316`** (1 nodes): `allocator-solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (1 nodes): `allocator-solver.test.js`
+- **Thin community `Community 317`** (1 nodes): `orchestrator-llm-capture.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (1 nodes): `orchestrator-llm-capture.test.js`
+- **Thin community `Community 318`** (1 nodes): `allocator-motivation-price-policy.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (1 nodes): `allocator-motivation-price-policy.test.js`
+- **Thin community `Community 319`** (1 nodes): `moderator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (1 nodes): `moderator-persona-phase.test.js`
+- **Thin community `Community 320`** (1 nodes): `configurator-artifact-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (1 nodes): `configurator-artifact-fixtures.test.js`
+- **Thin community `Community 321`** (1 nodes): `director-budget-allocation.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (1 nodes): `director-budget-allocation.test.js`
+- **Thin community `Community 322`** (1 nodes): `moderator-affinity-target-effects.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (1 nodes): `moderator-affinity-target-effects.test.js`
+- **Thin community `Community 323`** (1 nodes): `configurator-artifact-builders.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (1 nodes): `configurator-artifact-builders.test.js`
+- **Thin community `Community 324`** (1 nodes): `annotator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (1 nodes): `annotator-state-machine.test.js`
+- **Thin community `Community 325`** (1 nodes): `configurator-affinity-interaction-core.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (1 nodes): `configurator-affinity-interaction-core.test.js`
+- **Thin community `Community 326`** (1 nodes): `director-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (1 nodes): `director-persona-phase.test.js`
+- **Thin community `Community 327`** (1 nodes): `allocator-motivation-spend-integration.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (1 nodes): `allocator-motivation-spend-integration.test.js`
+- **Thin community `Community 328`** (1 nodes): `tick-orchestrator.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (1 nodes): `tick-orchestrator.test.js`
+- **Thin community `Community 329`** (1 nodes): `configurator-level-strategy-map.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (1 nodes): `configurator-level-strategy-map.test.js`
+- **Thin community `Community 330`** (1 nodes): `actor-budget-gating.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (1 nodes): `actor-budget-gating.test.js`
+- **Thin community `Community 331`** (1 nodes): `configurator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (1 nodes): `configurator-state-machine.test.js`
+- **Thin community `Community 332`** (1 nodes): `actor-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (1 nodes): `actor-state-machine.test.js`
+- **Thin community `Community 333`** (1 nodes): `orchestrator-budget-inputs.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (1 nodes): `orchestrator-budget-inputs.test.js`
+- **Thin community `Community 334`** (1 nodes): `allocator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (1 nodes): `allocator-persona-phase.test.js`
+- **Thin community `Community 335`** (1 nodes): `orchestrator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (1 nodes): `orchestrator-state-machine.test.js`
+- **Thin community `Community 336`** (1 nodes): `orchestrator-llm-session.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (1 nodes): `orchestrator-llm-session.test.js`
+- **Thin community `Community 337`** (1 nodes): `configurator-level-gen-input.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (1 nodes): `configurator-level-gen-input.test.js`
+- **Thin community `Community 338`** (1 nodes): `configurator-actor-generator.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (1 nodes): `configurator-actor-generator.test.js`
+- **Thin community `Community 339`** (1 nodes): `annotator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (1 nodes): `annotator-persona-phase.test.js`
+- **Thin community `Community 340`** (1 nodes): `annotator-llm-trace.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (1 nodes): `annotator-llm-trace.test.js`
+- **Thin community `Community 341`** (1 nodes): `moderator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (1 nodes): `moderator-state-machine.test.js`
+- **Thin community `Community 342`** (1 nodes): `tick-inspect.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (1 nodes): `tick-inspect.test.js`
+- **Thin community `Community 343`** (1 nodes): `allocator-actor-behavior.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (1 nodes): `allocator-actor-behavior.test.js`
+- **Thin community `Community 344`** (1 nodes): `director-solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (1 nodes): `director-solver.test.js`
+- **Thin community `Community 345`** (1 nodes): `configurator-feasibility.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (1 nodes): `configurator-feasibility.test.js`
+- **Thin community `Community 346`** (1 nodes): `configurator-affinity-loadouts.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (1 nodes): `configurator-affinity-loadouts.test.js`
+- **Thin community `Community 347`** (1 nodes): `allocator-motivation-cost-core.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (1 nodes): `allocator-motivation-cost-core.test.js`
+- **Thin community `Community 348`** (1 nodes): `orchestrator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (1 nodes): `orchestrator-persona-phase.test.js`
+- **Thin community `Community 349`** (1 nodes): `director-configurator-behavior.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (1 nodes): `director-configurator-behavior.test.js`
+- **Thin community `Community 350`** (1 nodes): `configurator-motivation-evaluation-core.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (1 nodes): `configurator-motivation-evaluation-core.test.js`
+- **Thin community `Community 351`** (1 nodes): `orchestrator-llm-budget-loop.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (1 nodes): `orchestrator-llm-budget-loop.test.js`
+- **Thin community `Community 352`** (1 nodes): `configurator-affinity-effects.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (1 nodes): `configurator-affinity-effects.test.js`
+- **Thin community `Community 353`** (1 nodes): `configurator-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (1 nodes): `configurator-persona-phase.test.js`
+- **Thin community `Community 354`** (1 nodes): `allocator-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (1 nodes): `allocator-state-machine.test.js`
+- **Thin community `Community 355`** (1 nodes): `actor-persona-phase.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (1 nodes): `actor-persona-phase.test.js`
+- **Thin community `Community 356`** (1 nodes): `tick-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (1 nodes): `tick-state-machine.test.js`
+- **Thin community `Community 357`** (1 nodes): `annotator-telemetry.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (1 nodes): `annotator-telemetry.test.js`
+- **Thin community `Community 358`** (1 nodes): `actor-runtime-decision.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (1 nodes): `actor-runtime-decision.test.js`
+- **Thin community `Community 359`** (1 nodes): `orchestrator-llm-budget-loop-feasibility.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (1 nodes): `orchestrator-llm-budget-loop-feasibility.test.js`
+- **Thin community `Community 360`** (1 nodes): `actor-persona-filter.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (1 nodes): `actor-persona-filter.test.js`
+- **Thin community `Community 361`** (1 nodes): `configurator-solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (1 nodes): `configurator-solver.test.js`
+- **Thin community `Community 362`** (1 nodes): `configurator-trap-vitals.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (1 nodes): `configurator-trap-vitals.test.js`
+- **Thin community `Community 363`** (1 nodes): `configurator-actor-config-generation.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (1 nodes): `configurator-actor-config-generation.test.js`
+- **Thin community `Community 364`** (1 nodes): `director-state-machine.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (1 nodes): `director-state-machine.test.js`
+- **Thin community `Community 365`** (1 nodes): `incentive-model.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (1 nodes): `incentive-model.test.js`
+- **Thin community `Community 366`** (1 nodes): `budget-allocation.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (1 nodes): `budget-allocation.test.js`
+- **Thin community `Community 367`** (1 nodes): `cost-model.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (1 nodes): `cost-model.test.js`
+- **Thin community `Community 368`** (1 nodes): `budget-pool-handoff.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (1 nodes): `budget-pool-handoff.test.js`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (1 nodes): `motivation-pricing.test.js`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (1 nodes): `solver.test.js`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (1 nodes): `adapter-modules.test.js`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 369`** (1 nodes): `motivation-pricing.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 370`** (1 nodes): `solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (1 nodes): `adapter-fixtures.test.js`
+- **Thin community `Community 371`** (1 nodes): `adapter-modules.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (1 nodes): `adapter-modules.test.js`
+- **Thin community `Community 372`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 373`** (1 nodes): `solver.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (1 nodes): `allocator-selection-spend.test.js`
+- **Thin community `Community 374`** (1 nodes): `adapter-fixtures.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (1 nodes): `allocator-layout-spend.test.js`
+- **Thin community `Community 375`** (1 nodes): `adapter-modules.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (1 nodes): `level-generation-benchmark.test.js`
+- **Thin community `Community 376`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (1 nodes): `observation-static-traps.test.js`
+- **Thin community `Community 377`** (1 nodes): `allocator-selection-spend.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (1 nodes): `observation-affinity.test.js`
+- **Thin community `Community 378`** (1 nodes): `allocator-layout-spend.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (1 nodes): `affinity-readers.test.js`
+- **Thin community `Community 379`** (1 nodes): `level-generation-benchmark.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (1 nodes): `smoke.test.js`
+- **Thin community `Community 380`** (1 nodes): `observation-static-traps.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (1 nodes): `core-ts.test.js`
+- **Thin community `Community 381`** (1 nodes): `observation-affinity.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (1 nodes): `movement.test.js`
+- **Thin community `Community 382`** (1 nodes): `affinity-readers.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (1 nodes): `motivation-readers.test.js`
+- **Thin community `Community 383`** (1 nodes): `smoke.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (1 nodes): `index.js`
+- **Thin community `Community 384`** (1 nodes): `core-ts.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (1 nodes): `index.ts`
+- **Thin community `Community 385`** (1 nodes): `movement.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (1 nodes): `artifacts.ts`
+- **Thin community `Community 386`** (1 nodes): `motivation-readers.test.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (1 nodes): `persona.js`
+- **Thin community `Community 387`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (1 nodes): `contracts.ts`
+- **Thin community `Community 388`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (1 nodes): `idle.ts`
+- **Thin community `Community 389`** (1 nodes): `artifacts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 390`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2599,19 +2606,19 @@ Nodes (1): Structured Stdout Contract
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 398`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (1 nodes): `movement-directions.js`
+- **Thin community `Community 399`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (1 nodes): `persona.js`
+- **Thin community `Community 400`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (1 nodes): `contracts.ts`
+- **Thin community `Community 401`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (1 nodes): `defaults.js`
+- **Thin community `Community 402`** (1 nodes): `movement-directions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (1 nodes): `idle.ts`
+- **Thin community `Community 403`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (1 nodes): `persona.js`
+- **Thin community `Community 404`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (1 nodes): `contracts.ts`
+- **Thin community `Community 405`** (1 nodes): `defaults.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 406`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2621,9 +2628,9 @@ Nodes (1): Structured Stdout Contract
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 409`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (1 nodes): `contracts.ts`
+- **Thin community `Community 410`** (1 nodes): `persona.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (1 nodes): `controller.ts`
+- **Thin community `Community 411`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 412`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2657,17 +2664,23 @@ Nodes (1): Structured Stdout Contract
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 427`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (1 nodes): `map.js`
+- **Thin community `Community 428`** (1 nodes): `contracts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (1 nodes): `capability.ts`
+- **Thin community `Community 429`** (1 nodes): `controller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (1 nodes): `Solver-Z3 Adapter`
+- **Thin community `Community 430`** (1 nodes): `idle.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (1 nodes): `CLI build Command`
+- **Thin community `Community 431`** (1 nodes): `map.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (1 nodes): `CLI llm-plan Command`
+- **Thin community `Community 432`** (1 nodes): `capability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (1 nodes): `Structured Stdout Contract`
+- **Thin community `Community 433`** (1 nodes): `Solver-Z3 Adapter`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 434`** (1 nodes): `CLI build Command`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 435`** (1 nodes): `CLI llm-plan Command`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 436`** (1 nodes): `Structured Stdout Contract`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -2678,9 +2691,9 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+- **Should `Community 2` be split into smaller, more focused modules?**
+  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**

--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -2452,6 +2452,36 @@ async function summarizeBuildLikeOutput({
   });
 }
 
+const GAMEPLAY_BUNDLE_SCHEMA = "agent-kernel/GameplayBundle";
+
+// Assemble a post-run agent-kernel/GameplayBundle by merging the resolved
+// SimConfig/InitialState artifacts that `run` writes with the tick frames it
+// recorded. Matches the shape produced by
+// packages/runtime/src/runner/core-facade.js compileScenarioPlaybackBundle
+// ({ schema, schemaVersion, meta, artifacts: [simConfig, initialState], spec, tickFrames })
+// so the UI's window.__ak_loadGameplayBundle / sandbox-bridge-client can consume
+// it unchanged. Unlike compileScenarioPlaybackBundle (which re-runs the
+// simulation itself), this reuses the tick frames already produced by `run`
+// rather than re-executing the sim.
+function buildGameplayBundleFromRunArtifacts({ runId, createdAt, simConfig, initialState, tickFrames, spec } = {}) {
+  if (!simConfig || !initialState || !Array.isArray(tickFrames)) {
+    return null;
+  }
+  return {
+    schema: GAMEPLAY_BUNDLE_SCHEMA,
+    schemaVersion: 1,
+    meta: {
+      id: runId || simConfig?.meta?.runId || initialState?.meta?.runId || "run",
+      runId: runId || simConfig?.meta?.runId || initialState?.meta?.runId || "run",
+      createdAt: createdAt || new Date().toISOString(),
+      producedBy: "cli-run",
+    },
+    artifacts: [simConfig, initialState],
+    ...(spec ? { spec } : {}),
+    tickFrames,
+  };
+}
+
 async function summarizeRunOutput({ outDir, args } = {}) {
   const runSummary = await readJsonIfExists(join(outDir, "run-summary.json"));
   const resolvedSimConfigPath = join(outDir, "resolved-sim-config.json");
@@ -2479,10 +2509,61 @@ async function summarizeRunOutput({ outDir, args } = {}) {
   if (existsSync(resolvedInitialStatePath)) {
     artifactPaths.resolved_initial_state = resolvedInitialStatePath;
   }
+
+  // M7 gap 3: stitch a post-run agent-kernel/GameplayBundle from the artifacts
+  // this run just (re)wrote so ak_push_to_ui has something to deliver to the UI.
+  const runId = runSummary?.meta?.runId || simConfig?.meta?.runId || initialState?.meta?.runId || "";
+  const tickFrames = await readJsonIfExists(artifactPaths.tick_frames);
+  // When the run's inputs came from an ak_create outDir, that directory holds
+  // the pre-run preview bundle.json ({ spec, schemas, artifacts } — no
+  // schema/schemaVersion/tickFrames). Carry its spec/schemas and any artifacts
+  // that the run does not supersede (e.g. ResourceBundleArtifact) into the
+  // post-run bundle, and upgrade that sibling bundle.json in place so the
+  // create outDir also ends up holding a loadable playback bundle.
+  const sourceSimConfigPath = resolvePath(args["sim-config"]);
+  const createBundlePath = sourceSimConfigPath ? join(dirname(sourceSimConfigPath), "bundle.json") : null;
+  const createBundle = createBundlePath && createBundlePath !== join(outDir, "bundle.json")
+    ? await readJsonIfExists(createBundlePath)
+    : null;
+  // Only stitch when the run's inputs came from an authored create outDir
+  // (identified by its pre-run bundle.json sibling). Fixture-driven runs stay
+  // bundle-free so CLI run output remains artifact-for-artifact equivalent to
+  // the browser host's run output (tests/integration/ui-cli-equivalence.test.js).
+  const bundle = createBundle && typeof createBundle === "object"
+    ? buildGameplayBundleFromRunArtifacts({
+      runId,
+      createdAt: runSummary?.meta?.createdAt,
+      simConfig,
+      initialState,
+      tickFrames: Array.isArray(tickFrames) ? tickFrames : null,
+      spec: createBundle.spec,
+    })
+    : null;
+  if (bundle) {
+    const SUPERSEDED_BY_RUN = new Set([
+      simConfig?.schema,
+      initialState?.schema,
+    ]);
+    const carriedArtifacts = Array.isArray(createBundle.artifacts)
+      ? createBundle.artifacts.filter((artifact) => artifact?.schema && !SUPERSEDED_BY_RUN.has(artifact.schema))
+      : [];
+    if (carriedArtifacts.length > 0) {
+      bundle.artifacts = [...bundle.artifacts, ...carriedArtifacts];
+    }
+    if (createBundle.schemas !== undefined) {
+      bundle.schemas = createBundle.schemas;
+    }
+    const bundlePath = join(outDir, "bundle.json");
+    await writeJson(bundlePath, bundle);
+    artifactPaths.bundle = bundlePath;
+    await writeJson(createBundlePath, bundle);
+    artifactPaths.create_bundle = createBundlePath;
+  }
+
   return {
     ok: true,
     command: "run",
-    runId: runSummary?.meta?.runId || simConfig?.meta?.runId || initialState?.meta?.runId || "",
+    runId,
     outDir,
     actorIds: deriveActorIds(initialState),
     roomIds: deriveRoomIds(simConfig),
@@ -3971,17 +4052,42 @@ function ensureAuthoringLevelGenCapacity(levelGen, { walkableTilesTarget, traps,
   // +4 = 2 walls + 2 padding so the clamp in readRoomSettings allows the full room size
   const profileGridSide = profileMinSize + 4;
 
+  // Grid capacity must also scale with the TOTAL requested room count, not just a single
+  // room's size profile. level-layout.js's placeRooms() lays candidate rooms out in a
+  // roughly-square grid of surface slots (buildRoomSurfaceSlots); if the interior is only
+  // just big enough for one room of roomMaxSize, additional rooms silently fail to place
+  // and orchestrateBuild returns fewer rooms than requested (confirmed: a 15x15 grid with
+  // roomCount=5/roomMinSize=roomMaxSize=5 deterministically yields only 4 placed rooms).
+  // Size the grid so a sqrt(roomCount) x sqrt(roomCount) arrangement of roomMaxSize rooms
+  // (plus 1-tile spacing per room and a 4-tile wall/padding border) always fits. Only
+  // applies when more than one room is requested — profileGridSide already sizes the
+  // single-room case correctly, and widening it here would shift absolute tile
+  // coordinates that other authoring flags (e.g. --trap x=..;y=..) depend on.
+  const requestedRoomCount = rooms.reduce((sum, entry) => {
+    const count = Number.isInteger(entry?.value?.count) && entry.value.count > 0 ? entry.value.count : 1;
+    return sum + count;
+  }, 0);
+  const roomCapacitySide = requestedRoomCount > 1
+    ? (() => {
+      const columns = Math.ceil(Math.sqrt(requestedRoomCount));
+      const gridRows = Math.max(1, Math.ceil(requestedRoomCount / columns));
+      return Math.max(columns, gridRows) * (sizeProfile.roomMaxSize + 1) + 4;
+    })()
+    : 0;
+
   const width = Math.max(
     Number.isInteger(levelGen?.width) ? levelGen.width : 0,
     walkableSide,
     trapWidth,
     profileGridSide,
+    roomCapacitySide,
   );
   const height = Math.max(
     Number.isInteger(levelGen?.height) ? levelGen.height : 0,
     walkableSide,
     trapHeight,
     profileGridSide,
+    roomCapacitySide,
   );
   const shape = levelGen?.shape && typeof levelGen.shape === "object" && !Array.isArray(levelGen.shape)
     ? { ...levelGen.shape }
@@ -4703,6 +4809,59 @@ function buildArtifactRefs(entries) {
     schema: entry.schema,
     schemaVersion: entry.schemaVersion,
   }));
+}
+
+// Extract the primary motivation string from a parsed delver/warden card's
+// `motivations` array. Delver cards append a synthetic "user_controlled" tag
+// (see parseDelverSpec) alongside the actual requested motivation, so that
+// tag must be excluded when resolving the single motivation.kind value the
+// runtime persona layer reads (resolveActorMotivationKind expects
+// actor.motivation.kind — see packages/runtime/src/personas/actor/controller.js).
+function resolvePrimaryCardMotivation(card) {
+  const motivations = Array.isArray(card?.motivations) ? card.motivations : [];
+  return motivations.find((entry) => entry && entry !== "user_controlled") || null;
+}
+
+// ak_create/ak_configure accept --delver/--warden "motivation=<kind>" but
+// orchestrateBuild (packages/runtime) does not carry that value through onto
+// the actor records it writes into InitialStateArtifact — it is only used
+// authoring-side for cost calculation (hasNonStationaryMobilityMotivation /
+// requiresMovementStamina). Patch `motivation: { kind }` onto each actor here,
+// matched by archetype + base-id prefix back to the parsed CLI card that
+// produced it. InitialStateArtifactV1.actors entries are not a closed/enumerated
+// key set (packages/runtime/src/contracts/artifacts.ts), so adding this field
+// does not require a schemaVersion bump.
+function applyMotivationToInitialStateActors(initialState, { parsedDelvers = [], parsedWardens = [] } = {}) {
+  const actors = Array.isArray(initialState?.actors) ? initialState.actors : [];
+  if (actors.length === 0) {
+    return;
+  }
+
+  const cardsByArchetype = {
+    delver: parsedDelvers.map((entry) => ({
+      baseId: entry?.value?.id,
+      motivation: resolvePrimaryCardMotivation(entry?.value),
+    })).filter((entry) => isNonEmptyString(entry.baseId) && isNonEmptyString(entry.motivation)),
+    warden: parsedWardens.map((entry) => ({
+      baseId: entry?.value?.id,
+      motivation: resolvePrimaryCardMotivation(entry?.value),
+    })).filter((entry) => isNonEmptyString(entry.baseId) && isNonEmptyString(entry.motivation)),
+  };
+
+  if (cardsByArchetype.delver.length === 0 && cardsByArchetype.warden.length === 0) {
+    return;
+  }
+
+  actors.forEach((actor) => {
+    const cards = cardsByArchetype[actor?.archetype];
+    if (!cards || cards.length === 0) {
+      return;
+    }
+    const match = cards.find((card) => actor.id === card.baseId || actor.id.startsWith(`${card.baseId}-`));
+    if (match) {
+      actor.motivation = { kind: match.motivation };
+    }
+  });
 }
 
 function attachMixedRoomAssembliesToBuildResult(buildResult) {
@@ -5516,6 +5675,7 @@ async function agentAuthoringCommand(argv, { commandName, action, allowDryRun = 
     producedBy: `cli-${commandName}`,
   });
   attachMixedRoomAssembliesToBuildResult(buildResult);
+  applyMotivationToInitialStateActors(buildResult.initialState, { parsedDelvers, parsedWardens });
 
   if (args["dry-run"]) {
     emitJsonStdout(buildDryRunSuccess({

--- a/packages/adapters-cli/src/mcp/tools/sandbox.mjs
+++ b/packages/adapters-cli/src/mcp/tools/sandbox.mjs
@@ -19,6 +19,7 @@ import {
 } from "../../../../runtime/src/contracts/sandbox-session.mjs";
 import { createDefaultResourceBundleArtifact } from "../../../../runtime/src/render/resource-bundle.js";
 import {
+  booleanSchema,
   createHandlerTool,
   integerSchema,
   pathSchema,
@@ -26,6 +27,7 @@ import {
   stringSchema,
   withCommonOutput,
 } from "./shared.mjs";
+import { getSandboxBridgeState, pushGameplayBundle } from "../bridge-server.mjs";
 
 // ---------------------------------------------------------------------------
 // Local I/O helpers (self-contained — no dependency on ak-impl.mjs)
@@ -935,6 +937,148 @@ export async function executeSandboxMove({
 }
 
 // ---------------------------------------------------------------------------
+// ak_push_to_ui — M7 gap 4: deliver a create+run GameplayBundle to the UI (M8 bridge)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_BRIDGE_PORT = Number(process.env.AK_SANDBOX_BRIDGE_PORT) || 38487;
+
+function makePushMessageId() {
+  return `msg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/**
+ * Push a compiled agent-kernel/GameplayBundle to the sandbox WS bridge so a
+ * connected browser UI (packages/ui-web/src/sandbox-bridge-client.js) loads
+ * it into the gameplay Phaser surface.
+ *
+ * Accepts either:
+ *   - `bundle`: an inline GameplayBundle object, or
+ *   - `bundlePath`: an explicit path to a GameplayBundle JSON file, or
+ *   - `outDir`: a run/create outDir containing bundle.json (the shape written
+ *     by `run` per the M7 gap-3 stitching step, or by `create` pre-run).
+ *
+ * @param {object} options
+ * @param {object} [options.bundle]
+ * @param {string} [options.bundlePath]
+ * @param {string} [options.outDir]
+ * @param {string} [options.targetTab]      "design" | "gameplay" (default "gameplay").
+ * @param {boolean} [options.requireClient] Fail if no browser UI is connected (default true).
+ * @param {string} [options.correlationId]
+ * @returns {Promise<object>}
+ */
+export async function executePushToUi({
+  bundle: inlineBundle,
+  bundlePath,
+  outDir,
+  targetTab = "gameplay",
+  requireClient = true,
+  correlationId,
+} = {}) {
+  let bundle = inlineBundle;
+
+  if (!bundle) {
+    const resolvedBundlePath = isNonEmptyString(bundlePath)
+      ? resolve(bundlePath)
+      : isNonEmptyString(outDir)
+        ? join(resolve(outDir), "bundle.json")
+        : null;
+    if (!resolvedBundlePath) {
+      return {
+        ok: false,
+        command: "push-to-ui",
+        error: "ak_push_to_ui requires one of bundle, bundlePath, or outDir.",
+      };
+    }
+    if (!existsSync(resolvedBundlePath)) {
+      return {
+        ok: false,
+        command: "push-to-ui",
+        error: `No bundle found at ${resolvedBundlePath}.`,
+        bundleNotFound: true,
+      };
+    }
+    try {
+      bundle = await readJson(resolvedBundlePath);
+    } catch (err) {
+      return {
+        ok: false,
+        command: "push-to-ui",
+        error: `Cannot read bundle: ${err.message}`,
+      };
+    }
+  }
+
+  if (!bundle || typeof bundle !== "object" || !Array.isArray(bundle.artifacts)) {
+    return {
+      ok: false,
+      command: "push-to-ui",
+      error: "Bundle must be an agent-kernel/GameplayBundle object with an artifacts[] array.",
+      invalidBundle: true,
+    };
+  }
+
+  const state = getSandboxBridgeState();
+
+  if (state.startFailed) {
+    return {
+      ok: false,
+      command: "push-to-ui",
+      error: "SANDBOX_BRIDGE_START_FAILED",
+      message: `The sandbox bridge server failed to start (port may be in use). Check port ${DEFAULT_BRIDGE_PORT}.`,
+      bridge: { port: DEFAULT_BRIDGE_PORT, connectedClients: 0, startFailed: true },
+    };
+  }
+
+  if (requireClient && state.connectedClients === 0) {
+    return {
+      ok: false,
+      command: "push-to-ui",
+      error: "SANDBOX_UI_NOT_CONNECTED",
+      message:
+        "No browser UI is connected to the sandbox bridge. " +
+        "Open the UI dev server and ensure the bridge client is running, or set requireClient: false to pre-stage the bundle.",
+      bridge: { port: DEFAULT_BRIDGE_PORT, connectedClients: 0 },
+    };
+  }
+
+  const messageId = makePushMessageId();
+  // D4 (sandbox-bridge-client.js handleBundle): targetTab lives at the envelope
+  // root, not inside payload.
+  const envelope = {
+    type: "ak.gameplayBundle.v1",
+    id: messageId,
+    ...(correlationId ? { correlationId } : {}),
+    createdAt: new Date().toISOString(),
+    targetTab,
+    payload: {
+      bundle,
+      source: { tool: "ak_push_to_ui" },
+    },
+  };
+
+  const { deliveredClientIds, timedOutClientIds } = await pushGameplayBundle(envelope);
+
+  return {
+    ok: true,
+    command: "push-to-ui",
+    ...(correlationId ? { correlationId } : {}),
+    targetTab,
+    bridge: {
+      port: DEFAULT_BRIDGE_PORT,
+      connectedClients: state.connectedClients,
+      deliveredClientIds,
+      timedOutClientIds,
+    },
+    bundleSummary: {
+      schema: bundle.schema,
+      schemaVersion: bundle.schemaVersion,
+      artifactCount: bundle.artifacts.length,
+      tickFrameCount: Array.isArray(bundle.tickFrames) ? bundle.tickFrames.length : 0,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // MCP tool definition
 // ---------------------------------------------------------------------------
 
@@ -1060,6 +1204,51 @@ export const sandboxTools = [
         actorId: isNonEmptyString(args.actorId) ? args.actorId : undefined,
         direction: isNonEmptyString(args.direction) ? args.direction : undefined,
         actionsOut: isNonEmptyString(args.actionsOut) ? args.actionsOut : undefined,
+      }),
+  }),
+
+  createHandlerTool({
+    name: "ak_push_to_ui",
+    description:
+      "Deliver a compiled agent-kernel/GameplayBundle (produced by ak_create + ak_run) to the " +
+      "connected browser UI via the sandbox WebSocket bridge, so the Phaser gameplay surface can " +
+      "load and play back the run. Accepts an explicit bundlePath, an outDir containing bundle.json " +
+      "(the shape ak_run writes after M7 stitching), or an inline bundle object. " +
+      "Returns ok: false with bundleNotFound: true when no bundle is found at the resolved path, " +
+      "SANDBOX_UI_NOT_CONNECTED when no browser UI is connected and requireClient is true, and " +
+      "SANDBOX_BRIDGE_START_FAILED when the bridge server failed to start.",
+    inputSchema: {
+      properties: {
+        outDir: pathSchema(
+          "Run or create outDir containing bundle.json. Used when bundle/bundlePath are omitted.",
+        ),
+        bundlePath: pathSchema("Explicit path to an agent-kernel/GameplayBundle JSON file."),
+        bundle: {
+          type: "object",
+          additionalProperties: true,
+          description: "Inline agent-kernel/GameplayBundle object, taking precedence over bundlePath/outDir.",
+        },
+        targetTab: {
+          type: "string",
+          enum: ["design", "gameplay"],
+          description: "Which UI tab to activate after loading. Defaults to 'gameplay'.",
+          default: "gameplay",
+        },
+        requireClient: booleanSchema(
+          "When true (default), fail immediately if no browser UI is connected. " +
+            "When false, push and store the bundle for replay when the UI connects.",
+        ),
+        correlationId: stringSchema("Optional caller-supplied correlation ID echoed back in the result."),
+      },
+    },
+    handler: (args) =>
+      executePushToUi({
+        bundle: args.bundle && typeof args.bundle === "object" ? args.bundle : undefined,
+        bundlePath: isNonEmptyString(args.bundlePath) ? args.bundlePath : undefined,
+        outDir: isNonEmptyString(args.outDir) ? args.outDir : undefined,
+        targetTab: args.targetTab === "design" ? "design" : "gameplay",
+        requireClient: args.requireClient === false ? false : true,
+        correlationId: isNonEmptyString(args.correlationId) ? args.correlationId : undefined,
       }),
   }),
 ];

--- a/packages/core-ts/src/state/world.ts
+++ b/packages/core-ts/src/state/world.ts
@@ -982,7 +982,10 @@ export function createWorldState() {
 
     getActorPlacementCount: () => placementActorCount,
 
-    validateActorPlacement(): number {
+    // allowReservedTiles: run-seeding mode — an initial state may legitimately
+    // seat an actor on the spawn (or exit) tile at tick 0. Authoring-time
+    // placement keeps the strict default, which reserves those tiles.
+    validateActorPlacement(allowReservedTiles: boolean = false): number {
       const count = getPlacementCount();
       if (count <= 0) return ValidationError.None;
       if (placementActorOverflow || count > maxMotivatedActors)
@@ -997,8 +1000,9 @@ export function createWorldState() {
         const px = getPlacementX(i);
         const py = getPlacementY(i);
         if (
-          (spawnX >= 0 && spawnY >= 0 && px === spawnX && py === spawnY) ||
-          (exitX >= 0 && exitY >= 0 && px === exitX && py === exitY)
+          !allowReservedTiles &&
+          ((spawnX >= 0 && spawnY >= 0 && px === spawnX && py === spawnY) ||
+            (exitX >= 0 && exitY >= 0 && px === exitX && py === exitY))
         )
           return ValidationError.ActorBlocked;
         if (!isWalkableActorKindLocal(getTileActorKindAt(px, py)))
@@ -1011,12 +1015,12 @@ export function createWorldState() {
       return ValidationError.None;
     },
 
-    applyActorPlacements(): number {
+    applyActorPlacements(allowReservedTiles: boolean = false): number {
       const count = getPlacementCount();
       if (count <= 0) return ValidationError.None;
       if (placementActorOverflow || count > maxMotivatedActors)
         return ValidationError.TooManyActors;
-      const error = this.validateActorPlacement();
+      const error = this.validateActorPlacement(allowReservedTiles);
       if (error !== ValidationError.None) return error;
       motivatedActorCount = count;
       activeMotivatedActorIndex = 0;

--- a/packages/runtime/src/commands/kernel.js
+++ b/packages/runtime/src/commands/kernel.js
@@ -410,54 +410,13 @@ function requireHostFunction(host, name) {
 }
 
 function createCommandRuntimeCore() {
-  const core = createCore();
-  return {
-    init: core.init,
-    step: core.step,
-    applyAction: core.applyAction,
-    getCounter: core.getCounter,
-    configureGrid: core.configureGrid,
-    setTileAt: core.setTileAt,
-    spawnActorAt: core.spawnActorAt,
-    setActorVital: core.setActorVital,
-    setBudget: core.setBudget,
-    getBudget: core.getBudget,
-    getBudgetUsage: core.getBudgetUsage,
-    getEffectCount: core.getEffectCount,
-    getEffectKind: core.getEffectKind,
-    getEffectValue: core.getEffectValue,
-    clearEffects: core.clearEffects,
-    version: core.version,
-    // Observation functions — required by canReadObservation() so the runtime-fsm
-    // can provide actor positions and tile data to the actor persona's buildMoveProposal.
-    getMapWidth: core.getMapWidth,
-    getMapHeight: core.getMapHeight,
-    getActorX: core.getActorX,
-    getActorY: core.getActorY,
-    getActorKind: core.getActorKind,
-    getActorVitalCurrent: core.getActorVitalCurrent,
-    getActorVitalMax: core.getActorVitalMax,
-    getActorVitalRegen: core.getActorVitalRegen,
-    getTileActorKind: core.getTileActorKind,
-    getCurrentTick: core.getCurrentTick,
-    // Additional helpers used by readObservation and renderBaseTiles
-    getActorCount: core.getActorCount,
-    getActorId: core.getActorId,
-    getActorHp: core.getActorHp,
-    getActorMaxHp: core.getActorMaxHp,
-    getActorPlacementCount: core.getActorPlacementCount,
-    getAffinityEffectCount: core.getAffinityEffectCount,
-    getAffinityFieldIntensityAt: core.getAffinityFieldIntensityAt,
-    getAffinityFieldExpressionAt: core.getAffinityFieldExpressionAt,
-    armStaticTrapAt: core.armStaticTrapAt,
-    destroyBarrierAt: core.destroyBarrierAt,
-    raiseBarrierAt: core.raiseBarrierAt,
-    // Required by canRenderBaseTiles() so baseTiles string grid is available
-    // for pathfinding (findExitFromTiles / isPassable) in buildMoveProposal.
-    renderBaseCellChar: core.renderBaseCellChar,
-    // Required by applyActionsToCore "missing_move_exports" check before applyMoveAction.
-    setMoveAction: core.setMoveAction,
-  };
+  // Expose the FULL core surface. This used to be a hand-picked subset, but
+  // the runtime's capability checks (canReadObservation, canApplyActorPlacements,
+  // applyActionsToCore, ...) silently degrade to legacy single-actor paths when
+  // a probed function is missing — the subset caused two such silent
+  // degradations as the runtime grew. The command kernel has no reason to see
+  // less of the core than the playback runtime does.
+  return createCore();
 }
 
 async function captureAdapterPayload({ capture, index, baseDir, spec, producedBy, allowNetwork, host }) {

--- a/packages/runtime/src/personas/actor/controller.js
+++ b/packages/runtime/src/personas/actor/controller.js
@@ -829,7 +829,116 @@ function resolveNearestHostile(view, actorId) {
  *   stationary                     → wait (no action)
  *   any        + no hostile        → existing exit pathfinding
  */
-function buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimConfig }) {
+// ── M3: Random motivation helpers ──────────────────────────────────────────
+//
+// Deterministic, seed-derived pseudo-random selection — never Math.random(),
+// never a clock read. The RNG is a pure function of (seed, actorId, tick):
+// same inputs always produce the same output, independent of instance or
+// call history, satisfying both the "identical seed -> identical trajectory"
+// and "no shared mutable RNG state" requirements.
+
+function resolveActorRandomSeed(view, actorId, payload, personaSeed) {
+  if (view?.actors && Array.isArray(view.actors)) {
+    const self = view.actors.find((a) => a && a.id === actorId);
+    if (self?.motivation?.seed !== undefined && self.motivation.seed !== null) {
+      return self.motivation.seed;
+    }
+  }
+  const configActors = payload?.initialState?.actors;
+  if (Array.isArray(configActors)) {
+    const configActor = configActors.find((a) => a && a.id === actorId);
+    if (configActor?.motivation?.seed !== undefined && configActor.motivation.seed !== null) {
+      return configActor.motivation.seed;
+    }
+  }
+  if (payload?.seed !== undefined && payload?.seed !== null) return payload.seed;
+  if (personaSeed !== undefined && personaSeed !== null) return personaSeed;
+  return 0;
+}
+
+/** Deterministic 32-bit hash of a seed/actorId/tick tuple (no Math.random, no clock). */
+function hashRandomInputs(seed, actorId, tick) {
+  const text = `${String(seed)}:${String(actorId)}:${String(Number.isFinite(tick) ? tick : 0)}`;
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  // Final mix (mulberry32-style) so nearby hashes decorrelate before use.
+  hash ^= hash << 13;
+  hash ^= hash >>> 17;
+  hash ^= hash << 5;
+  return hash >>> 0;
+}
+
+/** Pure deterministic RNG value in [0, 1) derived from seed + actorId + tick + salt. */
+function deterministicRandom(seed, actorId, tick, salt = 0) {
+  const hashed = hashRandomInputs(seed, actorId, (Number.isFinite(tick) ? tick : 0) * 2654435761 + salt);
+  return hashed / 4294967296;
+}
+
+function isOccupied(position, view, actorId) {
+  if (!view?.actors || !Array.isArray(view.actors)) return false;
+  return view.actors.some(
+    (other) => other && other.id !== actorId && other.position
+      && other.position.x === position.x && other.position.y === position.y,
+  );
+}
+
+function isReserved(position, reservedTargets) {
+  if (!Array.isArray(reservedTargets) || reservedTargets.length === 0) return false;
+  return reservedTargets.some((target) => target && target.x === position.x && target.y === position.y);
+}
+
+/**
+ * Random motivation: choose among legal adjacent walkable, unoccupied tiles
+ * using a deterministic seed-derived RNG. If the first choice is blocked,
+ * bounce to another legal candidate (deterministically re-ordered, not
+ * re-rolled with fresh entropy). If no legal adjacent tile exists, wait.
+ *
+ * `payload.reservedTargets` (array of {x,y}) carries move targets already
+ * claimed by other actors earlier in the same DECIDE phase — the runtime
+ * advances the actor persona once per actor per tick (see
+ * packages/runtime/src/runner/runtime-fsm.mjs), so without this, two
+ * actors evaluated in the same tick could both choose an identical
+ * currently-unoccupied tile before core state is updated at APPLY time.
+ */
+function buildRandomMoveProposals({ observation, payload, lastBaseTiles, lastSimConfig, personaSeed }) {
+  const view = resolveObservationView(observation);
+  const actorId = payload?.actorId;
+  const actor = resolveActor(view, actorId, observation);
+  if (!actor?.position) return [{ kind: "wait", params: { reason: "random" } }];
+
+  const baseTiles = resolveBaseTiles(payload, view, lastBaseTiles, lastSimConfig);
+  const tileKinds = resolveTileKinds(view, payload);
+  const reservedTargets = payload?.reservedTargets;
+  const candidates = buildAdjacentMoveProposals({ actor, tileKinds, baseTiles })
+    .filter((proposal) => !isOccupied(proposal.params.to, view, actorId))
+    .filter((proposal) => !isReserved(proposal.params.to, reservedTargets));
+
+  if (candidates.length === 0) {
+    return [{ kind: "wait", params: { reason: "random" } }];
+  }
+
+  const seed = resolveActorRandomSeed(view, actorId, payload, personaSeed);
+  const roll = deterministicRandom(seed, actorId, payload?.tick, 0);
+  const index = Math.floor(roll * candidates.length) % candidates.length;
+  const chosen = candidates[index];
+
+  return [
+    {
+      kind: "move",
+      params: {
+        direction: chosen.params.direction,
+        from: chosen.params.from,
+        to: chosen.params.to,
+        reason: "random",
+      },
+    },
+  ];
+}
+
+function buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimConfig, personaSeed }) {
   const view = resolveObservationView(observation);
   if (!view) return buildMoveProposal({ observation, payload, lastBaseTiles, lastSimConfig });
 
@@ -838,12 +947,18 @@ function buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimC
   if (!actor?.position) return buildMoveProposal({ observation, payload, lastBaseTiles, lastSimConfig });
 
   const motivationKind = resolveActorMotivationKind(view, actorId, payload);
-  const hostile = resolveNearestHostile(view, actorId);
 
   // Stationary: never propose movement
   if (motivationKind === "stationary") {
     return [];
   }
+
+  // Random: seed-derived deterministic movement to a legal adjacent tile
+  if (motivationKind === "random") {
+    return buildRandomMoveProposals({ observation, payload, lastBaseTiles, lastSimConfig, personaSeed });
+  }
+
+  const hostile = resolveNearestHostile(view, actorId);
 
   if (hostile) {
     const adjacent = hostile.distance <= 1;
@@ -891,7 +1006,7 @@ function buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimC
   return buildMoveProposal({ observation, payload, lastBaseTiles, lastSimConfig });
 }
 
-export function createActorPersona({ initialState = ActorStates.IDLE, clock = () => new Date().toISOString() } = {}) {
+export function createActorPersona({ initialState = ActorStates.IDLE, clock = () => new Date().toISOString(), seed: personaSeed } = {}) {
   const fsm = createActorStateMachine({ initialState, clock });
   let lastObservation = null;
   let lastBaseTiles = null;
@@ -928,7 +1043,7 @@ export function createActorPersona({ initialState = ActorStates.IDLE, clock = ()
     }
 
     const shouldEmitActions = event === "propose";
-    const derivedProposals = shouldEmitActions ? buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimConfig }) : [];
+    const derivedProposals = shouldEmitActions ? buildMotivatedProposals({ observation, payload: { ...payload, tick }, lastBaseTiles, lastSimConfig, personaSeed }) : [];
     const proposals = Array.isArray(payload.proposals) && payload.proposals.length > 0 ? payload.proposals : derivedProposals;
     const budgetReceipt = payload.budgetReceipt || payload.budget?.receipt || payload.budget?.receiptArtifact || null;
     const budgetAllocation = payload.budgetAllocation || payload.budget?.allocation || null;

--- a/packages/runtime/src/personas/actor/controller.mts
+++ b/packages/runtime/src/personas/actor/controller.mts
@@ -784,15 +784,127 @@ function resolveNearestHostile(view, actorId) {
   return nearest;
 }
 
-function buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimConfig }) {
+// ── M3: Random motivation helpers ──────────────────────────────────────────
+//
+// Deterministic, seed-derived pseudo-random selection — never Math.random(),
+// never a clock read. The RNG is a pure function of (seed, actorId, tick):
+// same inputs always produce the same output, independent of instance or
+// call history, satisfying both the "identical seed -> identical trajectory"
+// and "no shared mutable RNG state" requirements.
+
+function resolveActorRandomSeed(view, actorId, payload, personaSeed) {
+  if (view?.actors && Array.isArray(view.actors)) {
+    const self = view.actors.find((a) => a && a.id === actorId);
+    if (self?.motivation?.seed !== undefined && self.motivation.seed !== null) {
+      return self.motivation.seed;
+    }
+  }
+  const configActors = payload?.initialState?.actors;
+  if (Array.isArray(configActors)) {
+    const configActor = configActors.find((a) => a && a.id === actorId);
+    if (configActor?.motivation?.seed !== undefined && configActor.motivation.seed !== null) {
+      return configActor.motivation.seed;
+    }
+  }
+  if (payload?.seed !== undefined && payload?.seed !== null) return payload.seed;
+  if (personaSeed !== undefined && personaSeed !== null) return personaSeed;
+  return 0;
+}
+
+/** Deterministic 32-bit hash of a seed/actorId/tick tuple (no Math.random, no clock). */
+function hashRandomInputs(seed, actorId, tick) {
+  const text = `${String(seed)}:${String(actorId)}:${String(Number.isFinite(tick) ? tick : 0)}`;
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  // Final mix (mulberry32-style) so nearby hashes decorrelate before use.
+  hash ^= hash << 13;
+  hash ^= hash >>> 17;
+  hash ^= hash << 5;
+  return hash >>> 0;
+}
+
+/** Pure deterministic RNG value in [0, 1) derived from seed + actorId + tick + salt. */
+function deterministicRandom(seed, actorId, tick, salt = 0) {
+  const hashed = hashRandomInputs(seed, actorId, (Number.isFinite(tick) ? tick : 0) * 2654435761 + salt);
+  return hashed / 4294967296;
+}
+
+function isOccupied(position, view, actorId) {
+  if (!view?.actors || !Array.isArray(view.actors)) return false;
+  return view.actors.some(
+    (other) => other && other.id !== actorId && other.position
+      && other.position.x === position.x && other.position.y === position.y,
+  );
+}
+
+function isReserved(position, reservedTargets) {
+  if (!Array.isArray(reservedTargets) || reservedTargets.length === 0) return false;
+  return reservedTargets.some((target) => target && target.x === position.x && target.y === position.y);
+}
+
+/**
+ * Random motivation: choose among legal adjacent walkable, unoccupied tiles
+ * using a deterministic seed-derived RNG. If the first choice is blocked,
+ * bounce to another legal candidate (deterministically re-ordered, not
+ * re-rolled with fresh entropy). If no legal adjacent tile exists, wait.
+ *
+ * `payload.reservedTargets` (array of {x,y}) carries move targets already
+ * claimed by other actors earlier in the same DECIDE phase — the runtime
+ * advances the actor persona once per actor per tick (see
+ * packages/runtime/src/runner/runtime-fsm.mjs), so without this, two
+ * actors evaluated in the same tick could both choose an identical
+ * currently-unoccupied tile before core state is updated at APPLY time.
+ */
+function buildRandomMoveProposals({ observation, payload, lastBaseTiles, lastSimConfig, personaSeed }) {
+  const view = resolveObservationView(observation);
+  const actorId = payload?.actorId;
+  const actor = resolveActor(view, actorId, observation);
+  if (!actor?.position) return [{ kind: "wait", params: { reason: "random" } }];
+
+  const baseTiles = resolveBaseTiles(payload, view, lastBaseTiles, lastSimConfig);
+  const tileKinds = resolveTileKinds(view, payload);
+  const reservedTargets = payload?.reservedTargets;
+  const candidates = buildAdjacentMoveProposals({ actor, tileKinds, baseTiles })
+    .filter((proposal) => !isOccupied(proposal.params.to, view, actorId))
+    .filter((proposal) => !isReserved(proposal.params.to, reservedTargets));
+
+  if (candidates.length === 0) {
+    return [{ kind: "wait", params: { reason: "random" } }];
+  }
+
+  const seed = resolveActorRandomSeed(view, actorId, payload, personaSeed);
+  const roll = deterministicRandom(seed, actorId, payload?.tick, 0);
+  const index = Math.floor(roll * candidates.length) % candidates.length;
+  const chosen = candidates[index];
+
+  return [
+    {
+      kind: "move",
+      params: {
+        direction: chosen.params.direction,
+        from: chosen.params.from,
+        to: chosen.params.to,
+        reason: "random",
+      },
+    },
+  ];
+}
+
+function buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimConfig, personaSeed }) {
   const view = resolveObservationView(observation);
   if (!view) return buildMoveProposal({ observation, payload, lastBaseTiles, lastSimConfig });
   const actorId = payload?.actorId;
   const actor = resolveActor(view, actorId, observation);
   if (!actor?.position) return buildMoveProposal({ observation, payload, lastBaseTiles, lastSimConfig });
   const motivationKind = resolveActorMotivationKind(view, actorId, payload);
-  const hostile = resolveNearestHostile(view, actorId);
   if (motivationKind === "stationary") return [];
+  if (motivationKind === "random") {
+    return buildRandomMoveProposals({ observation, payload, lastBaseTiles, lastSimConfig, personaSeed });
+  }
+  const hostile = resolveNearestHostile(view, actorId);
   if (hostile) {
     const adjacent = hostile.distance <= 1;
     if (adjacent && (motivationKind === "attacking" || motivationKind === "defending")) {
@@ -823,7 +935,7 @@ function buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimC
   return buildMoveProposal({ observation, payload, lastBaseTiles, lastSimConfig });
 }
 
-export function createActorPersona({ initialState = ActorStates.IDLE, clock = () => new Date().toISOString() } = {}) {
+export function createActorPersona({ initialState = ActorStates.IDLE, clock = () => new Date().toISOString(), seed: personaSeed } = {}) {
   const fsm = createActorStateMachine({ initialState, clock });
   let lastObservation = null;
   let lastBaseTiles = null;
@@ -860,7 +972,7 @@ export function createActorPersona({ initialState = ActorStates.IDLE, clock = ()
     }
 
     const shouldEmitActions = event === "propose";
-    const derivedProposals = shouldEmitActions ? buildMotivatedProposals({ observation, payload, lastBaseTiles, lastSimConfig }) : [];
+    const derivedProposals = shouldEmitActions ? buildMotivatedProposals({ observation, payload: { ...payload, tick }, lastBaseTiles, lastSimConfig, personaSeed }) : [];
     const proposals = Array.isArray(payload.proposals) && payload.proposals.length > 0 ? payload.proposals : derivedProposals;
     const budgetReceipt = payload.budgetReceipt || payload.budget?.receipt || payload.budget?.receiptArtifact || null;
     const budgetAllocation = payload.budgetAllocation || payload.budget?.allocation || null;

--- a/packages/runtime/src/runner/core-setup.mjs
+++ b/packages/runtime/src/runner/core-setup.mjs
@@ -308,22 +308,27 @@ export function applyInitialStateToCore(core, initialState, { spawn } = {}) {
     && typeof core.validateActorPlacement === "function";
 
   if (supportsMulti) {
+    const multiResult = (() => {
     core.clearActorPlacements();
     const positions = [];
     for (let index = 0; index < actors.length; index += 1) {
       const actor = actors[index];
       const position = resolvePoint(actor.position) || (index === 0 && spawn ? { ...spawn } : null);
       if (!position) {
-        return { ok: false, reason: "missing_position" };
+        // Non-primary actors without positions only ever existed in states
+        // authored for the legacy spawn path (which ignores them entirely).
+        return { ok: false, reason: index > 0 ? "legacy_fallback" : "missing_position" };
       }
       positions.push(position);
       core.addActorPlacement(index + 1, position.x, position.y);
     }
-    const placementError = core.validateActorPlacement();
+    // Seeding mode: an initial state may seat actors on the spawn/exit tiles
+    // at tick 0 (bounds/walkability/collision checks still apply).
+    const placementError = core.validateActorPlacement(true);
     if (Number.isFinite(placementError) && placementError !== 0) {
       return { ok: false, reason: "invalid_actor_placement", error: placementError };
     }
-    const applyError = core.applyActorPlacements();
+    const applyError = core.applyActorPlacements(true);
     if (Number.isFinite(applyError) && applyError !== 0) {
       return { ok: false, reason: "invalid_actor_placement", error: applyError };
     }
@@ -368,6 +373,19 @@ export function applyInitialStateToCore(core, initialState, { spawn } = {}) {
       }
     }
     return { ok: true, actorId: primary.id, position: positions[0], actorCount: actors.length };
+    })();
+    // Single-actor states whose placement the strict validator rejects (e.g.
+    // older fixtures that seat the actor on the spawn tile) historically ran
+    // through the legacy spawn path below, which does not validate placement.
+    // Preserve that behavior by falling through for them; multi-actor states
+    // with invalid placements must keep failing loudly — the legacy path can
+    // only spawn one actor and would silently drop the rest.
+    const fallBackToLegacy = multiResult?.reason === "legacy_fallback"
+      || (multiResult?.reason === "invalid_actor_placement" && actors.length === 1);
+    if (!fallBackToLegacy) {
+      return multiResult;
+    }
+    core.clearActorPlacements();
   }
 
   if (typeof core.spawnActorAt !== "function" || typeof core.setActorVital !== "function") {

--- a/packages/runtime/src/runner/runtime-fsm.mjs
+++ b/packages/runtime/src/runner/runtime-fsm.mjs
@@ -680,7 +680,7 @@ export function createFsmRuntime({
     }
   }
 
-  function buildPersonaPayloads({ phase, observation, phaseInputs = {}, actions = [], emittedEffects = [], fulfilledEffects = [] } = {}) {
+  function buildPersonaPayloads({ phase, observation, phaseInputs = {}, actions = [], emittedEffects = [], fulfilledEffects = [], actorId, reservedTargets } = {}) {
     const overrides = normalizePersonaPayloadsMap(phaseInputs.personaPayloads || phaseInputs.inputs);
     const actorOverrides = overrides.actor || {};
     const annotatorOverrides = overrides.annotator || {};
@@ -717,9 +717,10 @@ export function createFsmRuntime({
 
     const actorPayload = {
       ...base,
-      actorId: primaryActorId,
+      actorId: actorId || primaryActorId,
       observation,
       baseTiles,
+      ...(Array.isArray(reservedTargets) && reservedTargets.length > 0 ? { reservedTargets } : {}),
       ...actorOverrides,
     };
 
@@ -1097,6 +1098,14 @@ export function createFsmRuntime({
       const sortedActorIds = actorIdMap.size > 0
         ? Array.from(actorIdMap.entries()).sort((a, b) => a[1] - b[1]).map(([id]) => id)
         : [];
+      // Deterministic decide-phase iteration order: initialState.actors array
+      // order (filtered to actors the core actually tracks), not the
+      // alphabetically-sorted numeric-index order used for core observation
+      // labeling above. Every tracked actor must get a chance to propose an
+      // action each tick — see tests/runtime/multi-actor-orchestration.test.js.
+      const decideActorIds = Array.isArray(initialState?.actors)
+        ? initialState.actors.map((a) => a?.id).filter((id) => id && actorIdMap.has(id))
+        : sortedActorIds;
       const observation = resolveObservation(core, primaryActorId, baseTiles, affinityEffects, layoutTraps, sortedActorIds);
       const observePersonaPayloads = buildPersonaPayloads({
         phase: TickPhases.OBSERVE,
@@ -1136,41 +1145,95 @@ export function createFsmRuntime({
         solverFulfilled: observeRecord.solverFulfilled,
       });
 
-      const decidePersonaPayloads = buildPersonaPayloads({
-        phase: TickPhases.DECIDE,
-        observation,
-        phaseInputs: stepOptions,
-      });
-      const decideInputs = {
-        personaTick: tick,
-        personaEvents: buildPersonaEvents({
+      // Advance the actor persona once per tracked actor (deterministic
+      // initialState order) so every actor gets a chance to propose a
+      // move/wait action each tick, not just initialState.actors[0]. Only
+      // the first pass transitions the shared tick-phase FSM
+      // (OBSERVE -> DECIDE); subsequent passes redispatch within the same
+      // DECIDE phase. Non-actor personas receive no event override on
+      // repeat passes, so collectPhaseRecord() treats them as pure view()
+      // reads (see packages/runtime/src/personas/_shared/tick-orchestrator.mts).
+      const decideActorIterationIds = decideActorIds.length > 0 ? decideActorIds : [primaryActorId];
+      const actions = [];
+      let decideRecord = null;
+      let decidePersonaPayloads = null;
+      for (let i = 0; i < decideActorIterationIds.length; i += 1) {
+        const actorId = decideActorIterationIds[i];
+        // Targets already claimed by actors decided earlier in this same
+        // tick, so two actors can't both propose a move onto the same
+        // currently-unoccupied tile before core state updates at APPLY time.
+        const reservedTargets = actions
+          .filter((a) => a?.kind === "move" && a.params?.to)
+          .map((a) => ({ x: a.params.to.x, y: a.params.to.y }));
+        decidePersonaPayloads = buildPersonaPayloads({
           phase: TickPhases.DECIDE,
+          observation,
           phaseInputs: stepOptions,
-          personaPayloads: decidePersonaPayloads,
-        }),
-        personaPayloads: decidePersonaPayloads,
-      };
-      const decideRecord = await orchestrator.stepPhase("decide", decideInputs);
-      const actorState = decideRecord.personaViews?.actor?.state;
-      if (actorState === "proposing" || actorState === "deciding") {
-        const cooldownRecord = await orchestrator.dispatchPhase({
-          phase: TickPhases.DECIDE,
-          event: "cooldown",
-          payload: {
-            personaTick: tick,
-            personaEvents: { actor: "cooldown" },
-            personaPayloads: decideInputs.personaPayloads,
-          },
+          actorId,
+          reservedTargets,
         });
-        decideRecord.personaViews = cooldownRecord.personaViews;
+        const decideInputs = {
+          personaTick: tick,
+          personaEvents: buildPersonaEvents({
+            phase: TickPhases.DECIDE,
+            phaseInputs: stepOptions,
+            personaPayloads: decidePersonaPayloads,
+          }),
+          personaPayloads: decidePersonaPayloads,
+        };
+        let record;
+        if (i === 0) {
+          record = await orchestrator.stepPhase("decide", decideInputs);
+        } else {
+          // The actor persona is a single shared FSM instance (cooldown after
+          // the previous actor's turn only accepts "observe"). Recycle it
+          // through observe -> decide before this actor's propose/cooldown.
+          // personaEvents scopes these transitions to the actor persona only;
+          // every other persona sees no override and is treated as a pure
+          // view() read (see tick-orchestrator.mts collectPhaseRecord()).
+          await orchestrator.dispatchPhase({
+            phase: TickPhases.DECIDE,
+            event: "observe",
+            payload: {
+              personaTick: tick,
+              personaEvents: { actor: "observe" },
+              personaPayloads: decidePersonaPayloads,
+            },
+          });
+          record = await orchestrator.dispatchPhase({
+            phase: TickPhases.DECIDE,
+            event: "decide",
+            payload: {
+              personaTick: tick,
+              personaEvents: { actor: ["decide", "propose"] },
+              personaPayloads: decidePersonaPayloads,
+            },
+          });
+        }
+        const actorState = record.personaViews?.actor?.state;
+        if (actorState === "proposing" || actorState === "deciding") {
+          const cooldownRecord = await orchestrator.dispatchPhase({
+            phase: TickPhases.DECIDE,
+            event: "cooldown",
+            payload: {
+              personaTick: tick,
+              personaEvents: { actor: "cooldown" },
+              personaPayloads: decideInputs.personaPayloads,
+            },
+          });
+          record.personaViews = cooldownRecord.personaViews;
+        }
+        if (Array.isArray(record.actions) && record.actions.length) {
+          actions.push(...record.actions);
+        }
+        decideRecord = record;
       }
-      const actions = Array.isArray(decideRecord.actions) ? decideRecord.actions : [];
 
       applyPersonaArtifacts(decideRecord);
       recordTickFrame({
         phaseDetail: TickPhases.DECIDE,
         personaViews: decideRecord.personaViews,
-        personaActions: decideRecord.actions,
+        personaActions: actions,
         personaEffects: decideRecord.effects,
         personaArtifacts: decideRecord.artifacts,
         telemetry: decideRecord.telemetry,

--- a/packages/ui-web/src/main.js
+++ b/packages/ui-web/src/main.js
@@ -221,7 +221,18 @@ globalThis.__ak_loadGameplayBundle = async (bundle, { targetTab = "design" } = {
     }
   }
   const ALLOWED_TABS = new Set(["design", "gameplay", "preview"]);
-  openTab(ALLOWED_TABS.has(targetTab) ? targetTab : "design");
+  // Opening the gameplay tab normally re-generates a run from the design
+  // (launchGameplayRun below), which would clobber the bundle we just loaded
+  // explicitly — scenario injection and the MCP bridge both land here. Hold
+  // gameplayRunPending across the tab switch so the onChange guard skips the
+  // auto-generate for this navigation only.
+  const wasPending = gameplayRunPending;
+  gameplayRunPending = true;
+  try {
+    openTab(ALLOWED_TABS.has(targetTab) ? targetTab : "design");
+  } finally {
+    gameplayRunPending = wasPending;
+  }
   return true;
 };
 
@@ -294,6 +305,10 @@ function summarizePreviewError(result) {
 
 async function launchGameplayRun({ autoGenerate = false } = {}) {
   if (!diagnosticsView) return;
+  // Capture the navigation generation at entry — the awaits below yield, and
+  // a user navigating away mid-launch must invalidate this build's completion.
+  // Capturing later (as before) missed navigations during the publish await.
+  const launchGeneration = tabGeneration;
 
   // In index_c.html the Phaser card builder is the live design state; designView reads
   // from DOM elements that don't exist there, so designView.getCards() is always empty.
@@ -341,7 +356,7 @@ async function launchGameplayRun({ autoGenerate = false } = {}) {
     }
     lastGameplaySpecText = built.specText;
     gameplayRunPending = true;
-    pendingGameplayGeneration = tabGeneration;
+    pendingGameplayGeneration = launchGeneration;
     buildResult = await diagnosticsView.runBuildWithSpec(built.specText);
   } else if (designView) {
     const published = await designView.publishPreviewSpec({
@@ -357,7 +372,7 @@ async function launchGameplayRun({ autoGenerate = false } = {}) {
       lastGameplaySpecText = published.specText;
     }
     gameplayRunPending = true;
-    pendingGameplayGeneration = tabGeneration;
+    pendingGameplayGeneration = launchGeneration;
     buildResult = await diagnosticsView.runBuild();
   } else {
     return { ok: false, reason: "no_spec_source" };
@@ -466,14 +481,32 @@ if (document.querySelector("#phaser-frame-root")) {
 // Keyboard events bypass Phaser's InputManager/hit-zone testing entirely, so this
 // works reliably even when canvas-based nav buttons don't (destroy/recreate timing,
 // camera-transform hit-testing, etc).
+// Screen navigation lives on Cmd/Ctrl+brackets and Ctrl+digits so it can
+// never collide with game-surface bindings: bare keys belong to the game
+// (movement, actions), Cmd+arrows to tick playback, Cmd+[/] to screen
+// back/forward, Ctrl+digit to direct screen jumps. Cmd+digit is off-limits —
+// Chrome reserves it for browser-tab switching and pages cannot intercept it.
 document.addEventListener("keydown", (event) => {
-  if (!(event.metaKey || event.ctrlKey)) return;
-  if (event.key === "ArrowRight") {
-    event.preventDefault();
-    navigateScreens("forward");
-  } else if (event.key === "ArrowLeft") {
-    event.preventDefault();
-    navigateScreens("back");
+  if (event.metaKey || event.ctrlKey) {
+    if (event.key === "]") {
+      event.preventDefault();
+      navigateScreens("forward");
+      return;
+    }
+    if (event.key === "[") {
+      event.preventDefault();
+      navigateScreens("back");
+      return;
+    }
+  }
+  if (event.ctrlKey && !event.metaKey) {
+    if (event.key === "1") {
+      event.preventDefault();
+      tabs?.setActive("design");
+    } else if (event.key === "2") {
+      event.preventDefault();
+      tabs?.setActive("gameplay");
+    }
   }
 });
 

--- a/packages/ui-web/src/views/gameplay-phaser-renderer.js
+++ b/packages/ui-web/src/views/gameplay-phaser-renderer.js
@@ -155,6 +155,8 @@ export function createGameplayPhaserRenderer({ loadPhaser = defaultLoadPhaser, o
   let selectedActorKey = null;
   let playerPanelContainer = null;
   let playerPanelOpen = false;
+  let playbackControls = null;
+  let keydownHandler = null;
   let cameraState = {
     worldWidth: 1,
     worldHeight: 1,
@@ -379,8 +381,31 @@ export function createGameplayPhaserRenderer({ loadPhaser = defaultLoadPhaser, o
       const zoomFactor = deltaY > 0 ? 1 / CAMERA_ZOOM_STEP : CAMERA_ZOOM_STEP;
       applyCameraZoom(cameraState.zoom * zoomFactor, { centerX: pointer.worldX, centerY: pointer.worldY });
     });
-    scene.input.keyboard?.on?.("keydown", (event) => {
+    // Keyboard goes through a window-level DOM listener rather than
+    // scene.input.keyboard: Phaser v4 does not expose the v3 keyboard plugin
+    // on the scene, so that binding never fires (silently, via the optional
+    // chain). The listener only acts while the gameplay stage is visible and
+    // the user is not typing in a form field.
+    keydownHandler = (event) => {
+      if (!stageEl || stageEl.offsetParent === null) return;
+      const target = event?.target;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) return;
       const key = String(event?.key || "").toLowerCase();
+
+      if (event?.metaKey) {
+        // Cmd+Arrow drives tick-playback navigation instead of camera pan —
+        // plain arrows (no modifier) remain reserved for camera pan / future
+        // direct player movement, handled in the branch below. Auto-repeat
+        // is ignored so one press moves the cursor exactly one step.
+        if (event.repeat) { event.preventDefault?.(); return; }
+        if (key === "arrowright") { event.preventDefault?.(); playbackControls?.stepForward?.(); }
+        if (key === "arrowleft") { event.preventDefault?.(); playbackControls?.stepBack?.(); }
+        if (key === "arrowdown") { event.preventDefault?.(); playbackControls?.jumpToEnd?.(); }
+        if (key === "arrowup") { event.preventDefault?.(); playbackControls?.jumpToStart?.(); }
+        return;
+      }
+
       const amount = 48;
       if (key === "arrowup" || key === "w") panCameraBy(0, amount);
       if (key === "arrowdown" || key === "s") panCameraBy(0, -amount);
@@ -392,7 +417,18 @@ export function createGameplayPhaserRenderer({ loadPhaser = defaultLoadPhaser, o
       if (ACTOR_CONTROL_KEYS.has(key)) {
         onKeyPress?.({ key });
       }
-    });
+    };
+    // Bind exactly one keyboard seam — binding both double-steps every press.
+    // In the browser the window listener is authoritative (Phaser's scene
+    // keyboard delivers duplicate keydowns for a single press under v4).
+    // In Node test environments there is no window listener, so the
+    // fixture-based unit tests drive input through their fake scenes.
+    if (typeof globalThis.addEventListener === "function") {
+      globalThis.addEventListener("keydown", keydownHandler);
+    } else {
+      scene.input.keyboard?.on?.("keydown", keydownHandler);
+      keydownHandler = null;
+    }
     inputBound = true;
   }
 
@@ -796,7 +832,7 @@ export function createGameplayPhaserRenderer({ loadPhaser = defaultLoadPhaser, o
     return { ok: true };
   }
 
-  async function drawBoard(boardState, { resetCamera = false } = {}) {
+  async function drawBoard(boardState, { resetCamera = false, tickIndex = null } = {}) {
     const ready = await ensureGame(boardState);
     if (!ready?.ok || !scene) return ready;
 
@@ -829,6 +865,9 @@ export function createGameplayPhaserRenderer({ loadPhaser = defaultLoadPhaser, o
       stageEl.dataset.gameplayDelvers = String(delverCount);
       stageEl.dataset.gameplayWardens = String(wardenCount);
       stageEl.dataset.gameplayActorPositions = JSON.stringify(diagnostics);
+      if (Number.isInteger(tickIndex)) {
+        stageEl.dataset.gameplayCurrentTick = String(tickIndex);
+      }
     }
     configureCamera({ resetView: resetCamera || worldChanged, focusBoardState: boardState });
 
@@ -980,11 +1019,14 @@ export function createGameplayPhaserRenderer({ loadPhaser = defaultLoadPhaser, o
       container = nextContainer || container;
       stageEl = ensureGameplayStageElement(container);
     },
-    async renderRun(boardState) {
-      return drawBoard(boardState, { resetCamera: true });
+    async renderRun(boardState, { tickIndex = null } = {}) {
+      return drawBoard(boardState, { resetCamera: true, tickIndex });
     },
-    async renderFrame(boardState) {
-      return drawBoard(boardState);
+    async renderFrame(boardState, { tickIndex = null } = {}) {
+      return drawBoard(boardState, { tickIndex });
+    },
+    setPlaybackControls(controls) {
+      playbackControls = controls || null;
     },
     zoomIn() {
       return applyCameraZoom(cameraState.zoom * CAMERA_ZOOM_STEP);
@@ -1032,6 +1074,10 @@ export function createGameplayPhaserRenderer({ loadPhaser = defaultLoadPhaser, o
       sceneReady = null;
       inputBound = false;
       lastHoverTile = null;
+      if (keydownHandler) {
+        globalThis.removeEventListener?.("keydown", keydownHandler);
+        keydownHandler = null;
+      }
     },
   };
 }

--- a/packages/ui-web/src/views/gameplay-view.js
+++ b/packages/ui-web/src/views/gameplay-view.js
@@ -219,12 +219,14 @@ export function wireGameplayView({
       actorInspector.setRunning?.(true);
     }
 
-    void renderer.renderRun(frames[0]);
+    void renderer.renderRun(frames[0], { tickIndex: currentFrameIndex });
     renderer.setPlaybackControls?.({
       stepBack: () => stepBack(),
       stepForward: () => stepForward(),
       togglePlay: () => {},
       reset: () => clear(),
+      jumpToStart: () => runToStart(),
+      jumpToEnd: () => runToEnd(),
     });
     updateStepButtons();
     onRunLoaded?.(bundle);
@@ -248,7 +250,7 @@ export function wireGameplayView({
     if (!isRunActive() || currentFrameIndex >= frames.length - 1) return;
     currentFrameIndex++;
     const frame = frames[currentFrameIndex];
-    void renderer.renderFrame(frame);
+    void renderer.renderFrame(frame, { tickIndex: currentFrameIndex });
     updateStepButtons();
     actorInspector?.setActors?.(frame?.observation?.actors || [], { tick: currentFrameIndex });
   }
@@ -257,7 +259,7 @@ export function wireGameplayView({
     if (!isRunActive() || currentFrameIndex <= 0) return;
     currentFrameIndex--;
     const frame = frames[currentFrameIndex];
-    void renderer.renderFrame(frame);
+    void renderer.renderFrame(frame, { tickIndex: currentFrameIndex });
     updateStepButtons();
     actorInspector?.setActors?.(frame?.observation?.actors || [], { tick: currentFrameIndex });
   }
@@ -272,10 +274,23 @@ export function wireGameplayView({
     if (!isRunActive() || frames.length === 0) return;
     currentFrameIndex = frames.length - 1;
     const frame = frames[currentFrameIndex];
-    void renderer.renderFrame(frame);
+    void renderer.renderFrame(frame, { tickIndex: currentFrameIndex });
     updateStepButtons();
     actorInspector?.setActors?.(frame?.observation?.actors || [], { tick: currentFrameIndex });
     setStatus(`Run completed at tick ${currentFrameIndex}.`);
+  }
+
+  /**
+   * Run To Start — jump cursor to the first frame (tick 0) and render it.
+   * Mirrors runToEnd(): UI-only playback-cursor reset, no re-simulation.
+   */
+  function runToStart() {
+    if (!isRunActive() || frames.length === 0) return;
+    currentFrameIndex = 0;
+    const frame = frames[currentFrameIndex];
+    void renderer.renderFrame(frame, { tickIndex: currentFrameIndex });
+    updateStepButtons();
+    actorInspector?.setActors?.(frame?.observation?.actors || [], { tick: currentFrameIndex });
   }
 
   function selectEntity(position) {
@@ -412,6 +427,7 @@ export function wireGameplayView({
     stepForward,
     stepBack,
     runToEnd,
+    runToStart,
     dispose,
     isRunActive,
     clear,

--- a/tests/integration/cli-run-multi-actor-movement.test.js
+++ b/tests/integration/cli-run-multi-actor-movement.test.js
@@ -1,0 +1,258 @@
+/**
+ * M7 — CLI `create` + `run` path must move EVERY actor, not just actors[0].
+ *
+ * The runtime DECIDE-phase fix (tests/runtime/multi-actor-orchestration.test.js)
+ * loops all tracked actors, and it works through createPlaybackRuntime. But the
+ * CLI `run` command reaches the runtime through createCommandRuntimeCore()
+ * (packages/runtime/src/commands/kernel.js), which exposes a hand-picked subset
+ * of the core surface. Capability checks in the runtime (applyInitialStateToCore
+ * and friends) silently degrade to the legacy single-actor spawn path when the
+ * functions they probe for are missing from that subset — so a CLI-authored
+ * multi-actor run still moves only initialState.actors[0].
+ *
+ * This test drives the exact executeCommand seam the MCP server uses (same
+ * harness as mcp-cli-ui-random-scenario.test.js) and asserts per-actor action
+ * coverage, which no other test pins at this seam.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+const { mkdtempSync, existsSync, rmSync, readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const os = require("node:os");
+
+let ak_impl;
+
+async function loadImpl() {
+  ak_impl ??= await import("../../packages/adapters-cli/src/cli/ak-impl.mjs");
+  return ak_impl;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+async function runCliCommand(executeCommand, command, argv) {
+  const stdoutChunks = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const originalLog = console.log;
+  process.stdout.write = (chunk, encoding, callback) => {
+    stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk));
+    if (typeof encoding === "function") encoding();
+    else if (typeof callback === "function") callback();
+    return true;
+  };
+  console.log = (...parts) => {
+    stdoutChunks.push(`${parts.map(String).join(" ")}\n`);
+  };
+  try {
+    await executeCommand(command, argv);
+  } finally {
+    process.stdout.write = originalWrite;
+    console.log = originalLog;
+  }
+  const lines = stdoutChunks.join("").trim().split("\n").map((l) => l.trim()).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    try {
+      return JSON.parse(lines[i]);
+    } catch {
+      // keep scanning backwards for the JSON payload
+    }
+  }
+  throw new Error(`runCliCommand(${command}): no JSON payload found in stdout`);
+}
+
+describe("CLI create+run moves every actor (kernel command-core surface)", () => {
+  let outDir;
+
+  beforeAll(() => {
+    outDir = mkdtempSync(join(os.tmpdir(), "ak-cli-multi-actor-"));
+  });
+
+  afterAll(() => {
+    if (outDir && existsSync(outDir)) {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test("every random-motivation actor from create appears in accepted actions across a CLI run", async () => {
+    const impl = await loadImpl();
+
+    const createResult = await runCliCommand(impl.executeCommand, "create", [
+      "--room", "count=1;size=medium",
+      "--delver", "count=1;affinity=water;motivation=random",
+      "--warden", "count=2;affinity=fire;motivation=random",
+      "--run-id", "cli_multi_actor_movement",
+      "--out-dir", outDir,
+    ]);
+    assert.equal(createResult.ok, true, `create must succeed: ${JSON.stringify(createResult)}`);
+
+    const initialState = readJson(join(outDir, "initial-state.json"));
+    const actorIds = (initialState.actors || []).map((a) => a.id);
+    assert.equal(actorIds.length, 3, `expected 3 actors, got ${actorIds.length}`);
+
+    const runOutDir = join(outDir, "run");
+    const runResult = await runCliCommand(impl.executeCommand, "run", [
+      "--sim-config", join(outDir, "sim-config.json"),
+      "--initial-state", join(outDir, "initial-state.json"),
+      "--ticks", "24",
+      "--run-id", "cli_multi_actor_movement_run",
+      "--out-dir", runOutDir,
+    ]);
+    assert.equal(runResult.ok, true, `run must succeed: ${JSON.stringify(runResult)}`);
+
+    const tickFrames = readJson(join(runOutDir, "tick-frames.json"));
+    const frames = Array.isArray(tickFrames?.frames) ? tickFrames.frames : tickFrames;
+    assert.ok(Array.isArray(frames) && frames.length > 0, "run must produce tick frames");
+
+    // Every actor must be the subject of at least one accepted action (move or
+    // wait) somewhere in the run. With the command-core subset bug, only
+    // actors[0] ever gets actions.
+    const actedActorIds = new Set();
+    for (const frame of frames) {
+      const actions = Array.isArray(frame?.acceptedActions) ? frame.acceptedActions : [];
+      for (const action of actions) {
+        if (typeof action?.actorId === "string") {
+          actedActorIds.add(action.actorId);
+        }
+      }
+    }
+
+    for (const actorId of actorIds) {
+      assert.ok(
+        actedActorIds.has(actorId),
+        `actor ${actorId} never received an accepted action across ${frames.length} frames — ` +
+          `acting actors were ${JSON.stringify([...actedActorIds])}; the CLI run path is ` +
+          "degrading to single-actor orchestration (createCommandRuntimeCore subset)",
+      );
+    }
+  });
+});
+
+// ── Permutations expanded from TODO stubs ──
+
+describe("CLI create+run multi-actor permutations", () => {
+  let permOutRoot;
+
+  beforeAll(() => {
+    permOutRoot = mkdtempSync(join(os.tmpdir(), "ak-cli-multi-actor-perm-"));
+  });
+
+  afterAll(() => {
+    if (permOutRoot && existsSync(permOutRoot)) {
+      rmSync(permOutRoot, { recursive: true, force: true });
+    }
+  });
+
+  async function createAndRun(name, { createArgs, ticks }) {
+    const impl = await loadImpl();
+    const outDir = join(permOutRoot, name);
+    const createResult = await runCliCommand(impl.executeCommand, "create", [
+      "--room", "count=1;size=medium",
+      ...createArgs,
+      "--run-id", `perm_${name}`,
+      "--out-dir", outDir,
+    ]);
+    assert.equal(createResult.ok, true, `create must succeed: ${JSON.stringify(createResult)}`);
+    const initialState = readJson(join(outDir, "initial-state.json"));
+    const runOutDir = join(outDir, "run");
+    const runResult = await runCliCommand(impl.executeCommand, "run", [
+      "--sim-config", join(outDir, "sim-config.json"),
+      "--initial-state", join(outDir, "initial-state.json"),
+      "--ticks", String(ticks),
+      "--run-id", `perm_${name}_run`,
+      "--out-dir", runOutDir,
+    ]);
+    assert.equal(runResult.ok, true, `run must succeed: ${JSON.stringify(runResult)}`);
+    const tickFrames = readJson(join(runOutDir, "tick-frames.json"));
+    const frames = Array.isArray(tickFrames?.frames) ? tickFrames.frames : tickFrames;
+    return { initialState, frames };
+  }
+
+  function collectActedActorIds(frames) {
+    const acted = new Set();
+    for (const frame of frames) {
+      for (const action of Array.isArray(frame?.acceptedActions) ? frame.acceptedActions : []) {
+        if (typeof action?.actorId === "string") acted.add(action.actorId);
+      }
+    }
+    return acted;
+  }
+
+  test("warden-only roster (no delver): every warden acts", async () => {
+    const { initialState, frames } = await createAndRun("warden_only", {
+      createArgs: ["--warden", "count=3;affinity=fire;motivation=random"],
+      ticks: 24,
+    });
+    const wardenIds = initialState.actors.map((a) => a.id);
+    assert.equal(wardenIds.length, 3, `expected 3 wardens, got ${wardenIds.length}`);
+    const acted = collectActedActorIds(frames);
+    for (const id of wardenIds) {
+      assert.ok(acted.has(id), `warden ${id} never acted; acting: ${JSON.stringify([...acted])}`);
+    }
+  });
+
+  test("acceptance scale: 11-actor roster all act across 100 ticks", async () => {
+    const { initialState, frames } = await createAndRun("acceptance_scale", {
+      createArgs: [
+        "--delver", "count=1;affinity=water;motivation=random",
+        "--warden", "count=10;affinity=fire;motivation=random",
+      ],
+      ticks: 100,
+    });
+    const ids = initialState.actors.map((a) => a.id);
+    assert.equal(ids.length, 11, `expected 11 actors, got ${ids.length}`);
+    const acted = collectActedActorIds(frames);
+    for (const id of ids) {
+      assert.ok(acted.has(id), `actor ${id} never acted across 100 ticks`);
+    }
+  });
+
+  test("mixed motivations: random actors act while a stationary actor holds position", async () => {
+    const { initialState, frames } = await createAndRun("mixed_motivation", {
+      createArgs: [
+        "--delver", "count=1;affinity=water;motivation=random",
+        "--warden", "count=1;affinity=fire;motivation=random",
+        "--warden", "count=1;affinity=earth;motivation=stationary",
+      ],
+      ticks: 24,
+    });
+    const stationary = initialState.actors.find((a) => a?.motivation?.kind === "stationary");
+    const randoms = initialState.actors.filter((a) => a?.motivation?.kind === "random");
+    assert.ok(stationary, "roster must include the stationary warden");
+    assert.equal(randoms.length, 2, "roster must include both random actors");
+
+    const acted = collectActedActorIds(frames);
+    for (const actor of randoms) {
+      assert.ok(acted.has(actor.id), `random actor ${actor.id} never acted`);
+    }
+    // Stationary means never proposing movement: no accepted move action, and
+    // its position in every frame's accepted moves stays untouched.
+    const stationaryMoves = [];
+    for (const frame of frames) {
+      for (const action of Array.isArray(frame?.acceptedActions) ? frame.acceptedActions : []) {
+        if (action?.actorId === stationary.id && action?.kind === "move") {
+          stationaryMoves.push(action);
+        }
+      }
+    }
+    assert.equal(stationaryMoves.length, 0,
+      `stationary actor must not move, saw ${JSON.stringify(stationaryMoves)}`);
+  });
+
+  test("tick count 1 boundary: every actor receives its DECIDE pass in the single tick", async () => {
+    const { initialState, frames } = await createAndRun("single_tick", {
+      createArgs: [
+        "--delver", "count=1;affinity=water;motivation=random",
+        "--warden", "count=2;affinity=fire;motivation=random",
+      ],
+      ticks: 1,
+    });
+    const ids = initialState.actors.map((a) => a.id);
+    assert.equal(ids.length, 3);
+    const acted = collectActedActorIds(frames);
+    for (const id of ids) {
+      assert.ok(acted.has(id), `actor ${id} did not act in the single tick`);
+    }
+  });
+});

--- a/tests/integration/mcp-cli-ui-random-scenario.test.js
+++ b/tests/integration/mcp-cli-ui-random-scenario.test.js
@@ -135,7 +135,7 @@ describe("MCP -> CLI random-movement scenario pipeline (5 rooms / 10 wardens / 1
     }
   });
 
-  test.skip("ak_create MCP tool produces sim-config + initial-state with 1 delver, 10 wardens, motivation.kind random", async () => {
+  test("ak_create MCP tool produces sim-config + initial-state with 1 delver, 10 wardens, motivation.kind random", async () => {
     const { ak_impl, authoringToolsModule } = await loadModules();
     const createTool = findTool(authoringToolsModule.authoringTools, "ak_create");
 
@@ -336,7 +336,7 @@ describe("MCP -> CLI random-movement scenario pipeline (5 rooms / 10 wardens / 1
     }
   });
 
-  test.skip("bundle produced from the create+run outDir matches the agent-kernel/GameplayBundle shape expected by __ak_loadGameplayBundle (M7 stitching gap)", async () => {
+  test("bundle produced from the create+run outDir matches the agent-kernel/GameplayBundle shape expected by __ak_loadGameplayBundle (M7 stitching gap)", async () => {
     const { ak_impl, authoringToolsModule, simulationToolsModule } = await loadModules();
     const createTool = findTool(authoringToolsModule.authoringTools, "ak_create");
     const runTool = findTool(simulationToolsModule.simulationTools, "ak_run");
@@ -408,7 +408,7 @@ describe("MCP -> CLI random-movement scenario pipeline (5 rooms / 10 wardens / 1
     }
   });
 
-  test.skip("no ak_push_to_ui MCP tool exists yet to deliver the bundle over the sandbox bridge (M7 gap)", async () => {
+  test("no ak_push_to_ui MCP tool exists yet to deliver the bundle over the sandbox bridge (M7 gap)", async () => {
     // sandboxTools currently exposes ak_sandbox_create / ak_sandbox_place /
     // ak_sandbox_move only (packages/adapters-cli/src/mcp/tools/sandbox.mjs) —
     // none of these push a compiled GameplayBundle over the WS bridge

--- a/tests/playwright/helpers/serve-ui.mjs
+++ b/tests/playwright/helpers/serve-ui.mjs
@@ -11,7 +11,7 @@ function wait(ms) {
 }
 
 function parseServeUrl(output) {
-  const match = output.match(/Serving UI at:\s+(http:\/\/localhost:\d+\/packages\/ui-web\/index\.html)/);
+  const match = output.match(/Serving UI at:\s+(http:\/\/localhost:\d+\/packages\/ui-web\/index(?:_c)?\.html)/);
   return match ? match[1] : null;
 }
 
@@ -53,6 +53,11 @@ export async function startServeUi({ port = 0 } = {}) {
         reject(new Error(`Timed out waiting for serve:ui URL:\n${output}`));
       }
     }, 50);
+  }).catch(async (error) => {
+    // A failed startup must not leak the spawned server; orphans hold
+    // ports 8001+ and starve every subsequent Playwright run.
+    await stopProcess(proc);
+    throw error;
   });
 
   const healthUrl = new URL("/health", url);
@@ -68,6 +73,7 @@ export async function startServeUi({ port = 0 } = {}) {
     await wait(50);
   }
 
+  await stopProcess(proc);
   throw new Error(`Timed out waiting for serve:ui health readiness:\n${output}`);
 }
 

--- a/tests/playwright/runtime-actions-served.spec.mjs
+++ b/tests/playwright/runtime-actions-served.spec.mjs
@@ -6,7 +6,7 @@ test("served ui exposes gameplay step controls and removes legacy runtime moveme
 
   try {
     await page.goto(served.url);
-    await page.locator('[data-tab="gameplay"]').click();
+    await page.evaluate((id) => window.__ak_setActiveTab(id), "gameplay");
 
     await expect(page.locator('[data-tab-panel="gameplay"]')).toBeVisible();
     await expect(page.locator("#gameplay-step-back")).toBeVisible();

--- a/tests/playwright/screen-navigation-keys.spec.mjs
+++ b/tests/playwright/screen-navigation-keys.spec.mjs
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { startServeUi, stopProcess } from "./helpers/serve-ui.mjs";
+
+test("Cmd+brackets and Ctrl+digits navigate screens; Cmd+arrows do not", async ({ page }) => {
+  test.setTimeout(60_000);
+  const served = await startServeUi();
+  try {
+    await page.goto(served.url);
+    const activeTab = () => page.getAttribute(".workspace", "data-active-tab");
+
+    expect(await activeTab()).toBe("design");
+
+    await page.keyboard.press("Meta+]");
+    await page.waitForTimeout(300);
+    expect(await activeTab()).toBe("gameplay");
+
+    await page.keyboard.press("Meta+[");
+    await page.waitForTimeout(300);
+    expect(await activeTab()).toBe("design");
+
+    await page.keyboard.press("Control+2");
+    await page.waitForTimeout(300);
+    expect(await activeTab()).toBe("gameplay");
+
+    await page.keyboard.press("Control+1");
+    await page.waitForTimeout(300);
+    expect(await activeTab()).toBe("design");
+
+    // Cmd+arrows must no longer navigate screens from the design tab.
+    await page.keyboard.press("Meta+ArrowRight");
+    await page.waitForTimeout(300);
+    expect(await activeTab()).toBe("design");
+  } finally {
+    await stopProcess(served.proc);
+  }
+});

--- a/tests/playwright/serve-ui-script.spec.mjs
+++ b/tests/playwright/serve-ui-script.spec.mjs
@@ -22,8 +22,11 @@ test("nav exposes only Design and Gameplay tab buttons", async ({ page }) => {
     await page.goto(served.url);
     const tabButtons = page.locator("[data-tab]");
     await expect(tabButtons).toHaveCount(2);
-    await expect(page.locator('[data-tab="design"]')).toBeVisible();
-    await expect(page.locator('[data-tab="gameplay"]')).toBeVisible();
+    // The HTML tab bar is intentionally hidden once the Phaser frame mounts (tabs are
+    // Phaser-native now); the buttons still exist in the DOM, so assert attachment
+    // rather than visibility.
+    await expect(page.locator('[data-tab="design"]')).toBeAttached();
+    await expect(page.locator('[data-tab="gameplay"]')).toBeAttached();
     await expect(page.locator('[data-tab="preview"]')).toHaveCount(0);
     await expect(page.locator('[data-tab="simulation"]')).toHaveCount(0);
     await expect(page.locator('[data-tab="diagnostics"]')).toHaveCount(0);
@@ -87,7 +90,9 @@ test("actor inspector is hidden on design tab and visible on preview tab after b
 
   try {
     await page.goto(served.url);
-    await expect(page.locator('[data-tab="design"]')).toBeVisible();
+    // The HTML tab bar is intentionally hidden once the Phaser frame mounts (tabs are
+    // Phaser-native now); the button still exists in the DOM.
+    await expect(page.locator('[data-tab="design"]')).toBeAttached();
     await expect(page.locator("#actor-inspector")).not.toBeVisible();
 
     await page.setInputFiles("#bundle-file", bundlePath);

--- a/tests/runtime/multi-actor-orchestration.test.js
+++ b/tests/runtime/multi-actor-orchestration.test.js
@@ -1,0 +1,391 @@
+/**
+ * M7a — Multi-actor orchestration: every configured actor must be advanced
+ * every tick, not just initialState.actors[0].
+ *
+ * Bug: in packages/runtime/src/runner/runtime-fsm.mjs, buildPersonaPayloads()
+ * builds a single actor persona payload keyed to `primaryActorId`
+ * (== initialState.actors[0].id), and the tick orchestrator
+ * (packages/runtime/src/personas/_shared/tick-orchestrator.mts
+ * collectPhaseRecord()) invokes each registered persona exactly once per
+ * phase with that one payload. Every actor after index 0 is therefore never
+ * given a chance to propose a move/wait action, on any tick, in any run.
+ *
+ * This test drives the exact seam the CLI `run` command uses
+ * (packages/runtime/src/commands/kernel.js -> createRuntime() ->
+ * createFsmRuntime() in runtime-fsm.mjs), with 3+ actors, and asserts every
+ * actor id appears in accepted actions across a multi-tick run.
+ *
+ * Architecture: runtime + core-ts only, no LLM, no external IO, deterministic
+ * (seed-derived) actor iteration in initialState order.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const TICK_COUNT = 6;
+
+function makeFloorGrid(w, h) {
+  return Array.from({ length: h }, (_, y) =>
+    Array.from({ length: w }, (_, x) =>
+      x === 0 || x === w - 1 || y === 0 || y === h - 1 ? "#" : "."
+    ).join("")
+  );
+}
+
+function buildSimConfig({ width = 9, height = 9 } = {}) {
+  const tiles = makeFloorGrid(width, height);
+  return {
+    schema: "agent-kernel/SimConfigArtifact",
+    schemaVersion: 1,
+    meta: {
+      id: "multi_actor_orchestration_sim",
+      runId: "multi_actor_orchestration",
+      createdAt: "2026-07-02T00:00:00.000Z",
+    },
+    seed: 0,
+    layout: {
+      kind: "grid",
+      data: {
+        width,
+        height,
+        tiles,
+        spawn: { x: Math.floor(width / 2) - 1, y: Math.floor(height / 2) },
+        exit: { x: Math.floor(width / 2) + 1, y: Math.floor(height / 2) },
+        rooms: [{ id: "R1", x: 0, y: 0, width, height }],
+        traps: [],
+      },
+    },
+  };
+}
+
+function makeVitals(hp) {
+  return {
+    health: { current: hp, max: hp, regen: 0 },
+    mana: { current: hp, max: hp, regen: 0 },
+    stamina: { current: hp, max: hp, regen: 0 },
+    durability: { current: 1, max: 1, regen: 0 },
+  };
+}
+
+function buildInitialState() {
+  return {
+    schema: "agent-kernel/InitialStateArtifact",
+    schemaVersion: 1,
+    meta: {
+      id: "multi_actor_orchestration_state",
+      runId: "multi_actor_orchestration",
+      createdAt: "2026-07-02T00:00:00.000Z",
+    },
+    simConfigRef: {
+      id: "multi_actor_orchestration_sim",
+      schema: "agent-kernel/SimConfigArtifact",
+      schemaVersion: 1,
+    },
+    actors: [
+      {
+        id: "delver_1",
+        kind: "ambulatory",
+        archetype: "delver",
+        role: "delver",
+        position: { x: 1, y: 1 },
+        motivation: { kind: "random" },
+        traits: { affinities: { fire: 1 } },
+        vitals: makeVitals(10),
+      },
+      {
+        id: "warden_1",
+        kind: "ambulatory",
+        archetype: "warden",
+        role: "warden",
+        position: { x: 7, y: 1 },
+        motivation: { kind: "random" },
+        traits: { affinities: { dark: 1 } },
+        vitals: makeVitals(6),
+      },
+      {
+        id: "warden_2",
+        kind: "ambulatory",
+        archetype: "warden",
+        role: "warden",
+        position: { x: 1, y: 7 },
+        motivation: { kind: "random" },
+        traits: { affinities: { dark: 1 } },
+        vitals: makeVitals(6),
+      },
+      {
+        id: "warden_3",
+        kind: "ambulatory",
+        archetype: "warden",
+        role: "warden",
+        position: { x: 7, y: 7 },
+        motivation: { kind: "random" },
+        traits: { affinities: { dark: 1 } },
+        vitals: makeVitals(6),
+      },
+    ],
+  };
+}
+
+async function loadRuntimeDeps() {
+  const [{ createRuntime }, { createCore }] = await Promise.all([
+    import("../../packages/runtime/src/runner/runtime.js"),
+    import("../../packages/core-ts/src/index.ts"),
+  ]);
+  return { createRuntime, createCore };
+}
+
+async function runRuntimeScenario({
+  simConfig = buildSimConfig(),
+  initialState = buildInitialState(),
+  ticks = TICK_COUNT,
+  seed = simConfig.seed ?? 0,
+} = {}) {
+  const { createRuntime, createCore } = await loadRuntimeDeps();
+  const core = createCore();
+  // Same seam the CLI `run` command uses (packages/runtime/src/commands/kernel.js).
+  const runtime = createRuntime({ core, adapters: {} });
+  await runtime.init({ seed, simConfig, initialState });
+  for (let t = 0; t < ticks; t += 1) {
+    await runtime.step();
+  }
+  return { core, runtime, frames: runtime.getTickFrames() };
+}
+
+function acceptedActionsByActor(frames) {
+  const byActor = new Map();
+  frames.forEach((frame) => {
+    const accepted = Array.isArray(frame?.acceptedActions) ? frame.acceptedActions : [];
+    accepted.forEach((action) => {
+      if (!action?.actorId) return;
+      if (!byActor.has(action.actorId)) byActor.set(action.actorId, []);
+      byActor.get(action.actorId).push(action);
+    });
+  });
+  return byActor;
+}
+
+// ---------------------------------------------------------------------------
+// Every configured actor must receive accepted actions across the run
+// ---------------------------------------------------------------------------
+
+test("every configured actor (not just actors[0]) receives accepted move/wait actions across a multi-tick run", async () => {
+  const initialState = buildInitialState();
+  const expectedIds = initialState.actors.map((a) => a.id);
+
+  const { frames } = await runRuntimeScenario({ initialState, ticks: TICK_COUNT, seed: 0 });
+
+  const byActor = acceptedActionsByActor(frames);
+  const moveOrWaitByActor = new Map();
+  for (const [actorId, actions] of byActor.entries()) {
+    moveOrWaitByActor.set(
+      actorId,
+      actions.filter((a) => a.kind === "move" || a.kind === "wait"),
+    );
+  }
+
+  for (const actorId of expectedIds) {
+    const actions = moveOrWaitByActor.get(actorId) || [];
+    assert.ok(
+      actions.length > 0,
+      `actor "${actorId}" must receive at least one accepted move/wait action across ${TICK_COUNT} ticks ` +
+        `(actors with accepted actions: ${[...moveOrWaitByActor.keys()].join(",") || "none"})`,
+    );
+  }
+});
+
+test("actor iteration order is deterministic and matches initialState.actors order", async () => {
+  const initialState = buildInitialState();
+  const expectedIds = initialState.actors.map((a) => a.id);
+
+  const runA = await runRuntimeScenario({ initialState, ticks: TICK_COUNT, seed: 42 });
+  const runB = await runRuntimeScenario({ initialState: buildInitialState(), ticks: TICK_COUNT, seed: 42 });
+
+  const byActorA = acceptedActionsByActor(runA.frames);
+  const byActorB = acceptedActionsByActor(runB.frames);
+
+  expectedIds.forEach((actorId) => {
+    const seqA = (byActorA.get(actorId) || []).map((a) => `${a.kind}:${a.tick}`);
+    const seqB = (byActorB.get(actorId) || []).map((a) => `${a.kind}:${a.tick}`);
+    assert.deepEqual(seqA, seqB, `actor "${actorId}" accepted-action sequence must be reproducible for identical seed/initialState`);
+  });
+});
+
+test("core still tracks every configured actor after a multi-tick run with 4 actors", async () => {
+  const { core } = await runRuntimeScenario({ ticks: TICK_COUNT, seed: 7 });
+  assert.equal(core.getMotivatedActorCount(), buildInitialState().actors.length);
+});
+
+// ---------------------------------------------------------------------------
+// Permutations expanded from TODO stubs
+// ---------------------------------------------------------------------------
+
+function buildActor({ id, archetype, position, motivation = "random", hp = 6 }) {
+  return {
+    id,
+    kind: "ambulatory",
+    archetype,
+    role: archetype,
+    position,
+    motivation: { kind: motivation },
+    traits: { affinities: { [archetype === "delver" ? "fire" : "dark"]: 1 } },
+    vitals: makeVitals(hp),
+  };
+}
+
+function buildStateWithActors(actors) {
+  return { ...buildInitialState(), actors };
+}
+
+async function coverageForActors(actors, { ticks = TICK_COUNT, seed = 0 } = {}) {
+  const { frames } = await runRuntimeScenario({
+    initialState: buildStateWithActors(actors),
+    ticks,
+    seed,
+  });
+  return acceptedActionsByActor(frames);
+}
+
+test("actor-count permutations: 2, 3, and 11 actors all get full coverage", async () => {
+  const rosters = [
+    [
+      buildActor({ id: "delver_1", archetype: "delver", position: { x: 1, y: 1 } }),
+      buildActor({ id: "warden_1", archetype: "warden", position: { x: 7, y: 7 } }),
+    ],
+    [
+      buildActor({ id: "delver_1", archetype: "delver", position: { x: 1, y: 1 } }),
+      buildActor({ id: "warden_1", archetype: "warden", position: { x: 7, y: 1 } }),
+      buildActor({ id: "warden_2", archetype: "warden", position: { x: 7, y: 7 } }),
+    ],
+    // Acceptance-scenario scale: 1 delver + 10 wardens on distinct tiles.
+    [
+      buildActor({ id: "delver_1", archetype: "delver", position: { x: 1, y: 1 } }),
+      ...Array.from({ length: 10 }, (_, i) =>
+        buildActor({
+          id: `warden_${i + 1}`,
+          archetype: "warden",
+          position: { x: 1 + ((i + 2) % 7), y: 2 + Math.floor((i + 2) / 7) * 2 },
+        })),
+    ],
+  ];
+  for (const actors of rosters) {
+    const byActor = await coverageForActors(actors);
+    for (const actor of actors) {
+      assert.ok(
+        (byActor.get(actor.id) || []).some((a) => a.kind === "move" || a.kind === "wait"),
+        `roster of ${actors.length}: actor "${actor.id}" received no accepted move/wait`,
+      );
+    }
+  }
+});
+
+test("mixed motivations: stationary actors get zero moves while random/attacking actors act", async () => {
+  const actors = [
+    buildActor({ id: "random_1", archetype: "delver", position: { x: 1, y: 1 }, motivation: "random" }),
+    buildActor({ id: "attacker_1", archetype: "warden", position: { x: 7, y: 7 }, motivation: "attacking" }),
+    buildActor({ id: "stationary_1", archetype: "warden", position: { x: 7, y: 1 }, motivation: "stationary" }),
+  ];
+  const byActor = await coverageForActors(actors);
+
+  const stationaryMoves = (byActor.get("stationary_1") || []).filter((a) => a.kind === "move");
+  assert.equal(stationaryMoves.length, 0, "stationary actor must never receive an accepted move");
+
+  for (const id of ["random_1", "attacker_1"]) {
+    assert.ok(
+      (byActor.get(id) || []).length > 0,
+      `actor "${id}" must receive accepted actions in a mixed-motivation run`,
+    );
+  }
+});
+
+test("single-tick run still advances every actor, not just actors[0]", async () => {
+  const initialState = buildInitialState();
+  const byActor = await coverageForActors(initialState.actors, { ticks: 1 });
+  for (const actor of initialState.actors) {
+    assert.ok(
+      (byActor.get(actor.id) || []).length > 0,
+      `actor "${actor.id}" did not act during the single tick`,
+    );
+  }
+});
+
+test("actor coverage is unaffected by initialState.actors array order", async () => {
+  const forward = buildInitialState().actors;
+  const reversed = buildInitialState().actors.slice().reverse();
+
+  const coverageForward = await coverageForActors(forward);
+  const coverageReversed = await coverageForActors(reversed);
+
+  for (const actor of forward) {
+    assert.ok((coverageForward.get(actor.id) || []).length > 0, `forward order: "${actor.id}" missing coverage`);
+    assert.ok((coverageReversed.get(actor.id) || []).length > 0, `reversed order: "${actor.id}" missing coverage`);
+  }
+});
+
+test("long run (TICK_COUNT * 5) does not silently drop later actors", async () => {
+  const initialState = buildInitialState();
+  const byActor = await coverageForActors(initialState.actors, { ticks: TICK_COUNT * 5 });
+  for (const actor of initialState.actors) {
+    const count = (byActor.get(actor.id) || []).length;
+    assert.ok(count > 0, `actor "${actor.id}" has no accepted actions across the long run`);
+  }
+});
+
+test.skip("duplicate actor id must be rejected at initial-state application (IMPLEMENTATION GAP: currently causes action amplification)", async () => {
+  // Contract intent: duplicate ids should be rejected when the initial state
+  // is applied. Current implementation accepts them AND amplifies actions —
+  // measured 12 accepted move/wait actions per tick for a twice-placed id on
+  // the execute/apply frame alone (verified 2026-07-06); the per-actor DECIDE
+  // loop compounds proposals when ids collide. Skipped rather than pinned:
+  // the amplified count is an accident of the loop, not behavior worth
+  // locking in. Unskip once applyInitialStateToCore rejects duplicate ids
+  // (tracked as a follow-up task); the try/catch below then passes.
+  const actors = [
+    buildActor({ id: "dup_actor", archetype: "delver", position: { x: 1, y: 1 } }),
+    buildActor({ id: "dup_actor", archetype: "warden", position: { x: 7, y: 7 } }),
+    buildActor({ id: "warden_ok", archetype: "warden", position: { x: 7, y: 1 } }),
+  ];
+  let frames;
+  try {
+    ({ frames } = await runRuntimeScenario({
+      initialState: buildStateWithActors(actors),
+      ticks: TICK_COUNT,
+      seed: 0,
+    }));
+  } catch (error) {
+    // A future duplicate-id guard that rejects outright also satisfies intent.
+    assert.ok(error instanceof Error);
+    return;
+  }
+  // acceptedActions echo across a tick's phase frames — count only the
+  // execute/apply frame so each accepted action is counted once.
+  const perTick = new Map();
+  for (const frame of frames) {
+    if (frame?.phase !== "execute" || frame?.phaseDetail !== "apply") continue;
+    for (const action of Array.isArray(frame?.acceptedActions) ? frame.acceptedActions : []) {
+      if (action?.actorId !== "dup_actor" || (action.kind !== "move" && action.kind !== "wait")) continue;
+      perTick.set(action.tick, (perTick.get(action.tick) || 0) + 1);
+    }
+  }
+  assert.ok(perTick.size > 0, "duplicated-id actors must still act somewhere in the run");
+  for (const [tick, count] of perTick.entries()) {
+    assert.ok(
+      count <= 2,
+      `tick ${tick}: ${count} accepted move/wait actions for the duplicated id — more than its two placements`,
+    );
+  }
+});
+
+test("cross-check: delver + 3 wardens roster shape agrees with the integration suite's coverage expectations", async () => {
+  // Mirrors the roster shape used by tests/integration/multi-actor-random-run.test.js
+  // (one delver + three wardens, all random) so the two suites cannot drift
+  // apart on what "full actor coverage" means.
+  const actors = [
+    buildActor({ id: "delver_1", archetype: "delver", position: { x: 1, y: 1 }, hp: 10 }),
+    buildActor({ id: "warden_1", archetype: "warden", position: { x: 7, y: 1 } }),
+    buildActor({ id: "warden_2", archetype: "warden", position: { x: 1, y: 7 } }),
+    buildActor({ id: "warden_3", archetype: "warden", position: { x: 7, y: 7 } }),
+  ];
+  const byActor = await coverageForActors(actors);
+  const covered = actors.filter((a) => (byActor.get(a.id) || []).length > 0).map((a) => a.id);
+  assert.deepEqual(covered.sort(), actors.map((a) => a.id).sort(), "all four actors must be covered");
+});


### PR DESCRIPTION
Supersedes closed PR #59, which targeted codex/test-permutation-expansion instead of main.

This branch starts at origin/main and cherry-picks only the three patch-unique commits from feature/agent-movement:

- Add deterministic random movement and multi-actor tick orchestration
- Add Cmd+arrow tick playback and rebind screen navigation
- Wire MCP-to-CLI-to-UI pipeline for authored simulation runs

## Deferred gate: content-gen benchmark

Per AGENTS.md, changes to `ak_create` behavior require the content-gen benchmark (`run-content-gen --profiles dual --runs 3 --route external`, pass bar ≥ 99 % exec ok / avg score ≥ 75) before merge. The remote GPU node (207.6.34.73:2222) is unreachable, so this gate is **deferred with explicit maintainer approval (2026-07-07)**. Run the benchmark against main once the node returns; revert or fix forward if it regresses.

Correctness coverage at merge time: full Vitest suite green (2,131 tests) and Playwright at the accepted pre-existing baseline on a byte-identical tree (feature/agent-movement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)