### PR TITLE
test(allocator): characterize per-pool denial

### DIFF
--- a/tests/personas/allocator/allocator-per-pool-denial.test.js
+++ b/tests/personas/allocator/allocator-per-pool-denial.test.js
@@ -1,0 +1,53 @@
+/**
+ * Characterization for Prompt-Allocator-Per-Line-Denial.md.
+ *
+ * A positive receipt.remaining is the total-budget remainder. It does not
+ * override a category pool cap: scenario 59 spends 132 tokens from the
+ * 126-token warden pool while leaving 293 tokens unspent overall.
+ */
+const assert = require("node:assert/strict");
+const { readFileSync, rmSync, mkdtempSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const ROOT = resolve(__dirname, "../../..");
+const CLI = join(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+const SCENARIOS = join(ROOT, "tools/remote-ollama-control/benchmarks/content-gen/constrained.json");
+
+function constrainedScenario(index) {
+  const fixture = JSON.parse(readFileSync(SCENARIOS, "utf8"));
+  return fixture.scenarios.find((scenario) => scenario.index === index);
+}
+
+test("allocator denies a warden pool overspend while total budget remains", () => {
+  const scenario = constrainedScenario(59);
+  assert.equal(scenario.title, "Constrained Two Warden Patrol");
+
+  const outDir = mkdtempSync(join(tmpdir(), "ak-allocator-pool-denial-"));
+  try {
+    const result = spawnSync(process.execPath, [
+      CLI,
+      "create",
+      "--text", scenario.payload.text,
+      "--room", scenario.payload.room[0],
+      "--warden", scenario.payload.warden[0],
+      "--budget-tokens", String(scenario.payload.budgetTokens),
+      "--run-id", "allocator_pool_denial_characterization",
+      "--created-at", scenario.payload.createdAt,
+      "--emit-intermediates",
+      "--out-dir", outDir,
+    ], { cwd: ROOT, encoding: "utf8" });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Budget receipt denied: status=denied; remaining=293/);
+    assert.match(result.stderr, /deniedLines=actor:actor_spawn:wardens/);
+    assert.match(result.stderr, /deniedPools=wardens:132\/126/);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+});
+
+// ## TODO: Test Permutations
+// - an exact scenario whose active actor pool is capped at the former 55-token minimum
+// - a proposal at the pool cap remains approved when total remaining is positive


### PR DESCRIPTION
## Verdict

The Allocator is behaving as designed; the constrained benchmark catalog is miscalibrated. The issue is significant for measurement validity but small in production scope: no pricing or API defect was found, so this PR adds only the permitted real-path characterization test.

## Five-question diagnosis

1. **Is the pool split intentional? — Yes.** `buildAllocationAudit` separately totals each category pool, marks an overdrawn pool denied, and denies every line mapped to it ([validate-spend.js](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/packages/runtime/src/personas/allocator/validate-spend.js#L72-L107)). The existing unit test explicitly requires denial while total budget remains ([validate-spend-proposal.test.js](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/tests/runtime/allocator/validate-spend-proposal.test.js#L205-L227)). The charter fixes the Allocator as the sole owner of the split and spend validation ([architecture-charter.md](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/docs/architecture-charter.md#L275-L300)).

2. **How are allocations derived? — Proportional among authored categories.** `ak create` asks the Allocator for canonical weights, includes only authored kinds, and passes those weights into the build ([ak-impl.mjs](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/packages/adapters-cli/src/cli/ak-impl.mjs#L3840-L3877)). The canonical percentages are room 41, delver 20, warden 16, hazard 15, resource 8 ([base-costs.json](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/packages/runtime/src/personas/allocator/base-costs.json#L66-L73)). Omitted pools become weight zero; active weights are renormalized, floored, and leftover tokens go by largest fractional remainder with id as deterministic tie-break ([budget-allocation.js](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/packages/runtime/src/personas/allocator/budget-allocation.js#L136-L173), [budget-allocation.js](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/packages/runtime/src/personas/allocator/budget-allocation.js#L197-L294)). Default reserve is zero.

3. **Why does `actor_spawn:wardens` dominate? — Reporting order, not pricing order.** Actor items are emitted before the rest of each actor's priced payload and all share the `wardens` category ([spend-proposal.js](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/packages/runtime/src/personas/allocator/spend-proposal.js#L477-L647)). Pool overflow denies the whole category, and the error formatter shows only the first five denied lines ([orchestrate-build.js](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/packages/runtime/src/build/orchestrate-build.js#L127-L149)). Wardens are not priced last and do not absorb a global shortfall.

4. **Are “Exact” scenarios structurally invalid? — Yes, under current canonical authoring.** Deterministic fixture probes produced: 90 `65/55, remaining=-10`; 92 `58/55, -3`; 94 `58/55, 114`; 96 `64/55, 42`; 100 `116/110, 298`. Their budgets were selected so the relevant actor pool receives exactly the catalog's assumed 55 tokens per actor, but the real authored actor costs more. There is no off-by-one, reserve, or lost rounding token: allocation distributes every available token. The Exact/Under pairs therefore do not measure a one-token model boundary; the Exact success expectations are impossible, while Under passes merely reward the expected denial. Scenario definitions and stale reference spends are visible in [constrained.json](https://github.com/KomplexMojo/agent-kernel/blob/d6cd3c6/tools/remote-ollama-control/benchmarks/content-gen/constrained.json#L648-L1092).

5. **Minimal correct fix — recalibrate the benchmark scenarios, not the Allocator.** Recommended follow-up: derive each Exact budget from the current full authored spend and active-pool allocation, then set Under to one token below the true passing threshold and refresh reference spend/remaining. Retuning base costs/weights changes economy policy; allowing cross-pool borrowing removes an explicitly tested constraint; changing only the message improves clarity but not validity. All are broader than the inquiry authorized.

## Change

- Adds a fixture-backed `ak create` characterization for scenario 59, pinning `remaining=293` with `wardens:132/126` denial.
- No production code, base cost, pool split, API, or benchmark scenario changes.

## Validation

- `pnpm run test:vitest -- tests/personas/allocator` — 23 files, 113 passed
- `pnpm run test:vitest -- tests/architecture/pricing-authority.test.js` — 4 passed
- `pnpm run typecheck` — 0 errors
- `pnpm run test` — 424 files, 3222 passed, 207 skipped
- Perturbation: forcing pool statuses approved made the characterization fail because `create` exited successfully.
