### PR TITLE
Add openBrowser UI launch to ak_push_to_ui

### DIFF
--- a/packages/adapters-cli/src/mcp/tools/sandbox.mjs
+++ b/packages/adapters-cli/src/mcp/tools/sandbox.mjs
@@ -10,9 +10,11 @@
  *   Reuses the existing session's room dimensions for bounds checking.
  */
 
+import { spawn } from "node:child_process";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { resolve, join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   validateSandboxSession,
   SANDBOX_SESSION_SCHEMA,
@@ -942,8 +944,69 @@ export async function executeSandboxMove({
 
 const DEFAULT_BRIDGE_PORT = Number(process.env.AK_SANDBOX_BRIDGE_PORT) || 38487;
 
+// Canonical UI entry served for the bridge workflow. index.html / index_l.html
+// remain available via serve-ui.mjs --entry but are not the default.
+const UI_ENTRY = "index_c.html";
+// sandbox.mjs lives at packages/adapters-cli/src/mcp/tools/ — five levels below the repo root.
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+
 function makePushMessageId() {
   return `msg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+function canonicalUiUrl() {
+  const host = process.env.AK_UI_HOST || "127.0.0.1";
+  const port = Number(process.env.AK_UI_PORT) || 8001;
+  return `http://${host}:${port}/packages/ui-web/${UI_ENTRY}`;
+}
+
+function platformOpenCommand(url) {
+  if (process.platform === "darwin") return ["open", [url]];
+  if (process.platform === "win32") return ["cmd", ["/c", "start", "", url]];
+  return ["xdg-open", [url]];
+}
+
+/**
+ * Best-effort: ensure the canonical UI is being served and open it in the default
+ * browser. Side effects are skipped when AK_DISABLE_UI_LAUNCH=1 (tests, headless CI).
+ * Always returns the canonical URL so callers can surface it regardless.
+ */
+async function launchCanonicalUi() {
+  const url = canonicalUiUrl();
+  const out = { url, entry: UI_ENTRY, opened: false, serverSpawned: false };
+  if (process.env.AK_DISABLE_UI_LAUNCH === "1") return out;
+
+  // Spawn serve-ui on the canonical entry only if nothing is answering /health.
+  try {
+    const health = await fetch(new URL("/health", url)).catch(() => null);
+    if (!health || !health.ok) {
+      const child = spawn(
+        process.execPath,
+        ["scripts/serve-ui.mjs", "--entry", UI_ENTRY],
+        {
+          cwd: REPO_ROOT,
+          env: { ...process.env, PORT: String(Number(process.env.AK_UI_PORT) || 8001) },
+          stdio: "ignore",
+          detached: true,
+        },
+      );
+      child.unref();
+      out.serverSpawned = true;
+    }
+  } catch {
+    /* best-effort — a failed probe/spawn must not fail the push */
+  }
+
+  // Open the default browser at the canonical URL.
+  try {
+    const [cmd, args] = platformOpenCommand(url);
+    const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+    child.unref();
+    out.opened = true;
+  } catch {
+    out.opened = false;
+  }
+  return out;
 }
 
 /**
@@ -963,6 +1026,8 @@ function makePushMessageId() {
  * @param {string} [options.outDir]
  * @param {string} [options.targetTab]      "design" | "gameplay" (default "gameplay").
  * @param {boolean} [options.requireClient] Fail if no browser UI is connected (default true).
+ * @param {boolean} [options.openBrowser]   Serve + open the canonical UI and pre-stage the
+ *                                          bundle (implies requireClient: false, default false).
  * @param {string} [options.correlationId]
  * @returns {Promise<object>}
  */
@@ -972,8 +1037,12 @@ export async function executePushToUi({
   outDir,
   targetTab = "gameplay",
   requireClient = true,
+  openBrowser = false,
   correlationId,
 } = {}) {
+  if (openBrowser) {
+    requireClient = false;
+  }
   let bundle = inlineBundle;
 
   if (!bundle) {
@@ -1041,6 +1110,11 @@ export async function executePushToUi({
     };
   }
 
+  // Launch after all bundle/bridge validation so a bad request never spawns
+  // a server or browser, but before the push so the pre-staged bundle replays
+  // as soon as the freshly opened UI connects.
+  const ui = openBrowser ? await launchCanonicalUi() : null;
+
   const messageId = makePushMessageId();
   // D4 (sandbox-bridge-client.js handleBundle): targetTab lives at the envelope
   // root, not inside payload.
@@ -1062,6 +1136,7 @@ export async function executePushToUi({
     ok: true,
     command: "push-to-ui",
     ...(correlationId ? { correlationId } : {}),
+    ...(ui ? { ui } : {}),
     targetTab,
     bridge: {
       port: DEFAULT_BRIDGE_PORT,
@@ -1238,6 +1313,11 @@ export const sandboxTools = [
           "When true (default), fail immediately if no browser UI is connected. " +
             "When false, push and store the bundle for replay when the UI connects.",
         ),
+        openBrowser: booleanSchema(
+          "When true, serve the canonical index_c.html UI (if not already up) and open it in the " +
+            "default browser, then pre-stage the bundle so it loads as soon as the UI connects. " +
+            "Implies requireClient: false. Defaults to false.",
+        ),
         correlationId: stringSchema("Optional caller-supplied correlation ID echoed back in the result."),
       },
     },
@@ -1248,6 +1328,7 @@ export const sandboxTools = [
         outDir: isNonEmptyString(args.outDir) ? args.outDir : undefined,
         targetTab: args.targetTab === "design" ? "design" : "gameplay",
         requireClient: args.requireClient === false ? false : true,
+        openBrowser: args.openBrowser === true,
         correlationId: isNonEmptyString(args.correlationId) ? args.correlationId : undefined,
       }),
   }),

--- a/tests/adapters-cli/push-to-ui-launch.test.mjs
+++ b/tests/adapters-cli/push-to-ui-launch.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * ak_push_to_ui openBrowser launch — MCP-driven UI bootstrap
+ *
+ * The push tool must be able to launch the canonical UI (serve index_c.html +
+ * open the default browser) and pre-stage the bundle so the UI loads it on
+ * connect, instead of requiring a browser session to already exist.
+ *
+ * Side effects (server spawn, browser open) are disabled here via
+ * AK_DISABLE_UI_LAUNCH=1; the tests assert the structured result contract.
+ */
+
+import assert from "node:assert/strict";
+
+const MINIMAL_BUNDLE = {
+  schema: "agent-kernel/GameplayBundle",
+  schemaVersion: 1,
+  meta: { id: "bundle_launch_test", runId: "run_launch_test" },
+  artifacts: [
+    { schema: "agent-kernel/SimConfigArtifact", schemaVersion: 1, meta: { id: "sim_launch_test" } },
+  ],
+  tickFrames: [],
+};
+
+async function importPushToUi() {
+  const { executePushToUi } = await import(
+    "../../packages/adapters-cli/src/mcp/tools/sandbox.mjs"
+  );
+  return executePushToUi;
+}
+
+test("openBrowser: true succeeds with no connected client and reports the canonical UI url", async () => {
+  process.env.AK_DISABLE_UI_LAUNCH = "1";
+  delete process.env.AK_UI_HOST;
+  delete process.env.AK_UI_PORT;
+  const executePushToUi = await importPushToUi();
+
+  const result = await executePushToUi({
+    bundle: MINIMAL_BUNDLE,
+    openBrowser: true,
+  });
+
+  // openBrowser implies requireClient: false — must not fail on 0 clients
+  assert.equal(result.ok, true, `expected ok result, got: ${JSON.stringify(result)}`);
+  assert.equal(result.command, "push-to-ui");
+
+  // The launch report must always carry the canonical URL, even when side
+  // effects are disabled, so callers can surface it.
+  assert.ok(result.ui, "result must include a ui launch report when openBrowser is true");
+  assert.ok(
+    result.ui.url.endsWith("/packages/ui-web/index_c.html"),
+    `ui.url must target the canonical entry, got: ${result.ui.url}`,
+  );
+  assert.equal(result.ui.entry, "index_c.html");
+  assert.equal(result.ui.opened, false, "AK_DISABLE_UI_LAUNCH=1 must skip the browser open");
+  assert.equal(result.ui.serverSpawned, false, "AK_DISABLE_UI_LAUNCH=1 must skip the server spawn");
+});
+
+test("openBrowser: true pre-stages the bundle for replay when the UI connects", async () => {
+  process.env.AK_DISABLE_UI_LAUNCH = "1";
+  const executePushToUi = await importPushToUi();
+  const { getSandboxBridgeState } = await import(
+    "../../packages/adapters-cli/src/mcp/bridge-server.mjs"
+  );
+
+  const result = await executePushToUi({
+    bundle: MINIMAL_BUNDLE,
+    openBrowser: true,
+    correlationId: "corr_launch_prestage",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.correlationId, "corr_launch_prestage");
+
+  const state = getSandboxBridgeState();
+  assert.ok(state.latestBundle, "bundle must be stored for the bridge replay window");
+  assert.equal(state.latestBundle.payload.bundle.meta.id, "bundle_launch_test");
+});
+
+test("openBrowser url honors AK_UI_HOST / AK_UI_PORT overrides", async () => {
+  process.env.AK_DISABLE_UI_LAUNCH = "1";
+  process.env.AK_UI_HOST = "127.0.0.1";
+  process.env.AK_UI_PORT = "9123";
+  const executePushToUi = await importPushToUi();
+
+  const result = await executePushToUi({ bundle: MINIMAL_BUNDLE, openBrowser: true });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ui.url, "http://127.0.0.1:9123/packages/ui-web/index_c.html");
+
+  delete process.env.AK_UI_HOST;
+  delete process.env.AK_UI_PORT;
+});
+
+test("without openBrowser the result shape is unchanged (no ui field, requireClient still enforced)", async () => {
+  const executePushToUi = await importPushToUi();
+
+  const denied = await executePushToUi({ bundle: MINIMAL_BUNDLE });
+  assert.equal(denied.ok, false);
+  assert.equal(denied.error, "SANDBOX_UI_NOT_CONNECTED");
+
+  const prestaged = await executePushToUi({ bundle: MINIMAL_BUNDLE, requireClient: false });
+  assert.equal(prestaged.ok, true);
+  assert.equal(prestaged.ui, undefined, "ui launch report must only appear when openBrowser is true");
+});
+
+// ## TODO: Test Permutations
+// - openBrowser: true with a live /health responder must not spawn a second serve-ui process (serverSpawned: false)
+// - openBrowser: true with no /health responder and AK_DISABLE_UI_LAUNCH unset must report serverSpawned: true (needs spawn stub)
+// - openBrowser: true combined with explicit requireClient: true must still succeed (openBrowser wins)
+// - openBrowser: true with bundleNotFound outDir must fail before any launch side effect
+// - openBrowser: true when the bridge reports startFailed must return SANDBOX_BRIDGE_START_FAILED and skip the launch


### PR DESCRIPTION
Closes the one gap left by #60 relative to the intent of #49: **launching the UI from the MCP** so an agent can go `ak_create` → `ak_run` → `ak_push_to_ui { outDir, openBrowser: true }` and get a browser showing the generated scenario, with no manual serve/open step.

Ported from #49's `push-to-ui.mjs` implementation onto main's merged bridge tool:

- `openBrowser: true` probes `/health` on the canonical UI URL, spawns `scripts/serve-ui.mjs --entry index_c.html` only if nothing is serving, opens the default browser (`open`/`start`/`xdg-open`), and pre-stages the bundle for the bridge's replay window so the freshly opened UI loads it on connect.
- Implies `requireClient: false`. Launch runs after bundle/bridge validation, so invalid requests never spawn processes.
- `AK_DISABLE_UI_LAUNCH=1` skips all side effects (tests, headless CI); the result always carries `ui.url` / `ui.entry` / `ui.opened` / `ui.serverSpawned`.
- Host/port overridable via `AK_UI_HOST` / `AK_UI_PORT` (default `127.0.0.1:8001`).

Everything the launch relies on already exists on main: `serve-ui.mjs` defaults to `index_c.html` and answers `/health`, and `ui-web/src/main.js` auto-connects the sandbox bridge client.

Tests first: `tests/adapters-cli/push-to-ui-launch.test.mjs` (4 tests, written failing, with `## TODO: Test Permutations` stubs for Ollama). Full Vitest suite green: 291 files, 2135 passed.

Not a benchmark gate: `ak_create` schema, CLI arg mapping, and entity normalization are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)