### PR TITLE
Reject duplicate actor ids at initial-state application

### DIFF
--- a/packages/runtime/src/runner/core-setup.mjs
+++ b/packages/runtime/src/runner/core-setup.mjs
@@ -300,6 +300,17 @@ export function applyInitialStateToCore(core, initialState, { spawn } = {}) {
     return { ok: false, reason: "missing_actors" };
   }
 
+  const seenIds = new Set();
+  for (const actor of actors) {
+    const id = String(actor?.id || "");
+    if (seenIds.has(id)) {
+      // A shared id makes action attribution ambiguous; two id-less actors
+      // collide the same way but the root cause is the missing id.
+      return { ok: false, reason: id === "" ? "missing_actor_id" : "duplicate_actor_id", actorId: id };
+    }
+    seenIds.add(id);
+  }
+
   const primary = actors[0];
   const supportsMulti = typeof core.applyActorPlacements === "function"
     && typeof core.setMotivatedActorVital === "function"

--- a/tests/fixtures/artifacts/invalid/initial-state-artifact-v1-duplicate-actor-id.json
+++ b/tests/fixtures/artifacts/invalid/initial-state-artifact-v1-duplicate-actor-id.json
@@ -1,0 +1,122 @@
+{
+  "schema": "agent-kernel/InitialStateArtifact",
+  "schemaVersion": 1,
+  "meta": {
+    "id": "initial_state_duplicate_actor_id",
+    "runId": "run_mvp_grid",
+    "createdAt": "2026-03-28T00:00:00.000Z",
+    "producedBy": "fixture"
+  },
+  "simConfigRef": {
+    "id": "sim_config_mvp_grid",
+    "schema": "agent-kernel/SimConfigArtifact",
+    "schemaVersion": 1
+  },
+  "actors": [
+    {
+      "id": "actor_alpha",
+      "kind": "ambulatory",
+      "position": {
+        "x": 2,
+        "y": 1
+      },
+      "vitals": {
+        "health": {
+          "current": 10,
+          "max": 10,
+          "regen": 0
+        },
+        "mana": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        },
+        "stamina": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        },
+        "durability": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        }
+      },
+      "capabilities": {
+        "movementCost": 1,
+        "actionCostMana": 0,
+        "actionCostStamina": 0
+      }
+    },
+    {
+      "id": "actor_alpha",
+      "kind": "ambulatory",
+      "position": {
+        "x": 3,
+        "y": 1
+      },
+      "vitals": {
+        "health": {
+          "current": 20,
+          "max": 20,
+          "regen": 0
+        },
+        "mana": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        },
+        "stamina": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        },
+        "durability": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        }
+      },
+      "capabilities": {
+        "movementCost": 2,
+        "actionCostMana": 1,
+        "actionCostStamina": 0
+      }
+    },
+    {
+      "id": "actor_gamma",
+      "kind": "ambulatory",
+      "position": {
+        "x": 1,
+        "y": 2
+      },
+      "vitals": {
+        "health": {
+          "current": 30,
+          "max": 30,
+          "regen": 0
+        },
+        "mana": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        },
+        "stamina": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        },
+        "durability": {
+          "current": 0,
+          "max": 0,
+          "regen": 0
+        }
+      },
+      "capabilities": {
+        "movementCost": 1,
+        "actionCostMana": 0,
+        "actionCostStamina": 2
+      }
+    }
+  ]
+}

--- a/tests/runtime/multi-actor-initial-state.test.js
+++ b/tests/runtime/multi-actor-initial-state.test.js
@@ -52,3 +52,27 @@ test("runtime loads multi-actor initial state into core", async () => {
   assert.equal(core.getActorX(), 2);
   assert.equal(core.getActorY(), 1);
 });
+
+test("runtime init rejects initial state with duplicate actor ids", async () => {
+  const { createRuntime } = await import(
+    "../../packages/runtime/src/runner/runtime.js"
+  );
+  const { createCore } = await import(
+    "../../packages/core-ts/src/index.ts"
+  );
+
+  const core = createCore();
+
+  const simConfig = JSON.parse(
+    readFileSync(resolve(ROOT, "tests/fixtures/artifacts/sim-config-artifact-v1-mvp-grid.json"), "utf8"),
+  );
+  const initialState = JSON.parse(
+    readFileSync(resolve(ROOT, "tests/fixtures/artifacts/invalid/initial-state-artifact-v1-duplicate-actor-id.json"), "utf8"),
+  );
+
+  const runtime = createRuntime({ core, adapters: {} });
+  await assert.rejects(
+    runtime.init({ seed: 0, simConfig, initialState }),
+    /duplicate_actor_id/,
+  );
+});

--- a/tests/runtime/multi-actor-orchestration.test.js
+++ b/tests/runtime/multi-actor-orchestration.test.js
@@ -330,49 +330,24 @@ test("long run (TICK_COUNT * 5) does not silently drop later actors", async () =
   }
 });
 
-test.skip("duplicate actor id must be rejected at initial-state application (IMPLEMENTATION GAP: currently causes action amplification)", async () => {
-  // Contract intent: duplicate ids should be rejected when the initial state
-  // is applied. Current implementation accepts them AND amplifies actions —
-  // measured 12 accepted move/wait actions per tick for a twice-placed id on
-  // the execute/apply frame alone (verified 2026-07-06); the per-actor DECIDE
-  // loop compounds proposals when ids collide. Skipped rather than pinned:
-  // the amplified count is an accident of the loop, not behavior worth
-  // locking in. Unskip once applyInitialStateToCore rejects duplicate ids
-  // (tracked as a follow-up task); the try/catch below then passes.
+test("duplicate actor id is rejected at initial-state application", async () => {
+  // Duplicate ids make action attribution ambiguous and used to amplify
+  // accepted actions (measured 12 move/wait actions per tick for a
+  // twice-placed id, verified 2026-07-06). applyInitialStateToCore now
+  // rejects the state with reason "duplicate_actor_id" before placement.
   const actors = [
     buildActor({ id: "dup_actor", archetype: "delver", position: { x: 1, y: 1 } }),
     buildActor({ id: "dup_actor", archetype: "warden", position: { x: 7, y: 7 } }),
     buildActor({ id: "warden_ok", archetype: "warden", position: { x: 7, y: 1 } }),
   ];
-  let frames;
-  try {
-    ({ frames } = await runRuntimeScenario({
+  await assert.rejects(
+    runRuntimeScenario({
       initialState: buildStateWithActors(actors),
       ticks: TICK_COUNT,
       seed: 0,
-    }));
-  } catch (error) {
-    // A future duplicate-id guard that rejects outright also satisfies intent.
-    assert.ok(error instanceof Error);
-    return;
-  }
-  // acceptedActions echo across a tick's phase frames — count only the
-  // execute/apply frame so each accepted action is counted once.
-  const perTick = new Map();
-  for (const frame of frames) {
-    if (frame?.phase !== "execute" || frame?.phaseDetail !== "apply") continue;
-    for (const action of Array.isArray(frame?.acceptedActions) ? frame.acceptedActions : []) {
-      if (action?.actorId !== "dup_actor" || (action.kind !== "move" && action.kind !== "wait")) continue;
-      perTick.set(action.tick, (perTick.get(action.tick) || 0) + 1);
-    }
-  }
-  assert.ok(perTick.size > 0, "duplicated-id actors must still act somewhere in the run");
-  for (const [tick, count] of perTick.entries()) {
-    assert.ok(
-      count <= 2,
-      `tick ${tick}: ${count} accepted move/wait actions for the duplicated id — more than its two placements`,
-    );
-  }
+    }),
+    /duplicate_actor_id/,
+  );
 });
 
 test("cross-check: delver + 3 wardens roster shape agrees with the integration suite's coverage expectations", async () => {


### PR DESCRIPTION
Follow-up to #60, closing the tracked action-amplification gap: duplicate actor ids used to be accepted and amplified accepted actions (measured 12 move/wait actions per tick for a twice-placed id, verified 2026-07-06).

- `applyInitialStateToCore` now rejects the state with reason `duplicate_actor_id` (or `missing_actor_id` when empty ids collide) before placement.
- Unskips the orchestration test that was pinned to the gap.
- Adds a runtime init rejection test and the negative fixture `tests/fixtures/artifacts/invalid/initial-state-artifact-v1-duplicate-actor-id.json`.

Validation: both affected test files green after rebase onto main (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)