### PR TITLE
feat(runtime): E3 — world-state checkpoints, reconciled onto current main

### DIFF
--- a/packages/adapters-cli/README.md
+++ b/packages/adapters-cli/README.md
@@ -22,7 +22,7 @@ Start with the workflow map below, then jump to the command family you need. The
 | --- | --- | --- |
 | Author a room, delver, warden, hazard, or resource | `create`, `configure`, `room-plan`, `delver-plan`, `warden-plan` | `spec.json`, `bundle.json`, `sim-config.json`, `initial-state.json` |
 | Build from an existing BuildSpec | `build` | Canonical persisted handoff artifacts |
-| Run or replay deterministic simulation artifacts | `run`, `replay` | TickFrames, effects log, run summary |
+| Run or replay deterministic simulation artifacts | `run`, `replay` | TickFrames, effects log, run summary, final world state |
 | Inspect prior outputs | `show`, `diff`, `runs list`, `inspect`, `narrate` | Structured summaries and narrative artifacts |
 | Use LLM planning with captured inputs | `llm-plan`, `scenario`, `llm` | Captured LLM artifacts plus build/run outputs |
 | Exercise external adapters directly | `ipfs`, `blockchain`, `llm`, publish/load variants | Adapter response artifacts |
@@ -633,6 +633,7 @@ node packages/adapters-cli/src/cli/ak.mjs warden-plan --warden "count=1;affinity
 node packages/adapters-cli/src/cli/ak.mjs schemas --out-dir artifacts/shared/schemas
 node packages/adapters-cli/src/cli/ak.mjs solve --scenario "two actors conflict"
 node packages/adapters-cli/src/cli/ak.mjs run --sim-config path/to/sim-config.json --initial-state path/to/initial-state.json --ticks 3
+node packages/adapters-cli/src/cli/ak.mjs run --sim-config path/to/sim-config.json --initial-state path/to/initial-state.json --ticks 100 --world-state-checkpoints 0,10,25,50,100
 node packages/adapters-cli/src/cli/ak.mjs run --from-run run_fixture --ticks 5 --progress 2>&1 >/dev/null
 node packages/adapters-cli/src/cli/ak.mjs run --sim-config path/to/sim-config.json --initial-state path/to/initial-state.json --actions path/to/action-sequence.json --ticks 0
 node packages/adapters-cli/src/cli/ak.mjs configurator --level-gen path/to/level-gen.json --actors path/to/actors.json --out-dir path/to/out
@@ -692,6 +693,14 @@ node packages/adapters-cli/src/cli/ak.mjs warden-plan --warden "count=1;affinity
 node packages/adapters-cli/src/cli/ak.mjs solve --scenario "two actors conflict" --solver-fixture tests/fixtures/artifacts/solver-result-v1-basic.json
 node packages/adapters-cli/src/cli/ak.mjs run --sim-config tests/fixtures/artifacts/sim-config-artifact-v1-configurator-hazard.json --initial-state tests/fixtures/artifacts/initial-state-artifact-v1-configurator-affinity.json --ticks 0
 ```
+
+`run` always writes the final `world-state.json`. Supplying
+`--world-state-checkpoints` additionally writes the requested post-step states as existing
+`agent-kernel/WorldStateArtifact` v1 files under
+`<out-dir>/world-state-checkpoints/tick-NNNNNN.json`. Tick `0` is captured after runtime
+initialization; every other requested tick is captured immediately after that tick's
+`runtime.step()`. The list must be unique, strictly ascending, and within `--ticks`.
+Ordinary runs do not create the checkpoint directory.
 
 ## Agent workflow recipes
 

--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -19,6 +19,7 @@ import {
   buildBuildManifestEntries,
   collectBuildOutputArtifactRecords,
   createCommandKernel,
+  normalizeWorldStateCheckpoints,
 } from "../../../runtime/src/commands/kernel.js";
 import { orchestrateBuild } from "../../../runtime/src/build/orchestrate-build.js";
 import { attachMixedRoomAssembliesToBuildResult } from "../../../runtime/src/build/authoring-build.js";
@@ -155,7 +156,7 @@ function usage() {
   node ${rel} schemas [--out-dir dir]
   node ${rel} solve --scenario "..." [--out-dir dir] [--run-id id] [--plan path] [--intent path] [--options path]
   node ${rel} workflow <run|status|replay|cancel|validate> [--objective text | --input path] [--out-dir dir] [--policy path] [--runtime-profile path] [--dry-run]
-  node ${rel} run (--sim-config path --initial-state path | --from-run runId) [--execution-policy path] [--ticks N] [--seed N] [--out-dir dir] [--run-id id] [--actor spec] [--vital spec] [--vital-default spec] [--tile-wall xy] [--tile-barrier xy] [--tile-floor xy] [--actions path] [--affinity-presets path] [--affinity-loadouts path] [--affinity-summary path] [--progress] [--dry-run]
+  node ${rel} run (--sim-config path --initial-state path | --from-run runId) [--execution-policy path] [--ticks N] [--world-state-checkpoints ticks] [--seed N] [--out-dir dir] [--run-id id] [--actor spec] [--vital spec] [--vital-default spec] [--tile-wall xy] [--tile-barrier xy] [--tile-floor xy] [--actions path] [--affinity-presets path] [--affinity-loadouts path] [--affinity-summary path] [--progress] [--dry-run]
   node ${rel} configurator --level-gen path --actors path [--plan path] [--budget-receipt path] [--budget path --price-list path --receipt-out path] [--affinity-presets path] [--affinity-loadouts path] [--out-dir dir] [--run-id id]
   node ${rel} budget --budget path [--price-list path] [--receipt path] [--out-dir dir] [--out path] [--receipt-out path]
   node ${rel} replay --sim-config path --initial-state path --tick-frames path [--execution-policy path] [--ticks N] [--seed N] [--out-dir dir]
@@ -185,6 +186,7 @@ Options:
   --out-dir       Output directory (default: ./artifacts/runs/<runId>/<command>)
   --out           Output file path (command-specific default when omitted)
   --ticks         Number of ticks for run/replay (default: ${DEFAULT_TICKS})
+  --world-state-checkpoints  Comma-separated ticks to persist as WorldStateArtifact v1 files (run only)
   --seed          Seed for init (default: 0)
   --solver-fixture Fixture path for solve command (no network)
   --actor         Actor spec: id,x,y,kind (kind: motivated/ambulatory/stationary)
@@ -3926,6 +3928,7 @@ async function validateRunDryRun(args) {
   if (!Number.isFinite(ticks) || ticks < 0) {
     throw new Error("run requires a valid --ticks value.");
   }
+  const worldStateCheckpoints = normalizeWorldStateCheckpoints(args["world-state-checkpoints"], { ticks });
   if (!Number.isFinite(seed)) {
     throw new Error("run requires a valid --seed value.");
   }
@@ -3994,6 +3997,7 @@ async function validateRunDryRun(args) {
     roomIds: deriveRoomIds(resolvedSimConfig),
     extra: {
       ticks,
+      worldStateCheckpoints,
     },
   });
 }

--- a/packages/runtime/src/commands/kernel.js
+++ b/packages/runtime/src/commands/kernel.js
@@ -119,6 +119,53 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+/**
+ * Normalize the opt-in world-state checkpoint list used by adapter callers.
+ *
+ * The runtime owns validation because direct command-kernel callers and the CLI
+ * must observe the same contract. The returned array is safe to use as the
+ * exact set of post-step capture boundaries.
+ */
+export function normalizeWorldStateCheckpoints(value, { ticks } = {}) {
+  if (value === undefined || value === null || value === false) return [];
+  const entries = Array.isArray(value)
+    ? value
+    : typeof value === "string" && value.trim().length > 0
+      ? value.split(",").map((entry) => entry.trim())
+      : null;
+  if (!entries || entries.length === 0) {
+    throw new Error("--world-state-checkpoints requires a non-empty comma-separated list.");
+  }
+  if (!Number.isSafeInteger(ticks) || ticks < 0) {
+    throw new Error("--world-state-checkpoints requires --ticks to be a non-negative integer.");
+  }
+
+  const checkpoints = entries.map((entry) => {
+    if (typeof entry === "number" && Number.isSafeInteger(entry) && entry >= 0) return entry;
+    if (typeof entry === "string" && /^(?:0|[1-9][0-9]*)$/.test(entry)) return Number(entry);
+    throw new Error("--world-state-checkpoints must contain only non-negative integers.");
+  });
+  const seen = new Set();
+  for (let index = 0; index < checkpoints.length; index += 1) {
+    const checkpoint = checkpoints[index];
+    if (seen.has(checkpoint)) {
+      throw new Error(`--world-state-checkpoints must not contain duplicate tick ${checkpoint}.`);
+    }
+    if (index > 0 && checkpoint < checkpoints[index - 1]) {
+      throw new Error("--world-state-checkpoints must be strictly ascending.");
+    }
+    if (checkpoint > ticks) {
+      throw new Error(`--world-state-checkpoints tick ${checkpoint} cannot exceed --ticks ${ticks}.`);
+    }
+    seen.add(checkpoint);
+  }
+  return checkpoints;
+}
+
+function worldStateCheckpointFilename(tick) {
+  return `tick-${String(tick).padStart(6, "0")}.json`;
+}
+
 // CR.1 — pool weights are the Allocator's. This was a hand-maintained copy of its
 // DEFAULT_BUDGET_POOLS, byte-identical but free to diverge: a real duplicate, not an
 // alias, and one CR.1's own inventory missed (found by running the G2 guard as a
@@ -1048,6 +1095,8 @@ export function createCommandKernel(host = {}) {
     if (!Number.isFinite(seed)) {
       throw new Error("run requires a valid --seed value.");
     }
+    const worldStateCheckpoints = normalizeWorldStateCheckpoints(args["world-state-checkpoints"], { ticks });
+    const pendingWorldStateCheckpoints = new Set(worldStateCheckpoints);
     const simConfig = await readJson(simConfigPath);
     assertSchema(simConfig, SCHEMAS.simConfig);
     const initialState = await readJson(initialStatePath);
@@ -1155,9 +1204,35 @@ export function createCommandKernel(host = {}) {
     // affinity-less to the persona that decides what to do with one.
     const affinityEffects = buildAffinityEffectsFromInitialState(initialState);
     await runtime.init({ seed, simConfig, initialState, clock, affinityEffects });
+
+    const simConfigRef = toRef(simConfig);
+    async function captureWorldStateCheckpoint(expectedTick) {
+      if (!pendingWorldStateCheckpoints.has(expectedTick)) return;
+      const checkpoint = runtime.captureWorldState({
+        meta: createMeta({
+          producedBy: "annotator",
+          runId,
+          note: `world-state checkpoint at tick ${expectedTick}`,
+        }),
+        simConfigRef,
+      });
+      if (checkpoint.tick !== expectedTick) {
+        throw new Error(
+          `World-state checkpoint boundary mismatch: requested tick ${expectedTick}, captured ${checkpoint.tick}.`,
+        );
+      }
+      await writeJson(
+        join(outDir, "world-state-checkpoints", worldStateCheckpointFilename(expectedTick)),
+        checkpoint,
+      );
+      pendingWorldStateCheckpoints.delete(expectedTick);
+    }
+
+    await captureWorldStateCheckpoint(0);
     for (let i = 0; i < ticks; i += 1) {
       const effectCountBeforeStep = runtime.getEffectLog().length;
       await runtime.step();
+      await captureWorldStateCheckpoint(i + 1);
       if (onTickProgress) {
         const effectCountAfterStep = runtime.getEffectLog().length;
         await onTickProgress({
@@ -1209,7 +1284,7 @@ export function createCommandKernel(host = {}) {
     // still performs no IO of its own.
     const worldState = runtime.captureWorldState({
       meta: createMeta({ producedBy: "annotator", runId }),
-      simConfigRef: toRef(simConfig),
+      simConfigRef,
     });
     await writeJson(join(outDir, "world-state.json"), worldState);
 

--- a/tests/adapters-cli/world-state-checkpoints.test.js
+++ b/tests/adapters-cli/world-state-checkpoints.test.js
@@ -1,0 +1,190 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } = require("node:fs");
+const os = require("node:os");
+const { join, resolve } = require("node:path");
+
+const ROOT = resolve(__dirname, "../..");
+const CLI = resolve(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+const SIM_CONFIG = resolve(ROOT, "tests/fixtures/artifacts/sim-config-artifact-v1-configurator-hazard.json");
+const INITIAL_STATE = resolve(ROOT, "tests/fixtures/artifacts/initial-state-artifact-v1-configurator-affinity.json");
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], { cwd: ROOT, encoding: "utf8" });
+}
+
+function runArgs(outDir, checkpoints, simConfig = SIM_CONFIG) {
+  const args = [
+    "run",
+    "--sim-config", simConfig,
+    "--initial-state", INITIAL_STATE,
+    "--ticks", "3",
+    "--seed", "7",
+    "--run-id", "checkpoint_fixture",
+    "--out-dir", outDir,
+  ];
+  if (checkpoints !== undefined) args.push("--world-state-checkpoints", checkpoints);
+  return args;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function normalizedState(value) {
+  const { meta, ...state } = value;
+  return state;
+}
+
+test("ak run emits only requested WorldStateArtifact v1 checkpoints", () => {
+  const root = mkdtempSync(join(os.tmpdir(), "ak-world-state-checkpoints-"));
+  try {
+    const simConfig = readJson(SIM_CONFIG);
+    simConfig.layout.data.hazards[0].vitals.mana = { current: 0, max: 3, regen: 1 };
+    const simConfigPath = join(root, "sim-config.json");
+    writeFileSync(simConfigPath, `${JSON.stringify(simConfig, null, 2)}\n`);
+    const outDir = join(root, "with-checkpoints");
+    const result = runCli(runArgs(outDir, "0,1,3", simConfigPath));
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const checkpointDir = join(outDir, "world-state-checkpoints");
+    assert.deepEqual(readdirSync(checkpointDir).sort(), [
+      "tick-000000.json",
+      "tick-000001.json",
+      "tick-000003.json",
+    ]);
+
+    const initial = readJson(join(checkpointDir, "tick-000000.json"));
+    const intermediate = readJson(join(checkpointDir, "tick-000001.json"));
+    const final = readJson(join(checkpointDir, "tick-000003.json"));
+    for (const [expectedTick, checkpoint] of [[0, initial], [1, intermediate], [3, final]]) {
+      assert.equal(checkpoint.schema, "agent-kernel/WorldStateArtifact");
+      assert.equal(checkpoint.schemaVersion, 1);
+      assert.equal(checkpoint.tick, expectedTick);
+      assert.equal(checkpoint.meta.producedBy, "annotator");
+      assert.equal(checkpoint.meta.runId, "checkpoint_fixture");
+      assert.ok(checkpoint.actors.every((actor) => Array.isArray(actor.affinities)));
+      assert.doesNotThrow(() => JSON.stringify(checkpoint));
+    }
+    assert.deepEqual(
+      [initial, intermediate, final].map((checkpoint) => checkpoint.hazards[0].mana.current),
+      [0, 1, 3],
+      "checkpoint files must expose live hazard state, not repeat authored input or final state",
+    );
+
+    assert.deepEqual(
+      normalizedState(final),
+      normalizedState(readJson(join(outDir, "world-state.json"))),
+      "the requested final checkpoint and normal final-state output must describe the same world",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("run dry-run validates and reports normalized checkpoint ticks", () => {
+  const root = mkdtempSync(join(os.tmpdir(), "ak-world-state-checkpoint-dry-run-"));
+  try {
+    const result = runCli([...runArgs(join(root, "out"), "0,1,3"), "--dry-run"]);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.valid, true);
+    assert.deepEqual(output.worldStateCheckpoints, [0, 1, 3]);
+    assert.equal(existsSync(join(root, "out")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the checkpoint source reports live affinity grant mana and expiry", async () => {
+  const [{ createRuntime }, { ActionKind, createCore }, { AffinityKind, AffinityExpression }, { Direction }] = await Promise.all([
+    import("../../packages/runtime/src/runner/runtime.js"),
+    import("../../packages/core-ts/src/index.ts"),
+    import("../../packages/core-ts/src/state/affinity.ts"),
+    import("../../packages/core-ts/src/rules/move.ts"),
+  ]);
+  const core = createCore();
+  const runtime = createRuntime({ core, adapters: {} });
+  const initialState = readJson(INITIAL_STATE);
+  initialState.actors[0].vitals.stamina = { current: 10, max: 10, regen: 0 };
+  await runtime.init({
+    seed: 0,
+    simConfig: readJson(SIM_CONFIG),
+    initialState,
+  });
+
+  assert.equal(core.placeAffinityResourceAt(1, 1, AffinityKind.Water, AffinityExpression.Emit, 2, 8, 0), 1);
+  const actorId = core.getMotivatedActorIdByIndex(0);
+  core.setActiveMotivatedActor(actorId);
+  core.setMoveAction(actorId, 2, 1, 1, 1, Direction.West, core.getCurrentTick() + 1);
+  core.applyAction(ActionKind.Move, 0);
+
+  const meta = { id: "state_live_affinity", runId: "checkpoint_fixture", createdAt: "2026-01-01T00:00:00.000Z", producedBy: "annotator" };
+  const granted = runtime.captureWorldState({ meta });
+  assert.deepEqual(granted.actors[0].affinities, [{
+    kind: AffinityKind.Water,
+    expression: AffinityExpression.Emit,
+    stacks: 2,
+    mana: 8,
+    manaMax: 8,
+    manaRegen: 0,
+  }]);
+
+  core.spendMotivatedActorAffinityMana(0, AffinityKind.Water, 8);
+  const expired = runtime.captureWorldState({ meta });
+  assert.deepEqual(expired.actors[0].affinities, [], "spent temporary grants must disappear from checkpoint state");
+});
+
+test("world-state checkpoints are opt-in and deterministic after metadata normalization", () => {
+  const root = mkdtempSync(join(os.tmpdir(), "ak-world-state-checkpoint-determinism-"));
+  try {
+    const ordinaryDir = join(root, "ordinary");
+    const ordinary = runCli(runArgs(ordinaryDir));
+    assert.equal(ordinary.status, 0, ordinary.stderr || ordinary.stdout);
+    assert.equal(existsSync(join(ordinaryDir, "world-state-checkpoints")), false);
+    assert.equal(existsSync(join(ordinaryDir, "world-state.json")), true);
+
+    const firstDir = join(root, "first");
+    const secondDir = join(root, "second");
+    for (const outDir of [firstDir, secondDir]) {
+      const result = runCli(runArgs(outDir, "0,1,3"));
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+    }
+    for (const name of ["tick-000000.json", "tick-000001.json", "tick-000003.json"]) {
+      assert.deepEqual(
+        normalizedState(readJson(join(firstDir, "world-state-checkpoints", name))),
+        normalizedState(readJson(join(secondDir, "world-state-checkpoints", name))),
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("world-state checkpoint validation fails closed", () => {
+  const root = mkdtempSync(join(os.tmpdir(), "ak-world-state-checkpoint-invalid-"));
+  try {
+    const invalid = [
+      ["", /non-empty comma-separated list/],
+      ["0,1,1", /must not contain duplicate tick 1/],
+      ["0,2,1", /must be strictly ascending/],
+      ["0,-1", /non-negative integers/],
+      ["0,1.5", /non-negative integers/],
+      ["0,4", /cannot exceed --ticks 3/],
+    ];
+    for (const [index, [value, pattern]] of invalid.entries()) {
+      const result = runCli(runArgs(join(root, `invalid-${index}`), value));
+      assert.notEqual(result.status, 0, `expected ${JSON.stringify(value)} to fail`);
+      assert.match(result.stderr, pattern);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ## TODO: Test Permutations
+// - a very large but safe tick horizon preserves deterministic filename padding
+// - direct command-kernel callers may pass a numeric checkpoint array
+// - checkpoint writes propagate an injected host persistence failure without emitting a partial success


### PR DESCRIPTION
E5d3's first target: reconcile the isolated E3 checkpoint diff onto a clean current source commit. Rebased from its old `0e5f524` base onto `9ef3a00` with no conflicts.

## Why this has to land

`execution-runner.js` already passes `--world-state-checkpoints` to `ak run`. Without this change the flag is **silently accepted and ignored** — the run reports `ok: true`, writes no checkpoints, and nothing surfaces the gap. Verified both ways: current main produces no `world-state-checkpoints/` directory; with this change a 10-tick run at `0,5,10` writes three snapshots showing the actor trajectory (4,3) → (2,2).

## What it does

`--world-state-checkpoints` takes an ascending, duplicate-free list of tick boundaries and writes one normalized `WorldStateArtifact` per boundary. Validation lives in the runtime, not the CLI, because direct command-kernel callers and the CLI must observe the same contract.

Fails closed: an empty list, a non-integer entry, a tick beyond `--ticks`, a duplicate, or a descending list is an error rather than a silently narrowed capture set.

## Gates

- E3's own tests: 5/5 on the rebased base
- Full suite: 413 files, 3140 passed, 7 failed, 191 skipped — the 7 are pre-existing and unrelated: 5 from `74a5837`'s intentional red Z.5 baseline, 2 from the untracked `config/llm-host.env` this worktree lacks. No new failures.

## Known gap, not addressed here

`WorldStateArtifactV1` carries `actors` and `hazards` but no `resources`, so a checkpoint cannot show whether a resource is still on the map. Resource outcomes remain observable only through actor vitals and affinities. This is E2's documented evidence gap — those metrics report `evidence_unavailable` rather than a false pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)