### PR TITLE
fix(benchmark): stop offering the model resource fields the CLI rejects

### DIFF
--- a/tests/tools/remote-ollama-resource-spec-alignment.test.js
+++ b/tests/tools/remote-ollama-resource-spec-alignment.test.js
@@ -1,0 +1,82 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+const { AK_CREATE_TOOL } = require("../../tools/remote-ollama-control/scripts/lib/ak-tool-schema");
+const { normalizeToolArgs, REPO_ROOT } = require("../../tools/remote-ollama-control/scripts/lib/ak-runner");
+
+// The CLI is the authority on which resource fields exist. Read its allow-list out of the
+// source rather than restating it here: a copy would keep passing after the CLI moved on,
+// which is exactly how the 2026-08-22 run lost 73 of 700 attempts to fields the benchmark
+// advertised and the parser rejected.
+function cliV3ResourceFields() {
+  const source = readFileSync(
+    join(REPO_ROOT, "packages/adapters-cli/src/cli/ak-impl.mjs"),
+    "utf8",
+  );
+  const marker = "// V3: a vital payload";
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, "the V3 resource branch moved — this test must be re-anchored");
+  const block = source.slice(start, source.indexOf("]);", start));
+  const fields = [...block.matchAll(/"([A-Za-z][A-Za-z0-9]*)"/g)].map((match) => match[1]);
+  assert.ok(fields.length >= 5, "failed to read the V3 allow-list out of the CLI");
+  return new Set(fields);
+}
+
+function schemaResourceFields() {
+  const resource = AK_CREATE_TOOL.function.parameters.properties.resource;
+  return new Set(Object.keys(resource.items.properties));
+}
+
+test("every resource field offered to the model is one the CLI's V3 parser accepts", () => {
+  const allowed = cliV3ResourceFields();
+  const offered = [...schemaResourceFields()];
+  const rejected = offered.filter((field) => !allowed.has(field));
+  assert.deepEqual(
+    rejected,
+    [],
+    `the tool schema offers resource fields the CLI rejects: ${rejected.join(", ")}`,
+  );
+});
+
+test("no required-field combination steers the model into a shape the CLI rejects", () => {
+  const allowed = cliV3ResourceFields();
+  const resource = AK_CREATE_TOOL.function.parameters.properties.resource;
+  const required = (resource.items.anyOf || []).flatMap((branch) => branch.required || []);
+  const rejected = required.filter((field) => !allowed.has(field));
+  assert.deepEqual(rejected, [], `anyOf demands fields the CLI rejects: ${rejected.join(", ")}`);
+});
+
+test("the resource description does not promise support the CLI withdrew", () => {
+  const resource = AK_CREATE_TOOL.function.parameters.properties.resource;
+  const allowed = cliV3ResourceFields();
+  for (const field of ["tier", "stat", "dropRate"]) {
+    if (allowed.has(field)) continue;
+    assert.doesNotMatch(
+      resource.description,
+      new RegExp(field, "i"),
+      `the description advertises "${field}", which the CLI no longer accepts`,
+    );
+  }
+});
+
+test("normalization never adds a resource field the CLI would reject", () => {
+  const allowed = cliV3ResourceFields();
+  // The shape the model actually produced in the 2026-08-22 run: a V3 payload with legacy
+  // fields blended in. Normalization is the last chance to drop them before argv is built.
+  const normalized = normalizeToolArgs({
+    resource: [
+      { permanenceMode: "permanent", vital: "mana", stat: "vitalRegen", delta: 1 },
+      { tier: "level", stat: "vitalMax", delta: 8 },
+      { affinity: "life", expression: "emit", stacks: 1, mana: 4, dropRate: 10 },
+    ],
+  });
+  for (const spec of normalized.resource) {
+    const rejected = Object.keys(spec).filter((field) => !allowed.has(field));
+    assert.deepEqual(
+      rejected,
+      [],
+      `normalization emitted ${rejected.join(", ")} for ${JSON.stringify(spec)}`,
+    );
+  }
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-runner.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-runner.js
@@ -83,25 +83,16 @@ function normalizeEntitySpec(key, spec) {
   }
 
   if (key === 'resource') {
-    // Inject dropRate default when model omits it
-    if (out.tier && out.stat && out.delta != null && out.dropRate == null) {
-      out.dropRate = 10;
-    }
-    // Map natural stat names to canonical internal names
-    const STAT_ALIASES = {
-      health: 'vitalMax', mana: 'vitalMax', stamina: 'vitalMax', durability: 'vitalMax',
-      max_health: 'vitalMax', max_mana: 'vitalMax', max_stamina: 'vitalMax', max_durability: 'vitalMax',
-      health_regen: 'vitalRegen', mana_regen: 'vitalRegen', stamina_regen: 'vitalRegen',
-      regen_health: 'vitalRegen', regen_mana: 'vitalRegen', regen_stamina: 'vitalRegen',
-      affinity_stack: 'affinityStack', affinitystack: 'affinityStack',
-      push_expression: 'pushExpression', pushexpression: 'pushExpression',
-    };
-    if (out.stat && typeof out.stat === 'string') {
-      out.stat = STAT_ALIASES[out.stat.toLowerCase()] ?? out.stat;
-    }
     // Strip unsupported aggregate/model-invented fields. The canonical V3
     // affinity field is deliberately retained for temporary/permanent grants.
-    for (const f of ['vitals', 'affinities', 'goals', 'kind']) {
+    //
+    // tier/stat/dropRate are the pre-V3 resource vocabulary. The CLI rejects them
+    // outright once any V3 key (permanenceMode, vital, affinity) appears in the same
+    // spec, and models blend the two vocabularies freely — that blend cost 73 of 700
+    // attempts on 2026-08-22. Dropping them here is the last point before argv is
+    // built; the tool schema no longer offers them, so a model that still emits one
+    // is improvising rather than following the contract.
+    for (const f of ['vitals', 'affinities', 'goals', 'kind', 'tier', 'stat', 'dropRate']) {
       delete out[f];
     }
   }

--- a/tools/remote-ollama-control/scripts/lib/ak-tool-schema.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-tool-schema.js
@@ -17,7 +17,6 @@ const MOTIVATION_ENUM = [
 const SIZE_ENUM = ['small', 'medium', 'large'];
 const PRIORITY_ENUM = ['high', 'medium', 'low'];
 const GOAL_KIND_ENUM = ['max_mana', 'mana_regen', 'maximize_spend'];
-const RESOURCE_STAT_ENUM = ['vitalMax', 'vitalRegen', 'affinity', 'affinityStack', 'pushExpression'];
 
 const VITAL_CONFIG = {
   type: 'object',
@@ -178,7 +177,7 @@ const AK_CREATE_TOOL = {
         },
         resource: {
           type: 'array',
-          description: 'Resource pickups carrying a vital payload, an affinity payload, or both. Legacy tier/stat specs remain supported.',
+          description: 'Resource pickups carrying a vital payload, an affinity payload, or both.',
           items: {
             type: 'object',
             properties: {
@@ -191,19 +190,11 @@ const AK_CREATE_TOOL = {
               stacks: { type: 'integer', minimum: 1 },
               mana: { type: 'integer', minimum: 0 },
               manaRegen: { type: 'integer', minimum: 0 },
-              tier: { type: 'string', enum: ['level', 'permanent'] },
-              stat: {
-                type: 'string',
-                enum: RESOURCE_STAT_ENUM,
-                description: 'vitalMax=raise a stat cap, vitalRegen=raise regen, affinity=grant affinity expression, affinityStack=add affinity stacks, pushExpression=grant push'
-              },
-              delta: { type: 'number', description: 'Amount to apply' },
-              dropRate: { type: 'number', minimum: 0, maximum: 100, description: 'Drop chance 0–100' }
+              delta: { type: 'number', description: 'Amount to apply' }
             },
             anyOf: [
               { required: ['vital'] },
-              { required: ['affinity', 'expression', 'stacks', 'mana'] },
-              { required: ['tier', 'stat', 'delta'] }
+              { required: ['affinity', 'expression', 'stacks', 'mana'] }
             ]
           }
         },
@@ -222,4 +213,4 @@ const AK_CREATE_TOOL = {
   }
 };
 
-module.exports = { AK_CREATE_TOOL, AFFINITY_ENUM, EXPRESSION_ENUM, MOTIVATION_ENUM, GOAL_KIND_ENUM, RESOURCE_STAT_ENUM };
+module.exports = { AK_CREATE_TOOL, AFFINITY_ENUM, EXPRESSION_ENUM, MOTIVATION_ENUM, GOAL_KIND_ENUM };


### PR DESCRIPTION
## What this fixes

The 2026-08-22 content-gen qualification run lost **73 of 700 attempts** to
`resource[N] field "dropRate" is not supported in V3 spec` and the same for `stat`.

The model was not improvising. `ak-tool-schema.js` advertised `tier`, `stat` and `dropRate`
next to the V3 fields, declared a `{tier, stat, delta}` required-combination, and its
description promised *"Legacy tier/stat specs remain supported"*. The CLI's V3 branch accepts
only `id, permanenceMode, vital, delta, regen, affinity, expression, stacks, mana, manaRegen`,
and switches to V3 the moment `permanenceMode`, `vital` or `affinity` appears anywhere in the
spec. Two mutually exclusive vocabularies were both on offer, with nothing marking the
boundary — and the failing shapes are exactly the blends:

| shape the model emitted | count |
|---|---|
| `{delta, dropRate, permanenceMode, vital}` | 23 |
| `{affinity, dropRate, expression, mana, stacks}` | 17 |
| `{affinity, dropRate, expression, mana, permanenceMode, stacks}` | 12 |

The harness also manufactured collisions on its own: `normalizeToolArgs` injected
`dropRate: 10` whenever it saw `tier`+`stat`+`delta`, so a spec the model never wrote could
still be rejected downstream.

## Changes

- `ak-tool-schema.js` is V3-only: `tier`, `stat`, `dropRate`, the legacy `anyOf` branch, the
  now-unused `RESOURCE_STAT_ENUM`, and the misleading description are gone.
- `ak-runner.js` strips `tier`/`stat`/`dropRate` as model-invented instead of aliasing them
  into a shape the CLI refuses.

## Tests

`tests/tools/remote-ollama-resource-spec-alignment.test.js` reads the CLI's own allow-list out
of `ak-impl.mjs` rather than restating it — a hardcoded copy is what let this drift survive
unnoticed. Four cases: fields offered, fields required by `anyOf`, the description text, and
what normalization emits.

- tests/tools: **21 files / 195 passed**, 11 skipped
- Perturbation: re-adding `dropRate` to the schema turns the first test red naming that field;
  removing it again restores green.

## Deliberately not changed

- **The `matrix_incomplete` gate** (`ak-compare.js:95`). I first read it as unsatisfiable
  because it compares `completePasses` against `maximumPasses` while the policy sets
  `minimumCompletePasses: 1`. That was wrong: early stop fires only via `canStillQualify()`, so
  a configuration stops short only when nothing could rescue it. Relaxing the comparison would
  let a doomed run clear a completeness gate.
- **The 100-scenario catalog**, which still carries pure-legacy reference specs
  (`tier=permanent;stat=vitalRegen;delta=1;dropRate=10`). Those parse — with no V3 key present
  the CLI takes the legacy branch. Editing them changes `scenarioSet.sha256` and breaks
  comparability with the run that produced this evidence. Whether the catalog should migrate to
  V3 is a separate call.

## Attribution note

This touches the `ak_create` tool schema and entity normalization, so a change in the next
nightly result is attributable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)