### PR TITLE
docs: agent-movement milestone documentation pass (charter, diagram, CLI README)

### DIFF
--- a/docs/architecture-charter.md
+++ b/docs/architecture-charter.md
@@ -52,7 +52,9 @@ Heavy level synthesis runs behind a builder adapter. UI code hands off summaries
 
 - Simple actor motivations are resolved deterministically in `packages/runtime/src/personas/actor/controller.js`.
 - `buildMotivatedProposals()` reads `motivation.kind` from the observation actor record or `payload.initialState.actors`. It uses `resolveNearestHostile()` to choose the closest other actor by Chebyshev distance.
-- Current simple motivation kinds are `attacking`, `defending`, and `stationary`: attacking actors attack adjacent hostiles or pursue distant hostiles, defending actors attack adjacent hostiles or hold position when distant, and stationary actors emit no movement proposal.
+- Current simple motivation kinds are `attacking`, `defending`, `stationary`, and `random`: attacking actors attack adjacent hostiles or pursue distant hostiles, defending actors attack adjacent hostiles or hold position when distant, stationary actors emit no movement proposal, and random actors move to a seed-derived legal adjacent tile.
+- `random` movement is deterministic pseudo-random: the choice derives from `seed:actorId:tick` (FNV/mulberry), never `Math.random()`, and synthesizes a `wait` when no legal adjacent tile exists. Replays of the same seed produce identical movement.
+- Multi-actor ticks: `packages/runtime/src/runner/runtime-fsm.mjs` runs the DECIDE phase for every actor each tick and reserves proposed target tiles within the tick so two actors cannot move onto the same tile in the same tick.
 - Complex motivation is opt-in. Actors with runtime decisioning enabled, for example `runtimeDecisioning: { enabled: true, mode: "solver", preferred: "solver", targetAdapter: "z3" }`, emit a `solver_request` effect instead of directly returning a concrete action.
 
 ## Solver Adapter Boundary
@@ -69,6 +71,14 @@ Heavy level synthesis runs behind a builder adapter. UI code hands off summaries
 - `globalThis.__ak_loadScenario(scenario, options)` compiles and forwards to `globalThis.__ak_loadGameplayBundle(bundle, options)`.
 - `packages/ui-web/src/views/gameplay-view.js` implements Step and `runToEnd()` by moving the current frame cursor over `tickFrames`; it does not call runtime step during playback.
 - `packages/runtime/src/runner/core-facade.js` is the runtime-owned browser facade for preview/playback helpers that need deterministic core setup, frame rendering, observation reads, and affinity field records.
+- Tick playback is keyboard-driven with a fixed binding policy: bare keys belong to the game surface, Cmd/Ctrl+arrows step tick playback, Cmd/Ctrl+`[`/`]` navigate screens back/forward, and Ctrl+digit jumps directly to a screen. Cmd+digit is reserved by browsers and never bound. The gameplay stage exposes the cursor as `data-gameplay-current-tick`.
+
+## Sandbox Bridge (MCP → CLI → UI)
+
+- The `ak_push_to_ui` MCP tool delivers an `agent-kernel/GameplayBundle` to a connected browser UI over the sandbox WebSocket bridge (`packages/adapters-cli/src/mcp/bridge-server.mjs`, default port 38487, override with `AK_SANDBOX_BRIDGE_PORT`).
+- The tool accepts an inline `bundle`, a `bundlePath`, or an `outDir` containing `bundle.json`; the browser side is `packages/ui-web/src/sandbox-bridge-client.js`, which loads the bundle into the gameplay Phaser surface via `window.__ak_loadGameplayBundle`.
+- CLI `run` stitches a post-run `GameplayBundle` (`bundle.json`) only when its inputs came from an authored `create` outDir; fixture-driven runs stay bundle-free so CLI output remains artifact-for-artifact equivalent to the browser host's run output.
+- The bridge is an adapter-layer concern: bundle assembly reuses runtime contracts, and no bridge or WebSocket code lives in `runtime` or `core-ts`.
 
 ## Affinity Visualization
 

--- a/docs/architecture-charter.md
+++ b/docs/architecture-charter.md
@@ -77,6 +77,7 @@ Heavy level synthesis runs behind a builder adapter. UI code hands off summaries
 
 - The `ak_push_to_ui` MCP tool delivers an `agent-kernel/GameplayBundle` to a connected browser UI over the sandbox WebSocket bridge (`packages/adapters-cli/src/mcp/bridge-server.mjs`, default port 38487, override with `AK_SANDBOX_BRIDGE_PORT`).
 - The tool accepts an inline `bundle`, a `bundlePath`, or an `outDir` containing `bundle.json`; the browser side is `packages/ui-web/src/sandbox-bridge-client.js`, which loads the bundle into the gameplay Phaser surface via `window.__ak_loadGameplayBundle`.
+- `openBrowser: true` lets the MCP bootstrap the whole loop: it serves the canonical `index_c.html` via `scripts/serve-ui.mjs` when nothing answers `/health`, opens the default browser, and pre-stages the bundle for the bridge's replay window so the freshly opened UI loads it on connect.
 - CLI `run` stitches a post-run `GameplayBundle` (`bundle.json`) only when its inputs came from an authored `create` outDir; fixture-driven runs stay bundle-free so CLI output remains artifact-for-artifact equivalent to the browser host's run output.
 - The bridge is an adapter-layer concern: bundle assembly reuses runtime contracts, and no bridge or WebSocket code lives in `runtime` or `core-ts`.
 

--- a/docs/architecture/diagram.mmd
+++ b/docs/architecture/diagram.mmd
@@ -8,7 +8,9 @@ flowchart LR
     GameplaySurface["gameplay surface\ncreateGameplayPhaserRenderer"]
     PhaserIngestion["phaser-surface-ingestion"]
     ScenarioLoader["scenario-loader + preview-view"]
+    BridgeClient["sandbox-bridge-client"]
     CLI["CLI (ak.mjs)"]
+    MCP["MCP server (ak_* tools)"]
   end
 
   subgraph Runtime["Runtime (TypeScript)"]
@@ -39,6 +41,7 @@ flowchart LR
     ACli["adapters-cli"]
     ATest["adapters-test"]
     Z3Adapter["Z3-shaped solver adapter\n(adapters-test)"]
+    BridgeServer["sandbox bridge server (WS)\n(adapters-cli)"]
   end
 
   subgraph External["External Services"]
@@ -60,6 +63,10 @@ flowchart LR
   ScenarioLoader --> CoreFacade
   UIWeb --> ScenarioLoader
   CLI --> ACli
+  MCP --> ACli
+  MCP -- "ak_push_to_ui\nGameplayBundle" --> BridgeServer
+  BridgeServer -- "WebSocket" --> BridgeClient
+  BridgeClient -- "__ak_loadGameplayBundle" --> GameplaySurface
   AWeb --> CommandKernel
   ACli --> CommandKernel
   CommandKernel --> CardAuthoring

--- a/packages/adapters-cli/README.md
+++ b/packages/adapters-cli/README.md
@@ -204,7 +204,9 @@ Inputs/outputs:
 The canonical motivation-sandbox fixture is
 `tests/fixtures/scenarios/delver-warden-battle-v1-basic.json`. Its `cliEquivalent`
 documents the matching `create` invocation and the motivation kinds currently used by
-the sandbox path: `attacking`, `defending`, and `stationary`.
+the sandbox path: `attacking`, `defending`, and `stationary`. Authored actors also
+accept `motivation=random` (deterministic seed-derived movement), which `create`
+persists into the emitted initial state.
 
 ```bash
 ak.mjs create --room "size=medium;count=1" --delver "count=1;affinity=fire;motivation=attacking;vitals=health:10:10:0,mana:10:10:0,stamina:10:10:0" --warden "count=1;affinity=dark;motivation=defending;vitals=health:6:6:0,mana:6:6:0,stamina:6:6:0"
@@ -393,6 +395,15 @@ artifact plus a `SolverResult` using a stubbed/fixture-driven solver adapter (no
 ### `run`
 Execute a configured simulation run using captured artifacts, emitting TickFrame and
 effect logs plus a minimal RunSummary artifact.
+
+When the run's inputs come from an authored `create` outDir (identified by the sibling
+pre-run `bundle.json` next to `--sim-config`), `run` also stitches a post-run
+`agent-kernel/GameplayBundle` from the resolved artifacts and recorded tick frames. It
+writes that bundle to `bundle.json` in the run outDir, upgrades the create outDir's
+`bundle.json` in place to the same loadable playback shape, and reports both under
+`artifactPaths.bundle` and `artifactPaths.create_bundle`. Fixture-driven runs stay
+bundle-free so CLI run output remains artifact-for-artifact equivalent to the browser
+host's run output. The stitched bundle is what `ak_push_to_ui` delivers to the UI.
 
 ### `configurator`
 Build `SimConfigArtifact` + `InitialStateArtifact` outputs from deterministic configurator inputs.
@@ -683,6 +694,25 @@ pnpm run demo:cli -- /tmp/agent-kernel-demo
 - `log`/`telemetry` effects include severity/tags/personaRef for UI/CLI inspection.
 
 Inspect the emitted artifacts in your chosen `--out-dir` or `artifacts/demo-bundle` to see these shapes. Examples align with `tests/fixtures/adapters/effects-routing.json`.
+
+## MCP sandbox bridge (`ak_push_to_ui`)
+
+The MCP server's `ak_push_to_ui` tool delivers an `agent-kernel/GameplayBundle` to a
+connected browser UI over the sandbox WebSocket bridge
+(`packages/adapters-cli/src/mcp/bridge-server.mjs`), so an agent can author with
+`ak_create`, execute with `ak_run`, and load the result into the gameplay surface
+without manual file handoff.
+
+- Bundle source (one of): inline `bundle`, an explicit `bundlePath`, or an `outDir`
+  containing `bundle.json` (the shape written by `run`'s post-run stitching or by
+  `create` pre-run).
+- `targetTab`: `"design"` or `"gameplay"` (default `"gameplay"`).
+- `requireClient` (default `true`): fail if no browser UI is connected; the browser side
+  is `packages/ui-web/src/sandbox-bridge-client.js`.
+- Bridge port: `38487` by default, overridable with `AK_SANDBOX_BRIDGE_PORT`.
+- Failure results are structured: missing bundle sources, invalid bundle shape, bridge
+  start failure (`SANDBOX_BRIDGE_START_FAILED`), and no-connected-client cases each
+  return `ok: false` with a specific reason rather than throwing.
 
 ## Architectural Intent
 

--- a/packages/adapters-cli/README.md
+++ b/packages/adapters-cli/README.md
@@ -709,6 +709,11 @@ without manual file handoff.
 - `targetTab`: `"design"` or `"gameplay"` (default `"gameplay"`).
 - `requireClient` (default `true`): fail if no browser UI is connected; the browser side
   is `packages/ui-web/src/sandbox-bridge-client.js`.
+- `openBrowser` (default `false`): serve the canonical `index_c.html` via
+  `scripts/serve-ui.mjs` (only when nothing answers `/health`), open the default browser,
+  and pre-stage the bundle so the UI loads it on connect. Implies `requireClient: false`.
+  UI host/port come from `AK_UI_HOST` / `AK_UI_PORT` (default `127.0.0.1:8001`);
+  `AK_DISABLE_UI_LAUNCH=1` skips the side effects.
 - Bridge port: `38487` by default, overridable with `AK_SANDBOX_BRIDGE_PORT`.
 - Failure results are structured: missing bundle sources, invalid bundle shape, bridge
   start failure (`SANDBOX_BRIDGE_START_FAILED`), and no-connected-client cases each


### PR DESCRIPTION
Documentation pass for the merged agent-movement milestone (#60), per the working agreement's post-milestone docs obligation.

- **docs/architecture-charter.md** — adds the `random` simple motivation kind (deterministic seed-derived movement from `seed:actorId:tick`, never `Math.random()`), the multi-actor DECIDE loop with same-tick target-tile reservation, the tick-playback keyboard binding policy (bare keys = game, Cmd/Ctrl+arrows = tick playback, Cmd/Ctrl+[/] = screen nav, Ctrl+digit = jumps), and a new **Sandbox Bridge (MCP → CLI → UI)** section covering `ak_push_to_ui` and the boundary rule that no bridge/WS code lives in runtime or core-ts.
- **docs/architecture/diagram.mmd** — adds MCP server, sandbox bridge server (WS, adapters-cli), and sandbox-bridge-client nodes with the GameplayBundle delivery path. Mermaid syntax validated.
- **packages/adapters-cli/README.md** — documents `run`'s post-run GameplayBundle stitching (authored create outDirs only; fixture runs stay bundle-free for UI↔CLI equivalence), a new `ak_push_to_ui` section (bundle sources, `targetTab`, `requireClient`, port `38487` / `AK_SANDBOX_BRIDGE_PORT`, structured failures), and `motivation=random` authoring support.

Docs-only; no production code or tests touched.

Note: PR #61 further changes the charter's motivation-flow wording (controller.mts canonicalization) — whichever merges second should rebase trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)