### PR TITLE
fix(z3): the solver stops chasing allies, which DS.2 fixed only on the other path

### DIFF
--- a/packages/adapters-cli/src/adapters/z3/index.js
+++ b/packages/adapters-cli/src/adapters/z3/index.js
@@ -43,14 +43,37 @@ function movesCloserTo(candidate, origin, targets) {
   });
 }
 
+/**
+ * Whether the Actor persona ruled this visible actor an enemy.
+ *
+ * ⚠️ **Absent means HOSTILE, and the direction of that default is load-bearing.**
+ * Only `hostile === false` is an ally. Every envelope built before hostility was
+ * threaded carries no such field, and a fixture or an older run must keep
+ * behaving as it did rather than quietly pacifying: an adapter that read a
+ * missing flag as "allied" would stop pursuing anyone at all, in every one of
+ * them, while every ally-targeting test still passed.
+ *
+ * This adapter does NOT compare roles. Which roles are allied is the Actor
+ * persona's ruling (`rolesAreAllied`, `personas/actor/controller.js`), including
+ * a fail-safe that two MISSING roles must not compare equal. Re-deriving it here
+ * would make this file a second allegiance authority, free to drift from the
+ * first.
+ */
+function isHostile(visibleActor) {
+  return visibleActor?.hostile !== false;
+}
+
 function scoreCandidate(candidate, envelope) {
   if (candidate?.action?.kind === "attack") {
     return { score: PRIORITY_WEIGHTS.attack, ruleId: "attack" };
   }
 
   const actorPosition = envelope.actor?.position;
+  // Allies are excluded before the distance test, not after: `visibleActors` is
+  // everyone this actor perceives, and treating the whole list as enemies is
+  // what sent delvers chasing their own delvers on this path.
   const visiblePositions = Array.isArray(envelope.visibleActors)
-    ? envelope.visibleActors.map((actor) => actor?.position).filter(Boolean)
+    ? envelope.visibleActors.filter(isHostile).map((actor) => actor?.position).filter(Boolean)
     : [];
   if (movesCloserTo(candidate, actorPosition, visiblePositions)) {
     return {

--- a/packages/adapters-web/src/adapters/z3/index.js
+++ b/packages/adapters-web/src/adapters/z3/index.js
@@ -53,14 +53,37 @@ function movesCloserTo(candidate, origin, targets) {
   });
 }
 
+/**
+ * Whether the Actor persona ruled this visible actor an enemy.
+ *
+ * ⚠️ **Absent means HOSTILE, and the direction of that default is load-bearing.**
+ * Only `hostile === false` is an ally. Every envelope built before hostility was
+ * threaded carries no such field, and a fixture or an older run must keep
+ * behaving as it did rather than quietly pacifying: an adapter that read a
+ * missing flag as "allied" would stop pursuing anyone at all, in every one of
+ * them, while every ally-targeting test still passed.
+ *
+ * This adapter does NOT compare roles. Which roles are allied is the Actor
+ * persona's ruling (`rolesAreAllied`, `personas/actor/controller.js`), including
+ * a fail-safe that two MISSING roles must not compare equal. Re-deriving it here
+ * would make this file a second allegiance authority, free to drift from the
+ * first.
+ */
+function isHostile(visibleActor) {
+  return visibleActor?.hostile !== false;
+}
+
 function scoreCandidate(candidate, envelope) {
   if (candidate?.action?.kind === "attack") {
     return { score: PRIORITY_WEIGHTS.attack, ruleId: "attack" };
   }
 
   const actorPosition = envelope.actor?.position;
+  // Allies are excluded before the distance test, not after: `visibleActors` is
+  // everyone this actor perceives, and treating the whole list as enemies is
+  // what sent delvers chasing their own delvers on this path.
   const visiblePositions = Array.isArray(envelope.visibleActors)
-    ? envelope.visibleActors.map((actor) => actor?.position).filter(Boolean)
+    ? envelope.visibleActors.filter(isHostile).map((actor) => actor?.position).filter(Boolean)
     : [];
   if (movesCloserTo(candidate, actorPosition, visiblePositions)) {
     return {

--- a/packages/runtime/src/personas/actor/README.md
+++ b/packages/runtime/src/personas/actor/README.md
@@ -106,6 +106,12 @@ When runtime decisioning is enabled for an actor or boss, the Actor persona now 
 envelope from live observation plus candidate-action context and emits it through the existing `solver_request`
 pipeline. Solver-selected decisions are normalized back into executable `Action` records on the same runtime rail.
 
+Each entry in the envelope's `visibleActors` carries a boolean `hostile`, which is **this persona's ruling and not a
+raw fact about the other actor**: delvers ally with delvers, wardens with wardens, and an unknown role is always
+hostile. Solvers and other consumers must read that field rather than compare `role` themselves — allegiance has one
+authority here, and a consumer that re-derives it is free to disagree with the deterministic path. Absent means
+hostile, so an envelope built before this field existed keeps its previous behavior instead of quietly pacifying.
+
 Live LLM-backed runtime decisions are not implicit. Default execution remains deterministic and replay-safe:
 - solver-first during execution
 - LLM only from pre-captured/deferred structured responses

--- a/packages/runtime/src/personas/actor/controller.js
+++ b/packages/runtime/src/personas/actor/controller.js
@@ -309,8 +309,30 @@ function buildRuntimeDecisionCandidateActions({ actor, actorId, tick, proposals 
   return baseCandidates;
 }
 
+/**
+ * The other actors this one can see, each carrying the Actor's own hostility
+ * ruling for it.
+ *
+ * ⚠️ **`hostile` is stamped here so the SOLVER path cannot reach a different
+ * answer than the deterministic one.** `resolveNearestHostile` below applies
+ * `rolesAreAllied` and skips allies; the Z3 adapter ranks `visibleActors` and
+ * had no faction concept at all, so a run routed through the solver kept
+ * closing on its own allies after DS.2 fixed the other path. Sending the ruling
+ * rather than the raw roles keeps ONE allegiance authority: an adapter that
+ * compared roles itself would be free to disagree with this function — and
+ * would have to re-derive the fail-safe in `rolesAreAllied`, which is exactly
+ * the kind of quietly divergent second rule (F10) this codebase has removed
+ * once already.
+ *
+ * The self role is read from the observation, the same source
+ * `resolveNearestHostile` reads, so the two paths agree by construction rather
+ * than by coincidence. `hostile` is always present and always a boolean:
+ * unknown roles resolve to `true`, never to a missing field, because a consumer
+ * defaulting an absent flag has to guess and half of them would guess "allied".
+ */
 function resolveVisibleActors(view, actorId) {
   const actors = Array.isArray(view?.actors) ? view.actors : [];
+  const selfRole = actors.find((entry) => entry && entry.id === actorId)?.role;
   return actors
     .filter((entry) => entry && entry.id && entry.id !== actorId)
     .map((entry) => {
@@ -321,6 +343,7 @@ function resolveVisibleActors(view, actorId) {
       if (entry.role !== undefined) next.role = entry.role;
       if (entry.position) next.position = { ...entry.position };
       if (entry.vitals) next.vitals = JSON.parse(JSON.stringify(entry.vitals));
+      next.hostile = !rolesAreAllied(selfRole, entry.role);
       return next;
     });
 }

--- a/tests/architecture/z3-adapter-copies-in-sync.test.js
+++ b/tests/architecture/z3-adapter-copies-in-sync.test.js
@@ -1,0 +1,88 @@
+/**
+ * The two real-Z3 adapter copies must not drift apart.
+ *
+ * WHY THERE ARE TWO. `adapters-cli` and `adapters-web` each own their own solver
+ * implementation, and this repo has NO internal package.json dependency edges —
+ * every cross-package reference is relative-path only. An
+ * adapters-web -> adapters-cli import would be a lateral adapter-to-adapter
+ * dependency the architecture does not sanction, so Z.5 duplicated the file
+ * deliberately and said so in the web copy's header: *"Keep the two files in
+ * sync by hand until/unless a shared adapter package is introduced."*
+ *
+ * WHY THIS GUARD EXISTS. "By hand" was the entire mechanism. Nothing checked it:
+ * `tests/runtime/z3-real-adapter-conformance.test.js` imports only the CLI copy,
+ * so every behavioral assertion in the repo — conformance, determinism, ranking,
+ * and the faction-aware scoring this guard shipped beside — passes while the
+ * browser's copy says something else entirely. ⇒ *A duplicate with no equality
+ * check is not a duplicate, it is a fork with a comment asking politely.*
+ *
+ * WHAT IS COMPARED. Everything after each file's leading block comment, byte for
+ * byte. The headers legitimately differ — the web copy carries the paragraph
+ * explaining the duplication — and only the headers may. Comparing the code
+ * rather than a behavior sample is the point: a guard that checked "both export
+ * createRealZ3SolverAdapter" would pass against two arbitrarily different
+ * rankers, which is the spelling-versus-concept trap this repo keeps re-finding.
+ *
+ * WHEN THIS FAILS, the fix is to copy the change across — never to relax the
+ * comparison. If the duplication is ever replaced by a shared package, delete
+ * this file in that diff rather than leaving it asserting something untrue.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
+
+const ROOT = resolve(__dirname, "../..");
+
+const CLI_COPY = "packages/adapters-cli/src/adapters/z3/index.js";
+const WEB_COPY = "packages/adapters-web/src/adapters/z3/index.js";
+
+/**
+ * Drop the single leading block comment, which is the only part allowed to
+ * differ. Anything else — imports, constants, every line of the ranking — must
+ * match exactly.
+ */
+function bodyOf(relativePath) {
+  const source = readFileSync(resolve(ROOT, relativePath), "utf8");
+  const end = source.indexOf("*/");
+  assert.ok(
+    source.trimStart().startsWith("/*") && end !== -1,
+    `${relativePath} no longer opens with a block comment, so this guard cannot tell its header `
+      + "from its code. Restore the header or rewrite the comparison — do not delete the guard.",
+  );
+  return source.slice(end + 2).trim();
+}
+
+test("the adapters-cli and adapters-web Z3 adapters are identical below their headers", () => {
+  assert.equal(
+    bodyOf(WEB_COPY),
+    bodyOf(CLI_COPY),
+    `${WEB_COPY} has drifted from ${CLI_COPY}. These are deliberate copies kept in sync by hand, `
+      + "and only the CLI one is exercised by the conformance and scoring suites — so a change "
+      + "applied to one of them means the browser and the CLI now decide actor actions "
+      + "differently, with every test in the repo still green. Copy the change across.",
+  );
+});
+
+test("only the CLI copy is covered by the behavioral suites — which is why the guard above exists", () => {
+  const conformance = readFileSync(
+    resolve(ROOT, "tests/runtime/z3-real-adapter-conformance.test.js"),
+    "utf8",
+  );
+  assert.ok(
+    conformance.includes("adapters-cli/src/adapters/z3/index.js"),
+    "the conformance suite no longer loads the CLI copy",
+  );
+  assert.ok(
+    !conformance.includes("adapters-web/src/adapters/z3/index.js"),
+    "the conformance suite now loads the web copy too. That is an improvement, not a failure — "
+      + "update or remove this test to say what the coverage actually is, rather than leaving a "
+      + "claim here that has stopped being true.",
+  );
+});
+
+// ## TODO: Test Permutations
+// - a probe copy differing only in whitespace inside a function body: must FAIL (byte comparison)
+// - a probe copy differing only in its leading header: must PASS
+// - either file missing entirely: fails with a message naming which one

--- a/tests/personas/actor/actor-hostility-reaches-decision-envelope.test.js
+++ b/tests/personas/actor/actor-hostility-reaches-decision-envelope.test.js
@@ -1,0 +1,150 @@
+/**
+ * The Actor's hostility ruling must REACH the decision envelope, not stop at
+ * the deterministic path.
+ *
+ * THE DEFECT THIS FORBIDS, and why it is worth its own file. DS.2 taught this
+ * program the difference between a rule that is correct and a rule that is
+ * reachable: `rolesAreAllied` was right the day it was written and completely
+ * inert in production, because the data it read was never populated. The
+ * persona suite was green throughout. ⇒ *A rule the solver path cannot see is a
+ * rule that is not enforced, and nothing about the deterministic path's tests
+ * would ever say so.*
+ *
+ * So this file asserts the SPECIFIC VALUES on the envelope — `hostile: false`
+ * for the ally and `hostile: true` for the warden — rather than that the field
+ * exists. A shape test here would pass against a stub that stamped `hostile`
+ * on everything, which is exactly the ally-targeting bug wearing a new field.
+ *
+ * Companion: `tests/runtime/z3-faction-aware-scoring.test.js` covers the other
+ * half — that the adapter consumes this flag once it arrives. Neither test is
+ * sufficient alone: the adapter test would pass against an envelope nothing
+ * ever stamps, and this one would pass against an adapter that ignores it.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+
+function makeFloorGrid(w, h) {
+  return Array.from({ length: h }, (_, y) =>
+    Array.from({ length: w }, (_, x) =>
+      x === 0 || x === w - 1 || y === 0 || y === h - 1 ? "#" : "."
+    ).join("")
+  );
+}
+
+const BASE_TILES = makeFloorGrid(7, 3);
+
+// delver_a(1,1) — delver_b(2,1) ally — warden_1(4,1) enemy
+const OBSERVATION = Object.freeze({
+  actors: [
+    { id: "delver_a", kind: 2, position: { x: 1, y: 1 }, role: "delver", motivation: { kind: "attacking" } },
+    { id: "delver_b", kind: 2, position: { x: 2, y: 1 }, role: "delver", motivation: { kind: "attacking" } },
+    { id: "warden_1", kind: 2, position: { x: 4, y: 1 }, role: "warden" },
+  ],
+  tiles: { baseTiles: BASE_TILES },
+  exit: { x: 5, y: 1 },
+});
+
+const RUNTIME_DECISIONING = Object.freeze({
+  enabled: true,
+  mode: "solver",
+  preferred: "solver",
+  targetAdapter: "z3",
+});
+
+async function solverEnvelopeFor(actorId, observation = OBSERVATION) {
+  const [{ createActorPersona }, { TickPhases }] = await Promise.all([
+    import("../../../packages/runtime/src/personas/actor/persona.js"),
+    import("../../../packages/runtime/src/personas/_shared/tick-state-machine.mts"),
+  ]);
+  const persona = createActorPersona({ clock: () => "fixed" });
+  const payload = {
+    actorId,
+    observation,
+    baseTiles: BASE_TILES,
+    runtimeDecisioning: RUNTIME_DECISIONING,
+  };
+  persona.advance({ phase: TickPhases.OBSERVE, event: "observe", payload, tick: 0 });
+  persona.advance({ phase: TickPhases.DECIDE, event: "decide", payload, tick: 0 });
+  const result = persona.advance({ phase: TickPhases.DECIDE, event: "propose", payload, tick: 0 });
+
+  const solverEffect = (result.effects || []).find((effect) => effect?.kind === "solver_request");
+  assert.ok(solverEffect, "the actor emitted no solver request, so there is no envelope to inspect");
+  return solverEffect.request?.problem?.data;
+}
+
+function visible(envelope, id) {
+  return (envelope?.visibleActors || []).find((entry) => entry?.id === id);
+}
+
+test("a fellow delver reaches the envelope marked NOT hostile", async () => {
+  const envelope = await solverEnvelopeFor("delver_a");
+
+  assert.equal(
+    visible(envelope, "delver_b")?.hostile,
+    false,
+    "the ally arrived at the solver with no hostility ruling, or the wrong one. The Actor owns "
+      + "what 'allied' means (`rolesAreAllied`); if that answer does not cross into the envelope, "
+      + "the solver has to guess — and its guess has been 'everyone is an enemy'.",
+  );
+});
+
+test("a warden reaches the same envelope marked hostile", async () => {
+  const envelope = await solverEnvelopeFor("delver_a");
+
+  assert.equal(
+    visible(envelope, "warden_1")?.hostile,
+    true,
+    "marking the ally is only half the ruling. If the enemy is not marked hostile the delver has "
+      + "nothing to pursue, and 'never chases an ally' would be satisfied by an actor that chases "
+      + "nobody at all.",
+  );
+});
+
+test("the warden's own envelope inverts both — hostility is relative to the observer", async () => {
+  const envelope = await solverEnvelopeFor("warden_1");
+
+  assert.equal(visible(envelope, "delver_a")?.hostile, true);
+  assert.equal(visible(envelope, "delver_b")?.hostile, true);
+});
+
+test("two wardens are allies to each other, not merely 'not delvers'", async () => {
+  const observation = {
+    ...OBSERVATION,
+    actors: [
+      { id: "warden_a", kind: 2, position: { x: 1, y: 1 }, role: "warden", motivation: { kind: "attacking" } },
+      { id: "warden_b", kind: 2, position: { x: 2, y: 1 }, role: "warden" },
+      { id: "delver_1", kind: 2, position: { x: 4, y: 1 }, role: "delver" },
+    ],
+  };
+  const envelope = await solverEnvelopeFor("warden_a", observation);
+
+  assert.equal(visible(envelope, "warden_b")?.hostile, false);
+  assert.equal(visible(envelope, "delver_1")?.hostile, true);
+});
+
+test("an actor with NO role marks everyone hostile — unknown must never mean allied", async () => {
+  const observation = {
+    ...OBSERVATION,
+    actors: [
+      { id: "nameless_a", kind: 2, position: { x: 1, y: 1 }, motivation: { kind: "attacking" } },
+      { id: "nameless_b", kind: 2, position: { x: 2, y: 1 } },
+    ],
+  };
+  const envelope = await solverEnvelopeFor("nameless_a", observation);
+
+  assert.equal(
+    visible(envelope, "nameless_b")?.hostile,
+    true,
+    "two actors with missing roles compared equal and were called allies. That is the exact "
+      + "failure DS.2's fail-safe exists to prevent: it pacifies every run without role data "
+      + "while every 'does not attack an ally' assertion stays green.",
+  );
+});
+
+// ## TODO: Test Permutations
+// - an actor whose role is present but empty/whitespace: still hostile to everyone
+// - roles differing only in case ("Delver" vs "delver"): allied, matching rolesAreAllied's folding
+// - a third role beyond delver/warden ("boss"): allied only with its own kind
+// - an observation where only SOME actors carry roles: the unlabelled ones stay hostile
+// - the envelope's visibleActors order matches the observation order (replay stability)

--- a/tests/runtime/z3-faction-aware-scoring.test.js
+++ b/tests/runtime/z3-faction-aware-scoring.test.js
@@ -1,0 +1,262 @@
+/**
+ * The Z3 adapter must not score closing on an ALLY as pursuing a hostile.
+ *
+ * THE DEFECT THESE TESTS FORBID (live on `main` when they were written).
+ * DS.2 made hostility role-based — `resolveNearestHostile` skips allies, so the
+ * deterministic path stopped sending delvers after their own delvers. The Z3
+ * path never got the same treatment: `scoreCandidate` maps EVERY entry of
+ * `envelope.visibleActors` into the `move_toward_hostile` rule with no faction
+ * check at all. So a run routed through the solver still closes on allies, and
+ * with the ally nearer than the enemy it prefers the ally outright.
+ *
+ * ⇒ *A rule enforced on one path and not its neighbour. That reads as enforced
+ * — the persona suite is green, the fix is committed, and the bug is still
+ * reachable in a run — which is the defect class this repo keeps re-finding.*
+ *
+ * WHERE THE RULE LIVES, AND WHY NOT HERE. The adapter does NOT compare roles.
+ * Hostility is domain semantics owned by the Actor persona (`rolesAreAllied`,
+ * `personas/actor/controller.js`), including a fail-safe that is easy to get
+ * backwards: two MISSING roles must not compare equal, or every actor becomes
+ * everyone's ally and combat stops game-wide. Re-deriving that inside an adapter
+ * would be a second allegiance authority, quietly divergent from the first —
+ * the F10 defect this codebase has already paid for once. The persona stamps
+ * `hostile` on each visible actor; the adapter consumes it and nothing else.
+ *
+ * ⚠️ **ABSENT MEANS HOSTILE, and one test below exists only to forbid the
+ * opposite.** An envelope with no `hostile` field must behave exactly as it does
+ * today. Defaulting an unknown to "allied" would pacify every run whose envelope
+ * predates this change — and would leave every ally-targeting assertion here
+ * green while doing it.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+
+async function loadAdapter() {
+  return import("../../packages/adapters-cli/src/adapters/z3/index.js");
+}
+
+/**
+ * A delver at (5,5) with an ally 2 tiles WEST and a warden 4 tiles EAST.
+ *
+ * ⚠️ **The two are on OPPOSITE SIDES on purpose, and the test is worthless
+ * otherwise.** Put them both east and the ally-ward move closes on the warden
+ * as well, so it scores `move_toward_hostile` for a legitimate reason and the
+ * test passes without the rule ever being consulted. Each move here approaches
+ * exactly one of them and retreats from the other.
+ *
+ * ⚠️ The ally-ward move is deliberately FIRST in `candidateActions`. The
+ * adapter's tie-break is candidate input order, so with both moves scored
+ * `move_toward_hostile` (the pre-fix behavior) the ally move wins outright —
+ * which is what makes this red before the fix rather than accidentally green.
+ */
+function allyAndEnemyBoard() {
+  return {
+    contract: "runtime-decision-v1",
+    decisionKind: "next_move",
+    tick: 4,
+    actor: { id: "delver_a", role: "delver", position: { x: 5, y: 5 } },
+    visibleActors: [
+      // The ally is the NEARER of the two — the arrangement that made the old
+      // rule pick wrong, rather than one where it happened to pick right.
+      { id: "delver_b", role: "delver", position: { x: 3, y: 5 }, hostile: false },
+      { id: "warden_1", role: "warden", position: { x: 9, y: 5 }, hostile: true },
+    ],
+    candidateActions: [
+      {
+        id: "move_toward_ally",
+        action: { kind: "move", actorId: "delver_a", tick: 4, params: { to: { x: 4, y: 5 } } },
+      },
+      {
+        id: "move_toward_warden",
+        action: { kind: "move", actorId: "delver_a", tick: 4, params: { to: { x: 6, y: 5 } } },
+      },
+      { id: "wait_here", action: { kind: "wait", actorId: "delver_a", tick: 4, params: {} } },
+    ],
+    objectives: { primary: "resolve_visible_contacts" },
+  };
+}
+
+function rankOf(result, candidateActionId) {
+  const ranked = result?.model?.rankedCandidates || [];
+  return ranked.find((entry) => entry.candidateActionId === candidateActionId);
+}
+
+// ---------------------------------------------------------------------------
+// The fix itself: an ally is not a hostile, so closing on one is not pursuit.
+// ---------------------------------------------------------------------------
+
+test("the solver never treats closing on an ally as pursuing a hostile", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const result = await createRealZ3SolverAdapter().solve({
+    problem: { data: allyAndEnemyBoard() },
+  });
+
+  assert.equal(result.status, "fulfilled", JSON.stringify(result));
+  const allyMove = rankOf(result, "move_toward_ally");
+  assert.notEqual(
+    allyMove?.ruleId,
+    "move_toward_hostile",
+    "the adapter scored a move toward a FELLOW DELVER as hostile pursuit. `visibleActors` is "
+      + "every actor this one can see, allies included — the rule must read each entry's "
+      + "hostility rather than assuming the whole list is enemies.",
+  );
+});
+
+test("with an ally nearer than the warden, the solver still closes on the warden", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const result = await createRealZ3SolverAdapter().solve({
+    problem: { data: allyAndEnemyBoard() },
+  });
+
+  assert.equal(result.status, "fulfilled", JSON.stringify(result));
+  assert.equal(
+    result.model?.selectedActionId,
+    "move_toward_warden",
+    "'does not chase the ally' is trivially satisfied by an adapter that picks `wait` for "
+      + "everything, so this pairs with the test above: the delver must still engage the actual "
+      + "enemy. The ally move is listed first precisely so a faction-blind ranking picks it.",
+  );
+  assert.equal(rankOf(result, "move_toward_warden")?.ruleId, "move_toward_hostile");
+});
+
+test("with only allies visible, advancing to the exit beats closing on one of them", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const envelope = {
+    contract: "runtime-decision-v1",
+    decisionKind: "next_move",
+    tick: 7,
+    actor: { id: "delver_a", role: "delver", position: { x: 2, y: 2 } },
+    visibleActors: [
+      { id: "delver_b", role: "delver", position: { x: 5, y: 2 }, hostile: false },
+    ],
+    candidateActions: [
+      // Genuinely closes on the ally (Chebyshev 3 -> 2), so a faction-blind
+      // ranking scores it `move_toward_hostile` (80) and it beats the exit (50).
+      {
+        id: "move_toward_ally",
+        action: { kind: "move", actorId: "delver_a", tick: 7, params: { to: { x: 3, y: 2 } } },
+      },
+      {
+        id: "move_toward_exit",
+        action: { kind: "move", actorId: "delver_a", tick: 7, params: { to: { x: 1, y: 2 } } },
+      },
+    ],
+    objectives: { primary: "advance_to_exit", exit: { x: 0, y: 2 } },
+  };
+
+  const result = await createRealZ3SolverAdapter().solve({ problem: { data: envelope } });
+
+  assert.equal(result.status, "fulfilled", JSON.stringify(result));
+  assert.equal(
+    result.model?.selectedActionId,
+    "move_toward_exit",
+    "a party of allies with no enemy in sight must make progress. Scoring ally-pursuit at "
+      + "`move_toward_hostile` (80) outranks `move_toward_exit` (50), so a faction-blind adapter "
+      + "leaves a delver orbiting its own teammate instead of advancing.",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The fail-safe. These forbid a fix that pacifies the game by default.
+// ---------------------------------------------------------------------------
+
+test("a visible actor with NO hostility field is still pursued — absent must never mean allied", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const envelope = {
+    contract: "runtime-decision-v1",
+    decisionKind: "next_move",
+    tick: 2,
+    actor: { id: "actor_1", position: { x: 0, y: 0 } },
+    // No `hostile`, no `role` — the shape every envelope had before this change.
+    visibleActors: [{ id: "unknown_1", position: { x: 4, y: 0 } }],
+    candidateActions: [
+      {
+        id: "move_toward_unknown",
+        action: { kind: "move", actorId: "actor_1", tick: 2, params: { to: { x: 1, y: 0 } } },
+      },
+      { id: "wait_here", action: { kind: "wait", actorId: "actor_1", tick: 2, params: {} } },
+    ],
+  };
+
+  const result = await createRealZ3SolverAdapter().solve({ problem: { data: envelope } });
+
+  assert.equal(result.status, "fulfilled", JSON.stringify(result));
+  assert.equal(
+    rankOf(result, "move_toward_unknown")?.ruleId,
+    "move_toward_hostile",
+    "an unlabelled actor was treated as an ally. Every envelope built before this change carries "
+      + "no hostility field at all, so defaulting absent to 'allied' would stop the solver "
+      + "pursuing anyone in any of them — a game-wide ceasefire that every ally-targeting test "
+      + "in this file would still call correct.",
+  );
+});
+
+test("an explicit hostile: true is pursued even when a role would suggest otherwise", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const envelope = {
+    contract: "runtime-decision-v1",
+    decisionKind: "next_move",
+    tick: 9,
+    actor: { id: "delver_a", role: "delver", position: { x: 0, y: 0 } },
+    // Same role as the observer, but the persona has ruled it hostile. The
+    // adapter consumes that ruling; it does not second-guess it by comparing
+    // roles itself, because it is not the authority on what a role means.
+    visibleActors: [{ id: "delver_turncoat", role: "delver", position: { x: 4, y: 0 }, hostile: true }],
+    candidateActions: [
+      {
+        id: "move_toward_turncoat",
+        action: { kind: "move", actorId: "delver_a", tick: 9, params: { to: { x: 1, y: 0 } } },
+      },
+      { id: "wait_here", action: { kind: "wait", actorId: "delver_a", tick: 9, params: {} } },
+    ],
+  };
+
+  const result = await createRealZ3SolverAdapter().solve({ problem: { data: envelope } });
+
+  assert.equal(result.status, "fulfilled", JSON.stringify(result));
+  assert.equal(
+    rankOf(result, "move_toward_turncoat")?.ruleId,
+    "move_toward_hostile",
+    "the adapter must read the hostility the persona computed, not re-derive it from `role`. "
+      + "Re-deriving would make the adapter a second allegiance authority, free to disagree with "
+      + "the first.",
+  );
+});
+
+test("attack still outranks everything, ally or not — this narrows pursuit, it does not change priority", async () => {
+  const { createRealZ3SolverAdapter } = await loadAdapter();
+  const envelope = {
+    contract: "runtime-decision-v1",
+    decisionKind: "next_move",
+    tick: 5,
+    actor: { id: "delver_a", role: "delver", position: { x: 5, y: 5 } },
+    visibleActors: [
+      { id: "delver_b", role: "delver", position: { x: 6, y: 5 }, hostile: false },
+      { id: "warden_1", role: "warden", position: { x: 4, y: 5 }, hostile: true },
+    ],
+    candidateActions: [
+      {
+        id: "move_toward_ally",
+        action: { kind: "move", actorId: "delver_a", tick: 5, params: { to: { x: 6, y: 4 } } },
+      },
+      {
+        id: "attack_warden",
+        action: { kind: "attack", actorId: "delver_a", tick: 5, params: { targetId: "warden_1" } },
+      },
+    ],
+  };
+
+  const result = await createRealZ3SolverAdapter().solve({ problem: { data: envelope } });
+
+  assert.equal(result.status, "fulfilled", JSON.stringify(result));
+  assert.equal(result.model?.selectedActionId, "attack_warden");
+});
+
+// ## TODO: Test Permutations
+// - two allies and two wardens visible: the nearer WARDEN is closed on, not the nearer ally
+// - every visible actor allied and no exit in the envelope: falls to move_fallback, never wait-only
+// - `hostile: false` on ALL entries plus an attack candidate: attack still wins
+// - hostility flag present but not a boolean (string "false", 0, null): treated as hostile
+// - the same envelope solved twice: identical selectedActionId and rankedCandidates (replay safety)
+// - ranked order is stable when an ally and an enemy tie on distance


### PR DESCRIPTION
Closes the first finding of the 2026-08-22 review: **DS.1–DS.4 landed the inputs, and nothing consumed them.** This is the one of those findings that was reachable in a run today.

## The bug

DS.2 (#75) made hostility role-based — `resolveNearestHostile` skips allies, so the deterministic path stopped sending delvers after their own delvers. The Z3 path never got the same treatment. `scoreCandidate` mapped **every** entry of `envelope.visibleActors` into the `move_toward_hostile` rule with no faction check at all, so with an ally nearer than the enemy it preferred the ally outright, and with only allies in sight it orbited a teammate instead of advancing to the exit (80 beats 50).

⇒ *A rule enforced on one path and not its neighbour reads as enforced.* The persona suite was green, DS.2 was merged, and the bug was still live in any run routed through the solver.

## The design decision: the adapter does NOT compare roles

Hostility is the Actor persona's ruling (`rolesAreAllied`), including a fail-safe that is easy to get backwards — two **missing** roles must not compare equal, or every actor becomes everyone's ally and combat stops game-wide. An adapter that re-derived allegiance would be a second authority free to drift from the first, which is the F10 defect (two affinity authorities) that AM.4 was opened to remove.

So `resolveVisibleActors` stamps a boolean `hostile` on each visible actor, and the adapter reads only that. One rule, one owner, consumed downstream.

**Absent means hostile, and the direction is load-bearing.** Only `hostile === false` is an ally, so every envelope built before this field keeps its previous behavior. The opposite default would stop the solver pursuing anyone in any pre-existing envelope — a game-wide ceasefire that every ally-targeting assertion in the new suite would still call correct. One test exists solely to forbid it.

## The sync guard

Both adapter copies are changed. They are deliberate duplicates — this repo has no internal package.json dependency edges, and an `adapters-web -> adapters-cli` import would be a lateral adapter dependency the architecture does not sanction — kept in sync *"by hand"*, where by hand was the entire mechanism. Nothing checked it, and only the CLI copy is loaded by the conformance suite, so a one-sided change would have left the browser and the CLI deciding actor actions differently with every test in the repo green.

`tests/architecture/z3-adapter-copies-in-sync.test.js` now compares everything below each file's header, byte for byte.

## Tests, written red first — 8 failing before any production code

| File | What it holds |
|---|---|
| `tests/runtime/z3-faction-aware-scoring.test.js` | the adapter honors the flag |
| `tests/personas/actor/actor-hostility-reaches-decision-envelope.test.js` | the flag is actually **populated** in production |
| `tests/architecture/z3-adapter-copies-in-sync.test.js` | the two copies cannot drift |

The second file exists because of DS.1's lesson: a rule the solver path cannot see is not enforced, and the deterministic path's tests will never say so. **Neither of the first two is sufficient alone** — the adapter test passes against an envelope nothing stamps, the persona test against an adapter that ignores it.

## Perturbations — all four run, all reddened the intended tests

| Perturbation | Result |
|---|---|
| adapter drops the `isHostile` filter | 3 adapter tests red |
| persona stops stamping `hostile` | 5 persona tests red (adapter tests stay green — why both files exist) |
| `hostile !== false` → `hostile === true` | the absent-means-hostile test red, alone |
| web copy drifts by one constant | sync guard red |

## A fixture trap worth recording

The first ally/enemy board put both actors on the **same side** of the observer, so the ally-ward move closed on the warden as well, scored `move_toward_hostile` for a legitimate reason, and passed without the new rule ever being consulted. Opposite sides is what makes it a test — caught only by checking against the pre-fix baseline.

## Gates

- Full suite **423/423 files · 3221 passed · 207 skipped · 0 failures**
- `pnpm run typecheck` **0**

## What this does NOT close

The other review findings stand: the Z3 scorer still ignores vitals (Track 1), still ignores affinities and the motivation profile (DS.5, unwritten), and `envelope.hazards` is still global because `scopeObservation` narrows actors only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
