### PR TITLE
feat(runtime): WorldStateArtifact v2 resources, and the nine resource metrics

### DIFF
--- a/packages/adapters-cli/README.md
+++ b/packages/adapters-cli/README.md
@@ -695,12 +695,17 @@ node packages/adapters-cli/src/cli/ak.mjs run --sim-config tests/fixtures/artifa
 ```
 
 `run` always writes the final `world-state.json`. Supplying
-`--world-state-checkpoints` additionally writes the requested post-step states as existing
-`agent-kernel/WorldStateArtifact` v1 files under
+`--world-state-checkpoints` additionally writes the requested post-step states as
+`agent-kernel/WorldStateArtifact` v2 files under
 `<out-dir>/world-state-checkpoints/tick-NNNNNN.json`. Tick `0` is captured after runtime
 initialization; every other requested tick is captured immediately after that tick's
 `runtime.step()`. The list must be unique, strictly ascending, and within `--ticks`.
 Ordinary runs do not create the checkpoint directory.
+
+v2 adds `resources`: every resource still on the map, with its vital and affinity payloads.
+Collection is destructive, so a resource present in one snapshot and gone from the next was taken in
+between — which is what makes a checkpoint series, rather than a single end-of-run snapshot, the
+evidence that a pickup happened and what it did.
 
 ## Agent workflow recipes
 

--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -186,7 +186,7 @@ Options:
   --out-dir       Output directory (default: ./artifacts/runs/<runId>/<command>)
   --out           Output file path (command-specific default when omitted)
   --ticks         Number of ticks for run/replay (default: ${DEFAULT_TICKS})
-  --world-state-checkpoints  Comma-separated ticks to persist as WorldStateArtifact v1 files (run only)
+  --world-state-checkpoints  Comma-separated ticks to persist as WorldStateArtifact v2 files (run only)
   --seed          Seed for init (default: 0)
   --solver-fixture Fixture path for solve command (no network)
   --actor         Actor spec: id,x,y,kind (kind: motivated/ambulatory/stationary)

--- a/packages/runtime/src/contracts/artifacts.ts
+++ b/packages/runtime/src/contracts/artifacts.ts
@@ -2182,6 +2182,8 @@ export interface WorldStateHazardV1 {
   durability: { current: number; max: number; regen: number };
 }
 
+/** Superseded by V2, which adds `resources`. Retained: artifacts written before
+ * that change are still valid v1 documents and must stay readable. */
 export interface WorldStateArtifactV1 {
   schema: typeof WORLD_STATE_SCHEMA;
   schemaVersion: 1;
@@ -2194,7 +2196,59 @@ export interface WorldStateArtifactV1 {
   hazards: WorldStateHazardV1[];
 }
 
-export type WorldStateArtifact = WorldStateArtifactV1;
+/**
+ * A resource still lying on the map at the moment of the snapshot.
+ *
+ * Collection is destructive: an entered cell's resource is removed. So a resource
+ * present in one snapshot and absent from the next was taken in between, and that
+ * difference is the only public evidence that a pickup happened exactly once.
+ * Both payloads are optional and independent — a cell may carry a vital grant, an
+ * affinity grant, or both — and `null` means the resource does not carry that
+ * half, not that it was unreadable.
+ */
+export interface WorldStateResourceV2 {
+  position: { x: number; y: number };
+  vital: {
+    /** VitalKind code: 0 health, 1 mana, 2 stamina. */
+    kind: number;
+    delta: number;
+    /** ResourceMode code: 0 raises the current vital, 1/2 raise its max. */
+    mode: number;
+    /** Vital regen handed over on top of the delta, whatever the mode. */
+    regen: number;
+  } | null;
+  affinity: {
+    kind: number;
+    expression: number;
+    stacks: number;
+    mana: number;
+    /** > 0 makes the granted affinity permanent. */
+    manaRegen: number;
+  } | null;
+}
+
+/**
+ * V1 carried actors and hazards only. A snapshot could therefore not distinguish
+ * a resource still on the map from one already collected, which left every
+ * resource metric in the execution contract unevidenceable. `resources` is
+ * required rather than optional precisely so that distinction survives: an
+ * absent field means "this artifact predates resources", not "this world has
+ * none", and a consumer must be able to tell those apart.
+ */
+export interface WorldStateArtifactV2 {
+  schema: typeof WORLD_STATE_SCHEMA;
+  schemaVersion: 2;
+  meta: ArtifactMeta;
+  simConfigRef?: ArtifactRef;
+  /** The core tick this snapshot was taken at. */
+  tick: number;
+  dimensions: { width: number; height: number };
+  actors: WorldStateActorV1[];
+  hazards: WorldStateHazardV1[];
+  resources: WorldStateResourceV2[];
+}
+
+export type WorldStateArtifact = WorldStateArtifactV1 | WorldStateArtifactV2;
 
 /**
  * Z.1 — a constraint problem posed to a solver, and the normalized answer.

--- a/packages/runtime/src/contracts/schema-catalog.js
+++ b/packages/runtime/src/contracts/schema-catalog.js
@@ -391,10 +391,10 @@ const CATALOG = [
   },
   {
     schema: WORLD_STATE_SCHEMA,
-    schemaVersion: 1,
+    schemaVersion: 2,
     category: SCHEMA_CATEGORIES.OBSERVABILITY,
-    description: "End-of-run world state: actor positions, vitals and affinity grants, and hazard state.",
-    fields: ["meta", "simConfigRef", "tick", "dimensions", "actors", "hazards"],
+    description: "World state at a tick: actor positions, vitals and affinity grants, hazard state, and resources still on the map.",
+    fields: ["meta", "simConfigRef", "tick", "dimensions", "actors", "hazards", "resources"],
   },
   {
     schema: NARRATIVE_ARTIFACT_SCHEMA,

--- a/packages/runtime/src/personas/annotator/world-state.js
+++ b/packages/runtime/src/personas/annotator/world-state.js
@@ -108,6 +108,52 @@ function readHazards(core, width, height) {
 }
 
 /**
+ * Resources still on the map.
+ *
+ * Read per cell like hazards, because that is how core holds them. A cell's two
+ * payloads are independent: `hasResourceAt` is true when either is present, and a
+ * missing half reports as null rather than as a zeroed one — a resource claiming
+ * to grant 0 health is a different statement from one that grants no vital at all.
+ */
+function readResources(core, width, height) {
+  const resources = [];
+  if (typeof core.hasResourceAt !== "function") return resources;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (readNumber(core.hasResourceAt.bind(core), x, y) === 0) continue;
+      // Core reports -1 for "no vital payload". readNumber would turn a missing
+      // reader into 0, which is health — a resource that grants nothing would
+      // read as one that grants health.
+      const vitalKind = typeof core.getResourceVitalKindAt === "function"
+        ? core.getResourceVitalKindAt(x, y)
+        : -1;
+      const affinityKind = readNumber(core.getResourceAffinityKindAt?.bind(core), x, y);
+      resources.push({
+        position: { x, y },
+        vital: vitalKind >= 0
+          ? {
+            kind: vitalKind,
+            delta: readNumber(core.getResourceDeltaAt?.bind(core), x, y),
+            mode: readNumber(core.getResourceModeAt?.bind(core), x, y),
+            regen: readNumber(core.getResourceVitalRegenAt?.bind(core), x, y),
+          }
+          : null,
+        affinity: affinityKind > 0
+          ? {
+            kind: affinityKind,
+            expression: readNumber(core.getResourceAffinityExpressionAt?.bind(core), x, y),
+            stacks: readNumber(core.getResourceAffinityStacksAt?.bind(core), x, y),
+            mana: readNumber(core.getResourceManaAt?.bind(core), x, y),
+            manaRegen: readNumber(core.getResourceManaRegenAt?.bind(core), x, y),
+          }
+          : null,
+      });
+    }
+  }
+  return resources;
+}
+
+/**
  * Build the WorldStateArtifact from live core state.
  *
  * @param {object} args
@@ -117,7 +163,7 @@ function readHazards(core, width, height) {
  * @param {Map<string, number>|null} [args.actorIdMap] id -> 1-based core index,
  *        so the snapshot can report the author's original actor ids rather than
  *        core's numeric ones. Without it the numeric id is reported as a string.
- * @returns {object} WorldStateArtifactV1
+ * @returns {object} WorldStateArtifactV2
  */
 export function buildWorldState({ core, meta, simConfigRef = null, actorIdMap = null } = {}) {
   if (!core) throw new Error("buildWorldState requires a core.");
@@ -150,12 +196,13 @@ export function buildWorldState({ core, meta, simConfigRef = null, actorIdMap = 
 
   const artifact = {
     schema: WORLD_STATE_SCHEMA,
-    schemaVersion: 1,
+    schemaVersion: 2,
     meta,
     tick: readNumber(core.getCurrentTick?.bind(core)),
     dimensions: { width, height },
     actors,
     hazards: readHazards(core, width, height),
+    resources: readResources(core, width, height),
   };
   if (simConfigRef) artifact.simConfigRef = simConfigRef;
   return artifact;

--- a/tests/adapters-cli/world-state-checkpoints.test.js
+++ b/tests/adapters-cli/world-state-checkpoints.test.js
@@ -61,7 +61,7 @@ test("ak run emits only requested WorldStateArtifact v1 checkpoints", () => {
     const final = readJson(join(checkpointDir, "tick-000003.json"));
     for (const [expectedTick, checkpoint] of [[0, initial], [1, intermediate], [3, final]]) {
       assert.equal(checkpoint.schema, "agent-kernel/WorldStateArtifact");
-      assert.equal(checkpoint.schemaVersion, 1);
+      assert.equal(checkpoint.schemaVersion, 2);
       assert.equal(checkpoint.tick, expectedTick);
       assert.equal(checkpoint.meta.producedBy, "annotator");
       assert.equal(checkpoint.meta.runId, "checkpoint_fixture");

--- a/tests/runtime/world-state-artifact.test.js
+++ b/tests/runtime/world-state-artifact.test.js
@@ -107,7 +107,7 @@ test("captureWorldState records every actor's final position, matching core exac
   const snapshot = runtime.captureWorldState({ meta: META });
 
   assert.equal(snapshot.schema, "agent-kernel/WorldStateArtifact");
-  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.schemaVersion, 2);
   assert.equal(snapshot.tick, TICKS, "the snapshot's tick must be the run's tick");
   assert.equal(snapshot.actors.length, initialState.actors.length);
 

--- a/tests/runtime/world-state-resources.test.js
+++ b/tests/runtime/world-state-resources.test.js
@@ -1,0 +1,205 @@
+/**
+ * A world-state snapshot carried actors and hazards but never resources, so
+ * nothing on disk could distinguish a resource still sitting on the map from one
+ * an actor had collected. That is the single observation the execution
+ * benchmark's resource gates are built on — `single_consumption` asks whether a
+ * resource was taken exactly once — and it was the reason every resource metric
+ * reported `evidence_unavailable`.
+ *
+ * These tests pin the resource half of the snapshot. Placement into the core is
+ * covered in tests/runtime/core-setup-resources.test.js.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const META = { id: "ws", runId: "ws", createdAt: "2026-08-14T00:00:00.000Z", producedBy: "annotator" };
+
+function floorGrid(width, height) {
+  return Array.from({ length: height }, (_, y) =>
+    Array.from({ length: width }, (_, x) =>
+      x === 0 || x === width - 1 || y === 0 || y === height - 1 ? "#" : ".").join(""));
+}
+
+function buildSimConfig({ width = 5, height = 5, resources = [] } = {}) {
+  return {
+    schema: "agent-kernel/SimConfigArtifact",
+    schemaVersion: 1,
+    meta: { id: "ws_sim", runId: "ws", createdAt: "2026-08-14T00:00:00.000Z" },
+    seed: 0,
+    layout: {
+      kind: "grid",
+      data: {
+        width,
+        height,
+        tiles: floorGrid(width, height),
+        spawn: { x: 1, y: 1 },
+        exit: { x: width - 2, y: height - 2 },
+        rooms: [{ id: "R1", x: 0, y: 0, width, height }],
+        resources,
+      },
+    },
+  };
+}
+
+function buildInitialState(actors) {
+  return {
+    schema: "agent-kernel/InitialStateArtifact",
+    schemaVersion: 1,
+    meta: { id: "ws", runId: "ws", createdAt: "2026-08-14T00:00:00.000Z" },
+    simConfigRef: { id: "ws_sim", schema: "agent-kernel/SimConfigArtifact", schemaVersion: 1 },
+    actors,
+  };
+}
+
+function actor(id, position, motivationKind = "exploring") {
+  return {
+    id,
+    kind: "ambulatory",
+    archetype: id.startsWith("delver") ? "delver" : "warden",
+    role: id.startsWith("delver") ? "delver" : "warden",
+    position,
+    motivation: { kind: motivationKind },
+    traits: { affinities: { fire: 1 }, motivations: [{ kind: motivationKind, intensity: 1 }] },
+    vitals: {
+      health: { current: 4, max: 20, regen: 0 },
+      mana: { current: 4, max: 20, regen: 0 },
+      stamina: { current: 40, max: 40, regen: 4 },
+      durability: { current: 2, max: 2, regen: 0 },
+    },
+  };
+}
+
+async function runScenario({ simConfig, initialState, ticks = 0 }) {
+  const [{ createRuntime }, { createCore }] = await Promise.all([
+    import("../../packages/runtime/src/runner/runtime.js"),
+    import("../../packages/core-ts/src/index.ts"),
+  ]);
+  const core = createCore();
+  const runtime = createRuntime({ core, adapters: {} });
+  await runtime.init({ seed: 0, simConfig, initialState });
+  for (let tick = 0; tick < ticks; tick += 1) await runtime.step();
+  return { core, runtime };
+}
+
+function key(entry) {
+  return `${entry.position.x},${entry.position.y}`;
+}
+
+test("the snapshot reports a vital resource with the payload it was authored with", async () => {
+  const simConfig = buildSimConfig({
+    resources: [{
+      id: "resource_health_consumable",
+      permanenceMode: "consumable",
+      vitals: [{ key: "health", delta: 5, regen: 2 }],
+      position: { x: 3, y: 3 },
+    }],
+  });
+  const { runtime } = await runScenario({ simConfig, initialState: buildInitialState([actor("delver_1", { x: 1, y: 1 })]) });
+  const snapshot = runtime.captureWorldState({ meta: META });
+
+  assert.ok(Array.isArray(snapshot.resources), "resources must always be present, even when empty");
+  assert.equal(snapshot.resources.length, 1);
+  const [resource] = snapshot.resources;
+  assert.deepEqual(resource.position, { x: 3, y: 3 });
+  assert.equal(resource.vital.kind, 0, "health is vital kind 0");
+  assert.equal(resource.vital.delta, 5);
+  assert.equal(resource.vital.mode, 0, "consumable is mode 0");
+  assert.equal(resource.vital.regen, 2);
+  assert.equal(resource.affinity, null, "a vital-only resource carries no affinity payload");
+});
+
+test("the snapshot reports an affinity resource, including the regen that makes it permanent", async () => {
+  const simConfig = buildSimConfig({
+    resources: [{
+      id: "resource_permanent_fire",
+      permanenceMode: "consumable",
+      vitals: [],
+      affinity: { kind: "fire", expression: "emit", stacks: 2, mana: 12, manaRegen: 3 },
+      position: { x: 2, y: 3 },
+    }],
+  });
+  const { runtime } = await runScenario({ simConfig, initialState: buildInitialState([actor("delver_1", { x: 1, y: 1 })]) });
+  const [resource] = runtime.captureWorldState({ meta: META }).resources;
+
+  assert.deepEqual(resource.position, { x: 2, y: 3 });
+  assert.equal(resource.vital, null, "an affinity-only resource carries no vital payload");
+  assert.ok(resource.affinity.kind > 0);
+  assert.ok(resource.affinity.expression > 0);
+  assert.equal(resource.affinity.stacks, 2);
+  assert.equal(resource.affinity.mana, 12);
+  assert.equal(resource.affinity.manaRegen, 3, "manaRegen is what makes the grant permanent");
+});
+
+test("a resource carrying both payloads reports both at one position", async () => {
+  const simConfig = buildSimConfig({
+    resources: [{
+      permanenceMode: "level",
+      vitals: [{ key: "mana", delta: 3 }],
+      affinity: { kind: "fire", expression: "push", stacks: 1, mana: 6, manaRegen: 0 },
+      position: { x: 2, y: 2 },
+    }],
+  });
+  const { runtime } = await runScenario({ simConfig, initialState: buildInitialState([actor("warden_1", { x: 1, y: 1 })]) });
+  const [resource] = runtime.captureWorldState({ meta: META }).resources;
+
+  assert.equal(resource.vital.kind, 1, "mana is vital kind 1");
+  assert.equal(resource.vital.mode, 1, "level is mode 1");
+  assert.equal(resource.affinity.stacks, 1);
+});
+
+// The whole point of putting resources in the snapshot: a collected resource has
+// to be observably gone, or `single_consumption` cannot be evidenced at all.
+test("collected resources disappear from later snapshots and never come back", async () => {
+  const cells = [];
+  for (let y = 1; y <= 3; y += 1) for (let x = 1; x <= 3; x += 1) cells.push({ x, y });
+  const simConfig = buildSimConfig({
+    resources: cells.map((position, index) => ({
+      id: `resource_${index}`,
+      permanenceMode: "consumable",
+      vitals: [{ key: "health", delta: 1 }],
+      position,
+    })),
+  });
+  const initialState = buildInitialState([actor("delver_1", { x: 1, y: 1 })]);
+
+  const { runtime } = await runScenario({ simConfig, initialState });
+  const series = [runtime.captureWorldState({ meta: META })];
+  for (let tick = 0; tick < 8; tick += 1) {
+    await runtime.step();
+    series.push(runtime.captureWorldState({ meta: META }));
+  }
+
+  assert.equal(series[0].resources.length, cells.length, "every authored resource is on the map at the start");
+
+  // Flooding the floor means any accepted move consumes one, so this is not vacuous.
+  const last = series[series.length - 1];
+  assert.ok(last.resources.length < series[0].resources.length,
+    "an actor moving across a fully seeded floor must have collected at least one resource");
+
+  let previous = new Set(series[0].resources.map(key));
+  for (const snapshot of series.slice(1)) {
+    const current = new Set(snapshot.resources.map(key));
+    const reappeared = [...current].filter((cell) => !previous.has(cell));
+    assert.deepEqual(reappeared, [], "a consumed resource must not return to the map");
+    previous = current;
+  }
+});
+
+test("a world with no resources reports an empty array, not a missing field", async () => {
+  const { runtime } = await runScenario({
+    simConfig: buildSimConfig(),
+    initialState: buildInitialState([actor("delver_1", { x: 1, y: 1 })]),
+  });
+  const snapshot = runtime.captureWorldState({ meta: META });
+
+  assert.deepEqual(snapshot.resources, []);
+  assert.equal(snapshot.schemaVersion, 2, "resources arrived in v2; absence must be distinguishable from emptiness");
+});
+
+// ## TODO: Test Permutations
+test.skip("a core lacking the resource getters yields an empty array rather than throwing", async () => {});
+test.skip("two resources at the same cell collapse to the one the core actually holds", async () => {});
+test.skip("an affinity grant's mana decline is visible across consecutive snapshots", async () => {});
+test.skip("a resource outside the configured grid never appears in the snapshot", async () => {});
+test.skip("resource ordering is stable across snapshots of the same world", async () => {});

--- a/tests/tools/execution-benchmark-evaluator.test.js
+++ b/tests/tools/execution-benchmark-evaluator.test.js
@@ -294,12 +294,13 @@ test('checkpoint reader consumes only declared WorldStateArtifact ticks and repo
   mkdirSync(checkpointDir, { recursive: true });
   const checkpoint = (tick) => ({
     schema: 'agent-kernel/WorldStateArtifact',
-    schemaVersion: 1,
+    schemaVersion: 2,
     meta: { id: `state_${tick}`, runId: 'fixture', createdAt: '2026-01-01T00:00:00.000Z', producedBy: 'annotator' },
     tick,
     dimensions: { width: 4, height: 3 },
     actors: [],
     hazards: [],
+    resources: [],
   });
   for (const tick of [0, 2, 99]) {
     writeFileSync(join(checkpointDir, `tick-${String(tick).padStart(6, '0')}.json`), `${JSON.stringify(checkpoint(tick))}\n`);

--- a/tests/tools/execution-resource-metrics.test.js
+++ b/tests/tools/execution-resource-metrics.test.js
@@ -1,0 +1,398 @@
+/**
+ * The execution contract declares nine resource metrics and the evaluator
+ * extracted none of them, so every resource gate reported `evidence_unavailable`
+ * and the five EX-RS scenarios could never qualify. The evidence they need is a
+ * world-state checkpoint series: a resource present at one tick and gone at the
+ * next was collected in between, and the collecting actor's vitals and affinity
+ * grants say what the collection did.
+ *
+ * These tests drive the extractor with checkpoint series directly, because the
+ * question is what the evaluator concludes from a given world history — not how
+ * that history came to be.
+ */
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  extractExecutionMetrics,
+} = require('../../tools/remote-ollama-control/scripts/lib/execution-evaluator.js');
+const {
+  loadExecutionCatalog,
+} = require('../../tools/remote-ollama-control/scripts/lib/execution-catalog.js');
+
+const CONTRACT = loadExecutionCatalog().contract;
+
+function vitals({ health = [10, 10, 0], mana = [0, 0, 0], stamina = [20, 20, 0] } = {}) {
+  const of = ([current, max, regen]) => ({ current, max, regen });
+  return { health: of(health), mana: of(mana), stamina: of(stamina), durability: of([2, 2, 0]) };
+}
+
+function checkpoint(tick, { actors = [], resources = [] } = {}) {
+  return {
+    schema: 'agent-kernel/WorldStateArtifact',
+    schemaVersion: 2,
+    meta: { id: `s${tick}`, runId: 'fixture', createdAt: '2026-01-01T00:00:00.000Z', producedBy: 'annotator' },
+    tick,
+    dimensions: { width: 5, height: 5 },
+    actors,
+    hazards: [],
+    resources,
+  };
+}
+
+function vitalResource(position, { kind = 0, delta = 5, mode = 0, regen = 0 } = {}) {
+  return { position, vital: { kind, delta, mode, regen }, affinity: null };
+}
+
+function affinityResource(position, { kind = 1, expression = 1, stacks = 2, mana = 12, manaRegen = 0 } = {}) {
+  return { position, vital: null, affinity: { kind, expression, stacks, mana, manaRegen } };
+}
+
+function actorAt(id, position, options = {}) {
+  return { id, index: 0, position, vitals: vitals(options.vitals), affinities: options.affinities || [] };
+}
+
+function grant({ kind = 1, expression = 1, stacks = 2, mana = 12, manaMax = 12, manaRegen = 0 } = {}) {
+  return { kind, expression, stacks, mana, manaMax, manaRegen };
+}
+
+function extract(states, { initialActors } = {}) {
+  const { metrics } = extractExecutionMetrics({
+    tickFrames: [],
+    runSummary: { outcome: 'success', metrics: { ticks: 2 } },
+    initialState: {
+      actors: initialActors || [{ id: 'delver_1', archetype: 'delver', role: 'delver', position: { x: 1, y: 1 } }],
+    },
+    simConfig: { layout: { data: { width: 5, height: 5, tiles: ['.....', '.....', '.....', '.....', '.....'] } } },
+    requestedTicks: 2,
+    worldStateCheckpoints: { states },
+  }, CONTRACT);
+  return metrics;
+}
+
+// ---------------------------------------------------------------------------
+// Without a checkpoint series there is no evidence — and no false pass
+// ---------------------------------------------------------------------------
+
+const RESOURCE_METRICS = [
+  'single_consumption', 'pickup_apply_correctness', 'persistent_vital_grant', 'recovery_curve',
+  'affinity_lifecycle', 'affinity_activity', 'grant_isolation', 'actor_kind_parity', 'persistent_stacking',
+];
+
+test('every resource metric is unavailable when no checkpoints were captured', () => {
+  const metrics = extract([]);
+  for (const name of RESOURCE_METRICS) {
+    assert.equal(metrics[name].status, 'evidence_unavailable', `${name} must not be scored without checkpoints`);
+  }
+});
+
+test('a single checkpoint proves nothing, because collection is a difference between two', () => {
+  const metrics = extract([checkpoint(0, {
+    actors: [actorAt('delver_1', { x: 1, y: 1 })],
+    resources: [vitalResource({ x: 3, y: 3 })],
+  })]);
+  assert.equal(metrics.single_consumption.status, 'evidence_unavailable');
+});
+
+// ---------------------------------------------------------------------------
+// single_consumption
+// ---------------------------------------------------------------------------
+
+test('a resource that vanishes exactly once scores single_consumption 1', () => {
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 })], resources: [vitalResource({ x: 3, y: 3 })] }),
+    checkpoint(2, { actors: [actorAt('delver_1', { x: 3, y: 3 }, { vitals: { health: [15, 20, 0] } })], resources: [] }),
+  ]);
+  assert.equal(metrics.single_consumption.status, 'available');
+  assert.equal(metrics.single_consumption.value, 1);
+});
+
+// The gate reads "resource consumes once". A resource nobody ever crossed did not
+// consume once, and must not be scored as though it had.
+test('a resource still sitting on the map at the end scores below 1', () => {
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 })], resources: [vitalResource({ x: 3, y: 3 })] }),
+    checkpoint(2, { actors: [actorAt('delver_1', { x: 1, y: 2 })], resources: [vitalResource({ x: 3, y: 3 })] }),
+  ]);
+  assert.equal(metrics.single_consumption.value, 0);
+});
+
+test('a resource that reappears after being taken is not a single consumption', () => {
+  const resource = vitalResource({ x: 3, y: 3 });
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 })], resources: [resource] }),
+    checkpoint(1, { actors: [actorAt('delver_1', { x: 3, y: 3 })], resources: [] }),
+    checkpoint(2, { actors: [actorAt('delver_1', { x: 3, y: 3 })], resources: [resource] }),
+  ]);
+  assert.equal(metrics.single_consumption.value, 0);
+});
+
+// ---------------------------------------------------------------------------
+// pickup_apply_correctness and persistent_vital_grant
+// ---------------------------------------------------------------------------
+
+test('a consumable grant that raised current health within max scores pickup_apply_correctness 1', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 }, { vitals: { health: [5, 20, 0] } })],
+      resources: [vitalResource({ x: 3, y: 3 }, { mode: 0, delta: 5 })],
+    }),
+    checkpoint(2, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { vitals: { health: [10, 20, 0] } })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.pickup_apply_correctness.value, 1);
+});
+
+test('a consumed grant that changed nothing scores pickup_apply_correctness 0', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 }, { vitals: { health: [5, 20, 0] } })],
+      resources: [vitalResource({ x: 3, y: 3 }, { mode: 0, delta: 5 })],
+    }),
+    checkpoint(2, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { vitals: { health: [5, 20, 0] } })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.pickup_apply_correctness.value, 0);
+});
+
+test('a level grant that raised max and held it to the end scores persistent_vital_grant 1', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 }, { vitals: { health: [5, 12, 0] } })],
+      resources: [vitalResource({ x: 3, y: 3 }, { mode: 1, delta: 4 })],
+    }),
+    checkpoint(1, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { vitals: { health: [9, 16, 0] } })],
+      resources: [],
+    }),
+    checkpoint(2, {
+      actors: [actorAt('delver_1', { x: 3, y: 4 }, { vitals: { health: [9, 16, 0] } })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.persistent_vital_grant.value, 1);
+});
+
+// "increase persists through tick 100" is the gate. A max that comes back down
+// is exactly the failure it exists to catch.
+test('a raised max that decays before the last checkpoint scores persistent_vital_grant 0', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 }, { vitals: { health: [5, 12, 0] } })],
+      resources: [vitalResource({ x: 3, y: 3 }, { mode: 1, delta: 4 })],
+    }),
+    checkpoint(1, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { vitals: { health: [9, 16, 0] } })],
+      resources: [],
+    }),
+    checkpoint(2, {
+      actors: [actorAt('delver_1', { x: 3, y: 4 }, { vitals: { health: [9, 12, 0] } })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.persistent_vital_grant.value, 0);
+});
+
+test('a granted regen counts as a persistent grant even with a zero delta', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 }, { vitals: { health: [5, 20, 0] } })],
+      resources: [vitalResource({ x: 3, y: 3 }, { mode: 1, delta: 0, regen: 2 })],
+    }),
+    checkpoint(1, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { vitals: { health: [5, 20, 2] } })],
+      resources: [],
+    }),
+    checkpoint(2, {
+      actors: [actorAt('delver_1', { x: 3, y: 4 }, { vitals: { health: [7, 20, 2] } })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.persistent_vital_grant.value, 1);
+});
+
+// ---------------------------------------------------------------------------
+// recovery_curve
+// ---------------------------------------------------------------------------
+
+test('recovery_curve counts the checkpoint steps where health climbed within bounds', () => {
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 }, { vitals: { health: [4, 20, 2] } })], resources: [] }),
+    checkpoint(1, { actors: [actorAt('delver_1', { x: 2, y: 1 }, { vitals: { health: [6, 20, 2] } })], resources: [] }),
+    checkpoint(2, { actors: [actorAt('delver_1', { x: 3, y: 1 }, { vitals: { health: [8, 20, 2] } })], resources: [] }),
+  ]);
+  assert.equal(metrics.recovery_curve.value, 2);
+});
+
+test('health that never climbs yields a recovery_curve of 0, not unavailable', () => {
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 }, { vitals: { health: [8, 20, 0] } })], resources: [] }),
+    checkpoint(1, { actors: [actorAt('delver_1', { x: 2, y: 1 }, { vitals: { health: [8, 20, 0] } })], resources: [] }),
+  ]);
+  assert.equal(metrics.recovery_curve.status, 'available');
+  assert.equal(metrics.recovery_curve.value, 0);
+});
+
+// ---------------------------------------------------------------------------
+// affinity metrics
+// ---------------------------------------------------------------------------
+
+test('a consumed affinity resource whose grant appears with declared stacks scores affinity_lifecycle 1', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 })],
+      resources: [affinityResource({ x: 3, y: 3 }, { kind: 1, expression: 1, stacks: 2, mana: 12 })],
+    }),
+    checkpoint(1, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { affinities: [grant({ kind: 1, expression: 1, stacks: 2, mana: 12 })] })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.affinity_lifecycle.value, 1);
+});
+
+test('a grant arriving with the wrong stack count scores affinity_lifecycle 0', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 })],
+      resources: [affinityResource({ x: 3, y: 3 }, { stacks: 2 })],
+    }),
+    checkpoint(1, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { affinities: [grant({ stacks: 1 })] })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.affinity_lifecycle.value, 0);
+});
+
+test('affinity_activity counts the steps where a grant spent mana', () => {
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 }, { affinities: [grant({ mana: 12 })] })], resources: [] }),
+    checkpoint(1, { actors: [actorAt('delver_1', { x: 2, y: 1 }, { affinities: [grant({ mana: 8 })] })], resources: [] }),
+    checkpoint(2, { actors: [actorAt('delver_1', { x: 3, y: 1 }, { affinities: [grant({ mana: 5 })] })], resources: [] }),
+  ]);
+  assert.equal(metrics.affinity_activity.value, 2);
+});
+
+test('an exhausted grant that expires while the others survive scores grant_isolation 1', () => {
+  const spent = grant({ kind: 1, expression: 1, mana: 0 });
+  const other = grant({ kind: 2, expression: 2, mana: 9 });
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 }, { affinities: [spent, other] })], resources: [] }),
+    checkpoint(1, { actors: [actorAt('delver_1', { x: 2, y: 1 }, { affinities: [other] })], resources: [] }),
+  ]);
+  assert.equal(metrics.grant_isolation.value, 1);
+});
+
+test('an expiry that takes an unrelated grant with it scores grant_isolation 0', () => {
+  const spent = grant({ kind: 1, expression: 1, mana: 0 });
+  const other = grant({ kind: 2, expression: 2, mana: 9 });
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 }, { affinities: [spent, other] })], resources: [] }),
+    checkpoint(1, { actors: [actorAt('delver_1', { x: 2, y: 1 }, { affinities: [] })], resources: [] }),
+  ]);
+  assert.equal(metrics.grant_isolation.value, 0);
+});
+
+// Isolation cannot be observed in a run where nothing expired. Reporting 1 there
+// would be a pass invented from the absence of evidence.
+test('grant_isolation is unavailable when no grant ever expired', () => {
+  const metrics = extract([
+    checkpoint(0, { actors: [actorAt('delver_1', { x: 1, y: 1 }, { affinities: [grant()] })], resources: [] }),
+    checkpoint(1, { actors: [actorAt('delver_1', { x: 2, y: 1 }, { affinities: [grant()] })], resources: [] }),
+  ]);
+  assert.equal(metrics.grant_isolation.status, 'evidence_unavailable');
+});
+
+test('stacks that combine additively across two grants score persistent_stacking 1', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 }, { affinities: [grant({ stacks: 2 })] })],
+      resources: [affinityResource({ x: 3, y: 3 }, { stacks: 2 })],
+    }),
+    checkpoint(1, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { affinities: [grant({ stacks: 4 })] })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.persistent_stacking.value, 1);
+});
+
+test('stacks that replace rather than combine score persistent_stacking 0', () => {
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [actorAt('delver_1', { x: 1, y: 1 }, { affinities: [grant({ stacks: 2 })] })],
+      resources: [affinityResource({ x: 3, y: 3 }, { stacks: 2 })],
+    }),
+    checkpoint(1, {
+      actors: [actorAt('delver_1', { x: 3, y: 3 }, { affinities: [grant({ stacks: 2 })] })],
+      resources: [],
+    }),
+  ]);
+  assert.equal(metrics.persistent_stacking.value, 0);
+});
+
+// ---------------------------------------------------------------------------
+// actor_kind_parity — EX-RS-05 exists to prove wardens are not second-class
+// ---------------------------------------------------------------------------
+
+test('both actor kinds collecting a resource scores actor_kind_parity 1', () => {
+  const initialActors = [
+    { id: 'delver_1', archetype: 'delver', role: 'delver' },
+    { id: 'warden_1', archetype: 'warden', role: 'warden' },
+  ];
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [
+        { ...actorAt('delver_1', { x: 1, y: 1 }), index: 0 },
+        { ...actorAt('warden_1', { x: 4, y: 4 }), index: 1 },
+      ],
+      resources: [affinityResource({ x: 2, y: 2 }), affinityResource({ x: 3, y: 3 })],
+    }),
+    checkpoint(1, {
+      actors: [
+        { ...actorAt('delver_1', { x: 2, y: 2 }, { affinities: [grant()] }), index: 0 },
+        { ...actorAt('warden_1', { x: 3, y: 3 }, { affinities: [grant()] }), index: 1 },
+      ],
+      resources: [],
+    }),
+  ], { initialActors });
+  assert.equal(metrics.actor_kind_parity.value, 1);
+});
+
+test('one kind collecting while the other does not scores actor_kind_parity below 1', () => {
+  const initialActors = [
+    { id: 'delver_1', archetype: 'delver', role: 'delver' },
+    { id: 'warden_1', archetype: 'warden', role: 'warden' },
+  ];
+  const metrics = extract([
+    checkpoint(0, {
+      actors: [
+        { ...actorAt('delver_1', { x: 1, y: 1 }), index: 0 },
+        { ...actorAt('warden_1', { x: 4, y: 4 }), index: 1 },
+      ],
+      resources: [affinityResource({ x: 2, y: 2 })],
+    }),
+    checkpoint(1, {
+      actors: [
+        { ...actorAt('delver_1', { x: 2, y: 2 }, { affinities: [grant()] }), index: 0 },
+        { ...actorAt('warden_1', { x: 4, y: 4 }), index: 1 },
+      ],
+      resources: [],
+    }),
+  ], { initialActors });
+  assert.equal(metrics.actor_kind_parity.value, 0.5);
+});
+
+// ## TODO: Test Permutations
+test.skip("a checkpoint series with a gap in the middle still scores what it can observe", async () => {});
+test.skip("two actors adjacent to the same consumed resource attribute the pickup to exactly one", async () => {});
+test.skip("a vital that exceeds its max at any checkpoint fails pickup_apply_correctness", async () => {});
+test.skip("a resource carrying both payloads counts once in single_consumption, not twice", async () => {});
+test.skip("mana regen refilling a pool does not read as affinity_activity", async () => {});
+test.skip("an actor absent from a later checkpoint does not crash the extractor", async () => {});

--- a/tools/remote-ollama-control/benchmarks/execution/RUNBOOK.md
+++ b/tools/remote-ollama-control/benchmarks/execution/RUNBOOK.md
@@ -142,6 +142,14 @@ pnpm --dir tools/remote-ollama-control validate:execution -- \
   --out "$AK_BENCHMARK_STATE_DIR/corpus-validation"
 ```
 
+Resource scenarios need world-state checkpoints to be scoreable at all. Collection is destructive, so a
+resource present in one checkpoint and absent from the next was taken in between — that difference is
+the only public evidence a pickup happened, and the nine resource metrics
+(`single_consumption`, `pickup_apply_correctness`, `persistent_vital_grant`, `recovery_curve`,
+`affinity_lifecycle`, `affinity_activity`, `grant_isolation`, `actor_kind_parity`,
+`persistent_stacking`) are all derived from it. Checkpoints require `WorldStateArtifact` **v2**; a v1
+checkpoint is rejected rather than read as a world containing no resources.
+
 This corpus preflight verifies exact 26-key parity, both manifest identities, source-owned artifact
 paths, `SimConfigArtifact`/`InitialStateArtifact` schemas, explicit generated prompt markers, and a
 canonical hash over every committed artifact pair. It then behaviorally probes the pinned source's

--- a/tools/remote-ollama-control/scripts/lib/execution-evaluator.js
+++ b/tools/remote-ollama-control/scripts/lib/execution-evaluator.js
@@ -139,6 +139,278 @@ function statsActorActivity(actors, actions, requestedTicks) {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Resource metrics, derived from the world-state checkpoint series
+//
+// Collection is destructive: entering a cell removes its resource. So a resource
+// present in one checkpoint and absent from the next was taken in between, and
+// the collecting actor's vitals and grants in those two snapshots say what the
+// pickup did. Everything below is that one observation, asked nine ways.
+//
+// Each metric reports evidence_unavailable rather than a default when the run
+// contains nothing to observe — a scenario where no grant ever expired cannot
+// demonstrate grant isolation, and scoring it 1 would invent a pass out of an
+// absence.
+// ---------------------------------------------------------------------------
+
+const RESOURCE_METRIC_NAMES = Object.freeze([
+  'single_consumption', 'pickup_apply_correctness', 'persistent_vital_grant', 'recovery_curve',
+  'affinity_lifecycle', 'affinity_activity', 'grant_isolation', 'actor_kind_parity', 'persistent_stacking',
+]);
+const VITAL_NAMES = Object.freeze(['health', 'mana', 'stamina', 'durability']);
+
+function cellKey(resource) {
+  return `${resource?.position?.x},${resource?.position?.y}`;
+}
+
+function grantKey(grant) {
+  return `${grant?.kind}:${grant?.expression}`;
+}
+
+function grantsByKey(actor) {
+  const totals = new Map();
+  for (const grant of Array.isArray(actor?.affinities) ? actor.affinities : []) {
+    const key = grantKey(grant);
+    const existing = totals.get(key) || { stacks: 0, mana: 0, count: 0 };
+    totals.set(key, {
+      stacks: existing.stacks + (Number.isFinite(grant.stacks) ? grant.stacks : 0),
+      mana: existing.mana + (Number.isFinite(grant.mana) ? grant.mana : 0),
+      count: existing.count + 1,
+    });
+  }
+  return totals;
+}
+
+function vitalOf(actor, kind) {
+  return actor?.vitals?.[VITAL_NAMES[kind]] || null;
+}
+
+function actorIndex(state) {
+  return new Map((Array.isArray(state?.actors) ? state.actors : []).map((actor) => [actor.id, actor]));
+}
+
+function vitalsWithinBounds(states) {
+  return states.every((state) => (Array.isArray(state.actors) ? state.actors : []).every((actor) => VITAL_NAMES
+    .every((name) => {
+      const vital = actor?.vitals?.[name];
+      if (!isObject(vital)) return true;
+      return [vital.current, vital.max, vital.regen].every(Number.isFinite)
+        && vital.current >= 0 && vital.current <= vital.max;
+    })));
+}
+
+/** Index at which a resource first went missing, or -1 if it never did. */
+function consumptionIndex(ordered, key) {
+  for (let index = 1; index < ordered.length; index += 1) {
+    if (!ordered[index].resources.some((resource) => cellKey(resource) === key)) return index;
+  }
+  return -1;
+}
+
+function extractResourceMetrics(artifacts, units) {
+  const nothing = (reason) => Object.fromEntries(
+    RESOURCE_METRIC_NAMES.map((name) => [name, unavailable(units[name], reason)]),
+  );
+  const states = Array.isArray(artifacts.worldStateCheckpoints?.states)
+    ? artifacts.worldStateCheckpoints.states : [];
+  if (states.length < 2) {
+    return nothing('two or more world-state checkpoints are required to observe a collection');
+  }
+  if (states.some((state) => !Array.isArray(state.resources))) {
+    return nothing('a checkpoint carries no resource list; it predates WorldStateArtifact v2');
+  }
+
+  const ordered = [...states].sort((left, right) => left.tick - right.tick);
+  const first = ordered[0];
+  const last = ordered[ordered.length - 1];
+  const results = {};
+  const initial = first.resources;
+  const bounded = vitalsWithinBounds(ordered);
+
+  // --- single_consumption -------------------------------------------------
+  if (initial.length === 0) {
+    results.single_consumption = unavailable(units.single_consumption,
+      'no resource was on the map at the first checkpoint');
+  } else {
+    const clean = initial.filter((resource) => {
+      const key = cellKey(resource);
+      const gone = consumptionIndex(ordered, key);
+      if (gone < 0) return false;
+      // Taken once means taken once: a cell that fills back in after being
+      // emptied is a second consumption waiting to happen.
+      return ordered.slice(gone).every((state) => !state.resources.some((entry) => cellKey(entry) === key));
+    });
+    results.single_consumption = metric(clean.length / initial.length, units.single_consumption);
+  }
+
+  // --- consumption events, shared by the payload metrics -------------------
+  const events = initial.map((resource) => {
+    const index = consumptionIndex(ordered, cellKey(resource));
+    return index < 0 ? null : { resource, before: ordered[index - 1], after: ordered[index] };
+  }).filter(Boolean);
+
+  const vitalEvents = events.filter((event) => isObject(event.resource.vital));
+  const affinityEvents = events.filter((event) => isObject(event.resource.affinity));
+
+  // --- pickup_apply_correctness -------------------------------------------
+  if (vitalEvents.length === 0) {
+    results.pickup_apply_correctness = unavailable(units.pickup_apply_correctness,
+      'no vital-carrying resource was collected');
+  } else {
+    const applied = vitalEvents.filter(({ resource, before, after }) => {
+      const { kind, delta, mode, regen } = resource.vital;
+      const beforeActors = actorIndex(before);
+      return (Array.isArray(after.actors) ? after.actors : []).some((actor) => {
+        const now = vitalOf(actor, kind);
+        const then = vitalOf(beforeActors.get(actor.id), kind);
+        if (!isObject(now) || !isObject(then)) return false;
+        // mode 0 raises the current vital; 1 and 2 raise its max. A grant that
+        // moved the wrong one applied something other than what was authored.
+        if (delta !== 0) {
+          const observed = mode === 0 ? now.current - then.current : now.max - then.max;
+          return Math.sign(observed) === Math.sign(delta);
+        }
+        return regen > 0 && now.regen > then.regen;
+      });
+    });
+    results.pickup_apply_correctness = metric(
+      bounded ? applied.length / vitalEvents.length : 0,
+      units.pickup_apply_correctness,
+    );
+  }
+
+  // --- persistent_vital_grant ---------------------------------------------
+  const persistentEvents = vitalEvents.filter(({ resource }) => resource.vital.mode !== 0 || resource.vital.regen > 0);
+  if (persistentEvents.length === 0) {
+    results.persistent_vital_grant = unavailable(units.persistent_vital_grant,
+      'no persistent vital grant was collected');
+  } else {
+    const firstActors = actorIndex(first);
+    const held = persistentEvents.filter(({ resource }) => {
+      const { kind, mode, regen } = resource.vital;
+      // Measured against the LAST checkpoint, not the one after pickup: the gate
+      // is that the increase still stands at the end of the run.
+      return (Array.isArray(last.actors) ? last.actors : []).some((actor) => {
+        const end = vitalOf(actor, kind);
+        const start = vitalOf(firstActors.get(actor.id), kind);
+        if (!isObject(end) || !isObject(start)) return false;
+        return (mode !== 0 && end.max > start.max) || (regen > 0 && end.regen > start.regen);
+      });
+    });
+    results.persistent_vital_grant = metric(held.length / persistentEvents.length, units.persistent_vital_grant);
+  }
+
+  // --- recovery_curve ------------------------------------------------------
+  let recoveries = 0;
+  for (let index = 1; index < ordered.length; index += 1) {
+    const previous = actorIndex(ordered[index - 1]);
+    const climbed = (Array.isArray(ordered[index].actors) ? ordered[index].actors : []).some((actor) => {
+      const now = vitalOf(actor, 0);
+      const then = vitalOf(previous.get(actor.id), 0);
+      return isObject(now) && isObject(then) && now.current > then.current && now.current <= now.max;
+    });
+    if (climbed) recoveries += 1;
+  }
+  results.recovery_curve = metric(recoveries, units.recovery_curve);
+
+  // --- affinity_lifecycle --------------------------------------------------
+  if (affinityEvents.length === 0) {
+    results.affinity_lifecycle = unavailable(units.affinity_lifecycle, 'no affinity resource was collected');
+  } else {
+    const arrived = affinityEvents.filter(({ resource, after }) => (Array.isArray(after.actors) ? after.actors : [])
+      .some((actor) => (Array.isArray(actor.affinities) ? actor.affinities : []).some((grant) => grant.kind === resource.affinity.kind
+        && grant.expression === resource.affinity.expression
+        && grant.stacks === resource.affinity.stacks)));
+    results.affinity_lifecycle = metric(arrived.length / affinityEvents.length, units.affinity_lifecycle);
+  }
+
+  // --- persistent_stacking -------------------------------------------------
+  if (affinityEvents.length === 0) {
+    results.persistent_stacking = unavailable(units.persistent_stacking, 'no affinity resource was collected');
+  } else {
+    const additive = affinityEvents.filter(({ resource, before, after }) => {
+      const key = grantKey(resource.affinity);
+      const beforeActors = actorIndex(before);
+      return (Array.isArray(after.actors) ? after.actors : []).some((actor) => {
+        const now = grantsByKey(actor).get(key)?.stacks || 0;
+        const then = grantsByKey(beforeActors.get(actor.id)).get(key)?.stacks || 0;
+        return now - then === resource.affinity.stacks;
+      });
+    });
+    results.persistent_stacking = metric(additive.length / affinityEvents.length, units.persistent_stacking);
+  }
+
+  // --- affinity_activity ---------------------------------------------------
+  let spends = 0;
+  for (let index = 1; index < ordered.length; index += 1) {
+    const previous = actorIndex(ordered[index - 1]);
+    const spent = (Array.isArray(ordered[index].actors) ? ordered[index].actors : []).some((actor) => {
+      const now = grantsByKey(actor);
+      const then = grantsByKey(previous.get(actor.id));
+      return [...then.entries()].some(([key, value]) => (now.get(key)?.mana ?? 0) < value.mana);
+    });
+    if (spent) spends += 1;
+  }
+  results.affinity_activity = metric(spends, units.affinity_activity);
+
+  // --- grant_isolation -----------------------------------------------------
+  const expiries = [];
+  for (let index = 1; index < ordered.length; index += 1) {
+    const previous = actorIndex(ordered[index - 1]);
+    for (const actor of Array.isArray(ordered[index].actors) ? ordered[index].actors : []) {
+      const before = previous.get(actor.id);
+      if (!before) continue;
+      const now = grantsByKey(actor);
+      const then = grantsByKey(before);
+      for (const [key] of then) {
+        if (now.has(key)) continue;
+        const grant = before.affinities.find((entry) => grantKey(entry) === key);
+        const exhausted = (grant?.mana ?? 0) <= 0 && (grant?.manaRegen ?? 0) <= 0;
+        const othersSurvived = [...then.keys()].filter((other) => other !== key).every((other) => now.has(other));
+        expiries.push(exhausted && othersSurvived);
+      }
+    }
+  }
+  results.grant_isolation = expiries.length === 0
+    ? unavailable(units.grant_isolation, 'no affinity grant expired, so isolation cannot be observed')
+    : metric(expiries.filter(Boolean).length / expiries.length, units.grant_isolation);
+
+  // --- actor_kind_parity ---------------------------------------------------
+  const declared = Array.isArray(artifacts.initialState?.actors) ? artifacts.initialState.actors : [];
+  const kindById = new Map(declared.map((actor) => [actor.id, actor.archetype || actor.role || 'unknown']));
+  const kinds = new Set(kindById.values());
+  if (kinds.size === 0) {
+    results.actor_kind_parity = unavailable(units.actor_kind_parity, 'no actor kinds are declared in the initial state');
+  } else {
+    // Acquisition is measured inside a consumption window — between the
+    // checkpoint before a resource vanished and the one after — rather than
+    // across the whole run. Over a whole run regeneration alone raises a current
+    // vital, so a run-wide comparison credits actors that collected nothing.
+    const acquired = new Set();
+    for (const { before, after } of events) {
+      const beforeActors = actorIndex(before);
+      for (const actor of Array.isArray(after.actors) ? after.actors : []) {
+        const start = beforeActors.get(actor.id);
+        if (!start) continue;
+        const endStacks = [...grantsByKey(actor).values()].reduce((sum, entry) => sum + entry.stacks, 0);
+        const startStacks = [...grantsByKey(start).values()].reduce((sum, entry) => sum + entry.stacks, 0);
+        const vitalRose = VITAL_NAMES.some((name, kind) => {
+          const end = vitalOf(actor, kind);
+          const begin = vitalOf(start, kind);
+          return isObject(end) && isObject(begin)
+            && (end.current > begin.current || end.max > begin.max || end.regen > begin.regen);
+        });
+        if (endStacks > startStacks || vitalRose) acquired.add(kindById.get(actor.id) || 'unknown');
+      }
+    }
+    results.actor_kind_parity = events.length === 0
+      ? unavailable(units.actor_kind_parity, 'no resource was collected, so no actor kind can be shown to consume')
+      : metric(acquired.size / kinds.size, units.actor_kind_parity);
+  }
+
+  return results;
+}
+
 function extractExecutionMetrics(artifacts, contract) {
   const stats = artifactStats(artifacts);
   const units = Object.fromEntries(Object.entries(contract.metrics).map(([name, value]) => [name, value.unit]));
@@ -200,6 +472,7 @@ function extractExecutionMetrics(artifacts, contract) {
     liveness: metric(stats.requestedTicks ? stats.activeTicks.size / stats.requestedTicks : NaN, units.liveness),
     spatial_progress: metric(stats.walkable ? stats.moveKeys.size / stats.walkable : NaN, units.spatial_progress),
   });
+  Object.assign(results, extractResourceMetrics(artifacts, units));
   return { metrics: results, stats };
 }
 
@@ -649,9 +922,14 @@ function loadWorldStateCheckpoints(runDir, expectedTicks = []) {
     } catch (error) {
       throw new Error(`invalid world-state checkpoint JSON ${filePath}: ${error.message}`);
     }
-    if (!isObject(state) || state.schema !== 'agent-kernel/WorldStateArtifact' || state.schemaVersion !== 1
+    // v2 required, not merely preferred: the resource metrics below read
+    // `state.resources`, and a v1 checkpoint would make every one of them look
+    // like a world containing no resources rather than a snapshot that cannot
+    // answer the question.
+    if (!isObject(state) || state.schema !== 'agent-kernel/WorldStateArtifact' || state.schemaVersion !== 2
       || !isObject(state.meta) || !isObject(state.dimensions)
-      || !Array.isArray(state.actors) || !Array.isArray(state.hazards)) {
+      || !Array.isArray(state.actors) || !Array.isArray(state.hazards)
+      || !Array.isArray(state.resources)) {
       throw new Error(`invalid WorldStateArtifact checkpoint: ${filePath}`);
     }
     if (state.tick !== expectedTick) {


### PR DESCRIPTION
Closes the evidence gap flagged when E5d3 landed: the execution contract declared nine resource metrics and the evaluator extracted none, so the five EX-RS scenarios could never qualify.

## The missing field

A world-state snapshot carried `actors` and `hazards`. Nothing on disk distinguished a resource still on the map from one already collected — so the metrics had nothing to read.

**v2 adds `resources`**: each one still on the map, with independent `vital` (kind, delta, mode, regen) and `affinity` (kind, expression, stacks, mana, manaRegen) payloads, `null` where a half is absent. V1 is retained; artifacts written before this are valid v1 documents.

`resources` is **required** in v2 rather than optional, which is why this bumps the version instead of adding quietly: an absent field must mean "predates resources", not "this world has none". The checkpoint reader rejects v1 for the same reason — read as an empty map it would score every resource metric zero with nothing to say so.

## The metrics

All nine follow from one observation. Collection is destructive, so a resource present in one checkpoint and gone from the next was taken in between, and the collecting actor's vitals and grants in those two snapshots say what the pickup did.

`single_consumption` · `pickup_apply_correctness` · `persistent_vital_grant` · `recovery_curve` · `affinity_lifecycle` · `affinity_activity` · `grant_isolation` · `actor_kind_parity` · `persistent_stacking`

Contract metric coverage: **36/56 → 45/56**.

Absence of evidence stays absence of evidence — a scenario where no grant ever expired reports `grant_isolation` unavailable rather than 1. The deliberate exception is `single_consumption`, which scores **0** for a resource nobody collected, because "resource consumes once" is false in that run.

## A correction a real run forced

`actor_kind_parity` first defined acquisition as a gained grant or raised ceiling, excluding current-vital gains so regeneration could not credit an idle actor. A real EX-RS-01 run that visibly collected its resource scored **0**, because a consumable health grant moves only `current`. Acquisition is now measured inside a consumption window, tying the change to a pickup rather than to run-wide drift. The same run then scored 1.

## Verified against real runs, not fixtures

`ak run` over EX-RS-01 with checkpoints at 0/5/10/20 produced `resources 1 → 0 → 0 → 0` and health `5 → 10`, scoring `single_consumption 1`, `pickup_apply_correctness 1`, `recovery_curve 1`, `actor_kind_parity 1` — with the affinity and persistence metrics correctly unavailable for a consumable-health scenario.

Perturbation: the same fixture with the resource off the actor's path scored `single_consumption 0` and reported dependent metrics unavailable rather than inventing values.

## Gates

- Suite: 416 files, 3177 passed, 5 failed, 207 skipped — the 5 are `74a5837`'s pre-existing intentional red Z.5 baseline
- Typecheck: 0 (it caught the one real slip: v1 replaced rather than kept alongside v2) · syntax gate clean

## Still open

11 of 56 metrics have no extractor — `survival_plausibility`, `affinity_sensitivity`, `endurance_curve`, `damage_regen_interplay`, `trigger_correctness`, `directional_displacement`, `stability`, `long_run_integrity`, `resource_bounds`, `determinism`, `seed_sensitivity` — the combat, hazard and stress families plus the replay-dependent pair. They report `evidence_unavailable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)