### PR TITLE
feat(z3): real Z3 adapter for actor action selection (gated off by default)

### DIFF
--- a/packages/adapters-cli/package.json
+++ b/packages/adapters-cli/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "z3-solver": "^5.1.0"
   }
 }

--- a/packages/adapters-cli/src/adapters/z3/index.js
+++ b/packages/adapters-cli/src/adapters/z3/index.js
@@ -1,0 +1,212 @@
+/**
+ * Real Z3 adapter for the actor_action_selection constraint domain.
+ *
+ * Candidate actions are produced and legality-filtered by the Actor persona.
+ * This adapter only ranks those candidates with a deterministic Optimize
+ * objective; it does not duplicate range, resource, or collision policy.
+ */
+
+import { init } from "z3-solver";
+
+const RUNTIME_DECISION_CONTRACT = "runtime-decision-v1";
+
+const PRIORITY_WEIGHTS = Object.freeze({
+  attack: 100,
+  move_toward_hostile: 80,
+  move_toward_exit: 50,
+  move_fallback: 20,
+  wait: 10,
+  no_match: 0,
+});
+
+let sharedZ3Promise;
+
+function getSharedZ3() {
+  sharedZ3Promise ||= init();
+  return sharedZ3Promise;
+}
+
+function chebyshevDistance(a, b) {
+  if (!a || !b) return null;
+  if (![a.x, a.y, b.x, b.y].every(Number.isFinite)) return null;
+  return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+}
+
+function movesCloserTo(candidate, origin, targets) {
+  if (candidate?.action?.kind !== "move") return false;
+  const destination = candidate.action.params?.to;
+  if (!destination || !origin) return false;
+  return targets.some((target) => {
+    const before = chebyshevDistance(origin, target);
+    const after = chebyshevDistance(destination, target);
+    return before !== null && after !== null && after < before;
+  });
+}
+
+function scoreCandidate(candidate, envelope) {
+  if (candidate?.action?.kind === "attack") {
+    return { score: PRIORITY_WEIGHTS.attack, ruleId: "attack" };
+  }
+
+  const actorPosition = envelope.actor?.position;
+  const visiblePositions = Array.isArray(envelope.visibleActors)
+    ? envelope.visibleActors.map((actor) => actor?.position).filter(Boolean)
+    : [];
+  if (movesCloserTo(candidate, actorPosition, visiblePositions)) {
+    return {
+      score: PRIORITY_WEIGHTS.move_toward_hostile,
+      ruleId: "move_toward_hostile",
+    };
+  }
+
+  const exit = envelope.objectives?.exit;
+  if (exit && movesCloserTo(candidate, actorPosition, [exit])) {
+    return { score: PRIORITY_WEIGHTS.move_toward_exit, ruleId: "move_toward_exit" };
+  }
+
+  if (candidate?.action?.kind === "move") {
+    return { score: PRIORITY_WEIGHTS.move_fallback, ruleId: "move_fallback" };
+  }
+  if (candidate?.action?.kind === "wait") {
+    return { score: PRIORITY_WEIGHTS.wait, ruleId: "wait" };
+  }
+  return { score: PRIORITY_WEIGHTS.no_match, ruleId: "no_match" };
+}
+
+function validateEnvelope(envelope) {
+  if (!envelope || envelope.contract !== RUNTIME_DECISION_CONTRACT) {
+    return "z3_missing_runtime_decision_envelope";
+  }
+  if (!Array.isArray(envelope.candidateActions)) {
+    return "z3_missing_candidate_actions";
+  }
+  if (envelope.candidateActions.some((candidate) => (
+    !candidate
+    || typeof candidate.id !== "string"
+    || candidate.id.length === 0
+    || !candidate.action
+    || typeof candidate.action !== "object"
+  ))) {
+    return "z3_invalid_candidate_action";
+  }
+  return null;
+}
+
+/**
+ * @param {{ init?: typeof init }} [options]
+ * @returns {{
+ *   solve: (request: object) => Promise<object>,
+ *   kind: "z3-real",
+ *   capabilities: { domains: string[], deterministic: true }
+ * }}
+ */
+export function createRealZ3SolverAdapter(options = {}) {
+  const getZ3 = typeof options.init === "function"
+    ? (() => {
+        let injectedZ3Promise;
+        return () => {
+          injectedZ3Promise ||= options.init();
+          return injectedZ3Promise;
+        };
+      })()
+    : getSharedZ3;
+
+  async function solve(request) {
+    try {
+      const envelope = request?.problem?.data;
+      const validationError = validateEnvelope(envelope);
+      if (validationError) {
+        return { status: "error", reason: validationError };
+      }
+
+      const candidates = envelope.candidateActions;
+      if (candidates.length === 0) {
+        return { status: "unsat", reason: "z3_no_candidates" };
+      }
+
+      const scored = candidates.map((candidate, index) => ({
+        candidate,
+        index,
+        ...scoreCandidate(candidate, envelope),
+      }));
+
+      const { Context } = await getZ3();
+      const context = new Context("actor_action_selection");
+      const { Bool, If, Optimize, Sum, isTrue } = context;
+      const selected = candidates.map((_, index) => (
+        Bool.const(`selected_${String(index).padStart(6, "0")}`)
+      ));
+      const optimizer = new Optimize();
+
+      optimizer.add(Sum(...selected.map((variable) => If(variable, 1, 0))).eq(1));
+
+      // Scaling makes the declared priority dominant. The decreasing bonus
+      // makes candidate input order a unique, deterministic tie-break before
+      // Z3 solves, rather than relying on its choice among equal optima.
+      const tieScale = candidates.length + 1;
+      const objective = Sum(...selected.map((variable, index) => {
+        const coefficient = (scored[index].score * tieScale) + (candidates.length - index);
+        return If(variable, coefficient, 0);
+      }));
+      optimizer.maximize(objective);
+
+      const status = await optimizer.check();
+      if (status === "unsat") {
+        return { status: "unsat", reason: "z3_no_satisfying_assignment" };
+      }
+      if (status !== "sat") {
+        // "unknown" is a real Z3 outcome (e.g. resource limits) but is not one of
+        // CONSTRAINT_RESULT_STATUS's four values — normalize to "error" so this
+        // adapter never returns a status the shared conformance suite would reject.
+        return {
+          status: "error",
+          reason: optimizer.reasonUnknown() || "z3_optimize_unknown",
+        };
+      }
+
+      const model = optimizer.model();
+      const selectedIndex = selected.findIndex((variable) => isTrue(model.eval(variable, true)));
+      if (selectedIndex < 0 || selectedIndex >= candidates.length) {
+        return { status: "error", reason: "z3_selected_action_missing" };
+      }
+
+      const winner = scored[selectedIndex];
+      const rankedCandidates = scored
+        .map(({ candidate, index, score, ruleId }) => ({
+          candidateActionId: candidate.id,
+          score,
+          ruleId,
+          index,
+        }))
+        .sort((a, b) => (b.score - a.score) || (a.index - b.index))
+        .map(({ index: _index, ...candidate }) => candidate);
+
+      return {
+        status: "fulfilled",
+        model: {
+          contract: RUNTIME_DECISION_CONTRACT,
+          decisionKind: envelope.decisionKind || "next_move",
+          selectedActionId: winner.candidate.id,
+          confidence: winner.score / PRIORITY_WEIGHTS.attack,
+          rationaleTags: [winner.ruleId],
+          rankedCandidates,
+        },
+      };
+    } catch (error) {
+      return {
+        status: "error",
+        reason: "z3_optimize_error",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  return {
+    solve,
+    kind: "z3-real",
+    capabilities: {
+      domains: ["actor_action_selection"],
+      deterministic: true,
+    },
+  };
+}

--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -3023,6 +3023,10 @@ function isLlmBudgetLoopEnabled() {
   return value === "1" || value === "true";
 }
 
+function isRealZ3SolverEnabled() {
+  return process.env.AK_SOLVER_ENGINE === "z3-real";
+}
+
 function isLocalBaseUrl(raw) {
   if (!isNonEmptyString(raw)) {
     return false;
@@ -4436,6 +4440,10 @@ const commandKernel = createCommandKernel({
   createBlockchainAdapter,
   createLlmAdapter,
   createSolverAdapter: async (options) => {
+    if (isRealZ3SolverEnabled()) {
+      const { createRealZ3SolverAdapter } = await import("../adapters/z3/index.js");
+      return createRealZ3SolverAdapter(options);
+    }
     const { createSolverAdapter } = await import("../adapters/solver-z3/index.js");
     return createSolverAdapter(options);
   },

--- a/packages/adapters-web/package.json
+++ b/packages/adapters-web/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@agent-kernel/adapters-web",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "z3-solver": "^5.1.0"
+  }
 }

--- a/packages/adapters-web/src/adapters/cli-worker/shared.js
+++ b/packages/adapters-web/src/adapters/cli-worker/shared.js
@@ -9,6 +9,10 @@ import { createIpfsAdapter } from "../ipfs/index.js";
 import { createLlmAdapter } from "../llm/index.js";
 import { createWebSolverAdapter } from "../solver/index.js";
 
+function isRealZ3SolverEnabled(env) {
+  return env?.AK_SOLVER_ENGINE === "z3-real";
+}
+
 function cloneJson(value) {
   if (value === undefined) return undefined;
   return JSON.parse(JSON.stringify(value));
@@ -202,6 +206,10 @@ function createBrowserKernelHost({
         fetchFn: options.fetchFn || fetchFn,
       }),
       createSolverAdapter: async ({ fixturePath } = {}) => {
+        if (isRealZ3SolverEnabled(env)) {
+          const { createRealZ3SolverAdapter } = await import("../z3/index.js");
+          return createRealZ3SolverAdapter();
+        }
         const fixture = fixturePath ? await readJson(fixturePath) : undefined;
         return createWebSolverAdapter({ fixture });
       },

--- a/packages/adapters-web/src/adapters/z3/index.js
+++ b/packages/adapters-web/src/adapters/z3/index.js
@@ -1,0 +1,222 @@
+/**
+ * Real Z3 adapter for the actor_action_selection constraint domain.
+ *
+ * Candidate actions are produced and legality-filtered by the Actor persona.
+ * This adapter only ranks those candidates with a deterministic Optimize
+ * objective; it does not duplicate range, resource, or collision policy.
+ *
+ * Deliberate duplicate of packages/adapters-cli/src/adapters/z3/index.js, not
+ * a shared import: this repo has no internal package.json dependency edges
+ * (every cross-package reference is relative-path only, by convention), and
+ * each adapter package already owns its own solver implementation
+ * (adapters-test's stand-in, adapters-cli's fixture stub, adapters-web's own
+ * createWebSolverAdapter). An adapters-web -> adapters-cli relative import
+ * would be a lateral adapter-to-adapter dependency the architecture does not
+ * sanction. Keep the two files in sync by hand until/unless a shared adapter
+ * package is introduced.
+ */
+
+import { init } from "z3-solver";
+
+const RUNTIME_DECISION_CONTRACT = "runtime-decision-v1";
+
+const PRIORITY_WEIGHTS = Object.freeze({
+  attack: 100,
+  move_toward_hostile: 80,
+  move_toward_exit: 50,
+  move_fallback: 20,
+  wait: 10,
+  no_match: 0,
+});
+
+let sharedZ3Promise;
+
+function getSharedZ3() {
+  sharedZ3Promise ||= init();
+  return sharedZ3Promise;
+}
+
+function chebyshevDistance(a, b) {
+  if (!a || !b) return null;
+  if (![a.x, a.y, b.x, b.y].every(Number.isFinite)) return null;
+  return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+}
+
+function movesCloserTo(candidate, origin, targets) {
+  if (candidate?.action?.kind !== "move") return false;
+  const destination = candidate.action.params?.to;
+  if (!destination || !origin) return false;
+  return targets.some((target) => {
+    const before = chebyshevDistance(origin, target);
+    const after = chebyshevDistance(destination, target);
+    return before !== null && after !== null && after < before;
+  });
+}
+
+function scoreCandidate(candidate, envelope) {
+  if (candidate?.action?.kind === "attack") {
+    return { score: PRIORITY_WEIGHTS.attack, ruleId: "attack" };
+  }
+
+  const actorPosition = envelope.actor?.position;
+  const visiblePositions = Array.isArray(envelope.visibleActors)
+    ? envelope.visibleActors.map((actor) => actor?.position).filter(Boolean)
+    : [];
+  if (movesCloserTo(candidate, actorPosition, visiblePositions)) {
+    return {
+      score: PRIORITY_WEIGHTS.move_toward_hostile,
+      ruleId: "move_toward_hostile",
+    };
+  }
+
+  const exit = envelope.objectives?.exit;
+  if (exit && movesCloserTo(candidate, actorPosition, [exit])) {
+    return { score: PRIORITY_WEIGHTS.move_toward_exit, ruleId: "move_toward_exit" };
+  }
+
+  if (candidate?.action?.kind === "move") {
+    return { score: PRIORITY_WEIGHTS.move_fallback, ruleId: "move_fallback" };
+  }
+  if (candidate?.action?.kind === "wait") {
+    return { score: PRIORITY_WEIGHTS.wait, ruleId: "wait" };
+  }
+  return { score: PRIORITY_WEIGHTS.no_match, ruleId: "no_match" };
+}
+
+function validateEnvelope(envelope) {
+  if (!envelope || envelope.contract !== RUNTIME_DECISION_CONTRACT) {
+    return "z3_missing_runtime_decision_envelope";
+  }
+  if (!Array.isArray(envelope.candidateActions)) {
+    return "z3_missing_candidate_actions";
+  }
+  if (envelope.candidateActions.some((candidate) => (
+    !candidate
+    || typeof candidate.id !== "string"
+    || candidate.id.length === 0
+    || !candidate.action
+    || typeof candidate.action !== "object"
+  ))) {
+    return "z3_invalid_candidate_action";
+  }
+  return null;
+}
+
+/**
+ * @param {{ init?: typeof init }} [options]
+ * @returns {{
+ *   solve: (request: object) => Promise<object>,
+ *   kind: "z3-real",
+ *   capabilities: { domains: string[], deterministic: true }
+ * }}
+ */
+export function createRealZ3SolverAdapter(options = {}) {
+  const getZ3 = typeof options.init === "function"
+    ? (() => {
+        let injectedZ3Promise;
+        return () => {
+          injectedZ3Promise ||= options.init();
+          return injectedZ3Promise;
+        };
+      })()
+    : getSharedZ3;
+
+  async function solve(request) {
+    try {
+      const envelope = request?.problem?.data;
+      const validationError = validateEnvelope(envelope);
+      if (validationError) {
+        return { status: "error", reason: validationError };
+      }
+
+      const candidates = envelope.candidateActions;
+      if (candidates.length === 0) {
+        return { status: "unsat", reason: "z3_no_candidates" };
+      }
+
+      const scored = candidates.map((candidate, index) => ({
+        candidate,
+        index,
+        ...scoreCandidate(candidate, envelope),
+      }));
+
+      const { Context } = await getZ3();
+      const context = new Context("actor_action_selection");
+      const { Bool, If, Optimize, Sum, isTrue } = context;
+      const selected = candidates.map((_, index) => (
+        Bool.const(`selected_${String(index).padStart(6, "0")}`)
+      ));
+      const optimizer = new Optimize();
+
+      optimizer.add(Sum(...selected.map((variable) => If(variable, 1, 0))).eq(1));
+
+      // Scaling makes the declared priority dominant. The decreasing bonus
+      // makes candidate input order a unique, deterministic tie-break before
+      // Z3 solves, rather than relying on its choice among equal optima.
+      const tieScale = candidates.length + 1;
+      const objective = Sum(...selected.map((variable, index) => {
+        const coefficient = (scored[index].score * tieScale) + (candidates.length - index);
+        return If(variable, coefficient, 0);
+      }));
+      optimizer.maximize(objective);
+
+      const status = await optimizer.check();
+      if (status === "unsat") {
+        return { status: "unsat", reason: "z3_no_satisfying_assignment" };
+      }
+      if (status !== "sat") {
+        // "unknown" is a real Z3 outcome (e.g. resource limits) but is not one of
+        // CONSTRAINT_RESULT_STATUS's four values — normalize to "error" so this
+        // adapter never returns a status the shared conformance suite would reject.
+        return {
+          status: "error",
+          reason: optimizer.reasonUnknown() || "z3_optimize_unknown",
+        };
+      }
+
+      const model = optimizer.model();
+      const selectedIndex = selected.findIndex((variable) => isTrue(model.eval(variable, true)));
+      if (selectedIndex < 0 || selectedIndex >= candidates.length) {
+        return { status: "error", reason: "z3_selected_action_missing" };
+      }
+
+      const winner = scored[selectedIndex];
+      const rankedCandidates = scored
+        .map(({ candidate, index, score, ruleId }) => ({
+          candidateActionId: candidate.id,
+          score,
+          ruleId,
+          index,
+        }))
+        .sort((a, b) => (b.score - a.score) || (a.index - b.index))
+        .map(({ index: _index, ...candidate }) => candidate);
+
+      return {
+        status: "fulfilled",
+        model: {
+          contract: RUNTIME_DECISION_CONTRACT,
+          decisionKind: envelope.decisionKind || "next_move",
+          selectedActionId: winner.candidate.id,
+          confidence: winner.score / PRIORITY_WEIGHTS.attack,
+          rationaleTags: [winner.ruleId],
+          rankedCandidates,
+        },
+      };
+    } catch (error) {
+      return {
+        status: "error",
+        reason: "z3_optimize_error",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  return {
+    solve,
+    kind: "z3-real",
+    capabilities: {
+      domains: ["actor_action_selection"],
+      deterministic: true,
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,10 +48,17 @@ importers:
       ws:
         specifier: ^8.21.0
         version: 8.21.0
+      z3-solver:
+        specifier: ^5.1.0
+        version: 5.1.0
 
   packages/adapters-test: {}
 
-  packages/adapters-web: {}
+  packages/adapters-web:
+    dependencies:
+      z3-solver:
+        specifier: ^5.1.0
+        version: 5.1.0
 
   packages/core-ts: {}
 
@@ -884,6 +891,9 @@ packages:
 
   ast-v8-to-istanbul@0.3.12:
     resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
+  async-mutex@0.3.2:
+    resolution: {integrity: sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -2854,6 +2864,10 @@ packages:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
 
+  z3-solver@5.1.0:
+    resolution: {integrity: sha512-U5tXTwtJKnBfqmAx152fkHXN2kh0oT5X3zCUmMAPBu/7OPUEAYADnxJXQKs3nXxU/7GcEUbUpXeM3g1i5U5sqA==}
+    engines: {node: '>=16'}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -3635,6 +3649,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  async-mutex@0.3.2:
+    dependencies:
+      tslib: 2.8.1
 
   atomic-sleep@1.0.0: {}
 
@@ -5709,6 +5727,10 @@ snapshots:
       fd-slicer: 1.1.0
 
   yn@3.1.1: {}
+
+  z3-solver@5.1.0:
+    dependencies:
+      async-mutex: 0.3.2
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:

--- a/tests/runtime/z3-real-adapter-conformance.test.js
+++ b/tests/runtime/z3-real-adapter-conformance.test.js
@@ -1,0 +1,135 @@
+/**
+ * Z.5 — the real Z3 adapter for actor_action_selection.
+ *
+ * Written before the adapter exists, per the repo's own working rule (tests before
+ * production code). This is the RED baseline for Z.5: every test here fails today
+ * because `packages/adapters-cli/src/adapters/z3/index.js` does not exist. Codex's
+ * job tomorrow is to make it exist and turn this green — nothing more, nothing less.
+ *
+ * Scope is deliberately narrow, matching the Z.1 verdict: actor_action_selection
+ * only, the single highest-value adopted site. Allocator budget-fit and
+ * Configurator satisfiability are NOT this adapter's job.
+ *
+ * What this file does NOT decide (flagged, not assumed — see `~/vault/plans/active/Plan.md`
+ * "## Z.5"): whether the adapter must independently re-verify candidate legality
+ * (range/mana/reserved-tile) as Z3 constraints, or whether `candidateActions` is
+ * already legal-only and Z3's job is purely optimization over priority. The tests
+ * below only exercise the uncontroversial layer: conformance, and a ranking
+ * preference already true of the JS stand-in it replaces.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+
+async function loadConformance() {
+  return import("../../packages/runtime/src/ports/solver-conformance.js");
+}
+
+async function loadAdapter() {
+  return import("../../packages/adapters-cli/src/adapters/z3/index.js");
+}
+
+// ---------------------------------------------------------------------------
+// Conformance — the Z.3 gate every solver adapter must clear before a run
+// touches it. This is the same suite the JS stand-in already passes; a real
+// Z3 binding starts from zero credit, not from the stand-in's track record.
+// ---------------------------------------------------------------------------
+
+test("the real Z3 adapter passes the shared conformance suite", async () => {
+  const { checkSolverConformance } = await loadConformance();
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const result = await checkSolverConformance(createRealZ3SolverAdapter());
+  assert.equal(result.ok, true, result.failures.join(" | "));
+});
+
+test("declares actor_action_selection only, same domain as the stand-in it replaces", async () => {
+  const { describeSolverCapabilities } = await loadConformance();
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const caps = describeSolverCapabilities(createRealZ3SolverAdapter());
+  assert.deepEqual(
+    caps.domains,
+    ["actor_action_selection"],
+    "Allocator budget-fit and Configurator satisfiability are separate milestones — an adapter "
+      + "that silently answered them would be a confidently wrong decision, not a convenience",
+  );
+  assert.equal(caps.deterministic, true);
+});
+
+// ---------------------------------------------------------------------------
+// Behavior — the minimum a Z3-backed ranking must reproduce from the JS
+// stand-in it replaces, using the REAL runtime-decision-v1 envelope shape
+// the Actor actually sends (`personas/actor/controller.js:566-587`), not the
+// abstract variables/constraints shape (which this domain does not use today).
+// ---------------------------------------------------------------------------
+
+test("picks attack over move-away when a legal attack candidate exists", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const adapter = createRealZ3SolverAdapter();
+  const envelope = {
+    contract: "runtime-decision-v1",
+    decisionKind: "next_move",
+    tick: 3,
+    actor: { id: "actor_1", position: { x: 5, y: 5 } },
+    visibleActors: [{ id: "hostile_1", position: { x: 6, y: 5 } }],
+    candidateActions: [
+      {
+        id: "attack_hostile_1",
+        action: { kind: "attack", actorId: "actor_1", tick: 3, params: { targetId: "hostile_1" } },
+      },
+      {
+        id: "move_away",
+        action: { kind: "move", actorId: "actor_1", tick: 3, params: { to: { x: 4, y: 5 } } },
+      },
+      { id: "wait_here", action: { kind: "wait", actorId: "actor_1", tick: 3, params: {} } },
+    ],
+    objectives: { primary: "resolve_visible_contacts" },
+  };
+  const result = await adapter.solve({ problem: { data: envelope } });
+  assert.equal(result.status, "fulfilled", JSON.stringify(result));
+  assert.equal(result.model?.selectedActionId, "attack_hostile_1");
+});
+
+test("selected action always names a real candidate id — resolveActionFromSolverResult's own requirement", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const { resolveActionFromSolverResult } = await import(
+    "../../packages/runtime/src/personas/_shared/runtime-decision.mts"
+  );
+  const adapter = createRealZ3SolverAdapter();
+  const envelope = {
+    contract: "runtime-decision-v1",
+    decisionKind: "next_move",
+    tick: 1,
+    actor: { id: "actor_1", position: { x: 0, y: 0 } },
+    visibleActors: [],
+    candidateActions: [
+      { id: "wait_here", action: { kind: "wait", actorId: "actor_1", tick: 1, params: {} } },
+    ],
+  };
+  const solverRequest = { problem: { data: envelope } };
+  const solverResult = await adapter.solve(solverRequest);
+  const resolved = resolveActionFromSolverResult({ solverRequest, solverResult });
+  assert.equal(resolved.ok, true, JSON.stringify(resolved.errors));
+  assert.equal(resolved.action.kind, "wait");
+});
+
+test("an envelope missing the runtime-decision-v1 contract defers cleanly instead of guessing", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const adapter = createRealZ3SolverAdapter();
+  const result = await adapter.solve({ problem: { data: { contract: "something-else" } } });
+  assert.notEqual(result.status, "fulfilled");
+});
+
+// ## TODO: Test Permutations
+//
+// - a mana-insufficient cast_affinity candidate is never selected even when it would
+//   otherwise score highest (needs the legality-scope decision resolved first)
+// - two candidates that score identically: fixed variable order picks the SAME one on
+//   every run — this is the determinism check applied to an actual tie, not just the
+//   whole-envelope repeat the conformance suite already covers
+// - empty `candidateActions` -> "unsat" with a `reason`, never a thrown error
+// - z3-solver internal timeout/OOM surfaces as a shaped "error" result, never hangs
+//   the tick and never rejects past the adapter boundary
+// - `visibleActors` containing a hostile OUT of any candidate's range does not by
+//   itself force an attack candidate to outrank a move-toward candidate
+// - replay determinism end-to-end: same envelope solved twice in the same process
+//   AND across two fresh process invocations produces byte-identical `model`


### PR DESCRIPTION
## Summary
- First real Z3 (`z3-solver`, WASM `Optimize`) adapter, scoped to the single highest-value adopted solver domain: actor action selection. Ranks pre-filtered candidate actions by a weighted priority objective; does not re-verify legality.
- Off by default behind `AK_SOLVER_ENGINE=z3-real` (mirrors the existing `AK_LLM_LIVE` pattern) in both the CLI/MCP host (`ak-impl.mjs`) and the browser worker host (`adapters-web`). Existing fixture-driven tests see zero behavior change.
- Deterministic by construction: fixed variable ordering plus a tie-break baked into the objective itself (`score × scale + candidate order`), so identical input always produces an identical decision — required for frame-by-frame replay.
- `adapters-web` gets its own copy of the adapter rather than reaching into `adapters-cli`'s source — this repo has no internal package.json dependency edges, and every adapter package owns its own solver implementation by convention.

## Test plan
- [x] `tests/runtime/z3-real-adapter-conformance.test.js` — 5/5 (the milestone's own red-baseline-then-green test)
- [x] `tests/runtime/solver-constraint-framework.test.js` — 11/11 (shared conformance suite, unaffected)
- [x] `tests/adapters-cli/ak-scenario.test.js`, `tests/adapters-cli/solver.test.js` — unchanged, prove the flag defaults off
- [x] Full suite: 398 files / 3014 tests passed, 0 failures
- [x] `pnpm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)