### PR TITLE
feat(benchmark): resumable content-gen runs, a deduped matrix, and a diagnostic mode

### DIFF
--- a/tests/tools/remote-ollama-benchmark.test.js
+++ b/tests/tools/remote-ollama-benchmark.test.js
@@ -19,10 +19,9 @@ test("hardware benchmark reserves secondary and maps every model to its declared
   const plan = buildHardwareBenchmarkSpecs(config, {
     models: [
       "qwen3-coder:30b-a3b-q4_K_M",
-      "qwen3-coder:30b",
       "qwen3.8:27b",
+      "qwen3.5:27b",
       "qwen3:14b",
-      "qwen2.5-coder:14b",
       "qwen2.5-coder:7b",
     ],
     contexts: [8192],
@@ -38,11 +37,14 @@ test("hardware benchmark reserves secondary and maps every model to its declared
   }
 
   assert.deepEqual([...byModel.get("qwen3-coder:30b-a3b-q4_K_M")].sort(), ["dual"]);
-  assert.deepEqual([...byModel.get("qwen3-coder:30b")].sort(), ["dual"]);
   assert.deepEqual([...byModel.get("qwen3.8:27b")].sort(), ["dual", "primary"]);
+  // qwen3.5:27b mirrors qwen3.8:27b exactly — same size, same profiles, same settings — so the
+  // only thing that differs between them is the generation. That is the whole point of its row.
+  assert.deepEqual([...byModel.get("qwen3.5:27b")].sort(), ["dual", "primary"]);
   assert.deepEqual([...byModel.get("qwen3:14b")].sort(), ["primary"]);
-  assert.deepEqual([...byModel.get("qwen2.5-coder:14b")].sort(), ["primary"]);
   assert.deepEqual([...byModel.get("qwen2.5-coder:7b")].sort(), ["primary"]);
+  assert.equal(byModel.has("qwen2.5-coder:14b"), false, "dropped: it scored below the 7b");
+  assert.equal(byModel.has("qwen3-coder:30b"), false, "dropped: same digest as :30b-a3b-q4_K_M");
 });
 
 test("content-gen matrix plans seven primary-or-dual configurations in resource order", () => {
@@ -50,7 +52,7 @@ test("content-gen matrix plans seven primary-or-dual configurations in resource 
   const plan = buildContentGenMatrix(config, { scenarioCount: 100 });
 
   assert.equal(plan.contractVersion, "content-gen-matrix-v1");
-  assert.equal(plan.sha256, "50a40410016f5abd216ce33ce98d78717f62847fc7422a94a7dfac541a522d8f");
+  assert.equal(plan.sha256, "64109b32ddcc3ee1645a04e2194808878fb1730a8a22dfdcd93141cda6e7e9e6");
   assert.equal(plan.configurationCount, 7);
   assert.deepEqual(plan.repeatPolicy, {
     minimumCompletePasses: 1,
@@ -60,11 +62,11 @@ test("content-gen matrix plans seven primary-or-dual configurations in resource 
   assert.deepEqual(plan.callBounds, { minimum: 700, maximum: 2100 });
   assert.deepEqual(plan.configurations.map((entry) => entry.configurationId), [
     "cg-v1--qwen2.5-coder_7b--primary--ctx32768--out4096",
-    "cg-v1--qwen2.5-coder_14b--primary--ctx32768--out4096",
     "cg-v1--qwen3_14b--primary--ctx32768--out4096",
+    "cg-v1--qwen3.5_27b--primary--ctx32768--out4096",
     "cg-v1--qwen3.8_27b--primary--ctx32768--out4096",
+    "cg-v1--qwen3.5_27b--dual--ctx65536--out32768",
     "cg-v1--qwen3.8_27b--dual--ctx65536--out32768",
-    "cg-v1--qwen3-coder_30b--dual--ctx65536--out32768",
     "cg-v1--qwen3-coder_30b-a3b-q4_K_M--dual--ctx65536--out32768",
   ]);
 
@@ -75,10 +77,9 @@ test("content-gen matrix plans seven primary-or-dual configurations in resource 
     profilesByModel.set(entry.model.id, profiles);
   }
   assert.deepEqual(profilesByModel.get("qwen3-coder:30b-a3b-q4_K_M"), ["dual"]);
-  assert.deepEqual(profilesByModel.get("qwen3-coder:30b"), ["dual"]);
   assert.deepEqual(profilesByModel.get("qwen3.8:27b"), ["primary", "dual"]);
+  assert.deepEqual(profilesByModel.get("qwen3.5:27b"), ["primary", "dual"]);
   assert.deepEqual(profilesByModel.get("qwen3:14b"), ["primary"]);
-  assert.deepEqual(profilesByModel.get("qwen2.5-coder:14b"), ["primary"]);
   assert.deepEqual(profilesByModel.get("qwen2.5-coder:7b"), ["primary"]);
 
   const resourceTuples = plan.configurations.map((entry) => [
@@ -177,7 +178,7 @@ test("hardware benchmark dry run advertises profile reset by default", () => {
     "--route",
     "internal",
     "--models",
-    "qwen3-coder:30b",
+    "qwen3-coder:30b-a3b-q4_K_M",
     "--contexts",
     "8192",
     "--efforts",
@@ -290,7 +291,7 @@ test("hardware benchmark dry run honors no-reset flag", () => {
     "--route",
     "internal",
     "--models",
-    "qwen3-coder:30b",
+    "qwen3-coder:30b-a3b-q4_K_M",
     "--contexts",
     "8192",
     "--efforts",

--- a/tests/tools/remote-ollama-benchmark.test.js
+++ b/tests/tools/remote-ollama-benchmark.test.js
@@ -22,7 +22,7 @@ test("hardware benchmark reserves secondary and maps every model to its declared
       "qwen3.8:27b",
       "qwen3.5:27b",
       "qwen3:14b",
-      "qwen2.5-coder:7b",
+      "qwen3.5:9b",
     ],
     contexts: [8192],
     efforts: ["high"],
@@ -42,8 +42,9 @@ test("hardware benchmark reserves secondary and maps every model to its declared
   // only thing that differs between them is the generation. That is the whole point of its row.
   assert.deepEqual([...byModel.get("qwen3.5:27b")].sort(), ["dual", "primary"]);
   assert.deepEqual([...byModel.get("qwen3:14b")].sort(), ["primary"]);
-  assert.deepEqual([...byModel.get("qwen2.5-coder:7b")].sort(), ["primary"]);
+  assert.deepEqual([...byModel.get("qwen3.5:9b")].sort(), ["primary"]);
   assert.equal(byModel.has("qwen2.5-coder:14b"), false, "dropped: it scored below the 7b");
+  assert.equal(byModel.has("qwen2.5-coder:7b"), false, "replaced as canary by qwen3.5:9b");
   assert.equal(byModel.has("qwen3-coder:30b"), false, "dropped: same digest as :30b-a3b-q4_K_M");
 });
 
@@ -52,7 +53,7 @@ test("content-gen matrix plans seven primary-or-dual configurations in resource 
   const plan = buildContentGenMatrix(config, { scenarioCount: 100 });
 
   assert.equal(plan.contractVersion, "content-gen-matrix-v1");
-  assert.equal(plan.sha256, "64109b32ddcc3ee1645a04e2194808878fb1730a8a22dfdcd93141cda6e7e9e6");
+  assert.equal(plan.sha256, "21d135595cf539764f9df8f94fb6334f027f6a51f93eb467e9512631aaa728c2");
   assert.equal(plan.configurationCount, 7);
   assert.deepEqual(plan.repeatPolicy, {
     minimumCompletePasses: 1,
@@ -61,7 +62,7 @@ test("content-gen matrix plans seven primary-or-dual configurations in resource 
   });
   assert.deepEqual(plan.callBounds, { minimum: 700, maximum: 2100 });
   assert.deepEqual(plan.configurations.map((entry) => entry.configurationId), [
-    "cg-v1--qwen2.5-coder_7b--primary--ctx32768--out4096",
+    "cg-v1--qwen3.5_9b--primary--ctx32768--out4096",
     "cg-v1--qwen3_14b--primary--ctx32768--out4096",
     "cg-v1--qwen3.5_27b--primary--ctx32768--out4096",
     "cg-v1--qwen3.8_27b--primary--ctx32768--out4096",
@@ -80,7 +81,7 @@ test("content-gen matrix plans seven primary-or-dual configurations in resource 
   assert.deepEqual(profilesByModel.get("qwen3.8:27b"), ["primary", "dual"]);
   assert.deepEqual(profilesByModel.get("qwen3.5:27b"), ["primary", "dual"]);
   assert.deepEqual(profilesByModel.get("qwen3:14b"), ["primary"]);
-  assert.deepEqual(profilesByModel.get("qwen2.5-coder:7b"), ["primary"]);
+  assert.deepEqual(profilesByModel.get("qwen3.5:9b"), ["primary"]);
 
   const resourceTuples = plan.configurations.map((entry) => [
     entry.resourceOrder.gpuCount,
@@ -242,7 +243,7 @@ test("hardware benchmark skips models with no configured profiles", () => {
 test("hardware benchmark resolves named effort from configured defaults", () => {
   const config = loadConfig(ROOT);
   const plan = buildHardwareBenchmarkSpecs(config, {
-    models: ["qwen2.5-coder:7b"],
+    models: ["qwen3.5:9b"],
     contexts: [8192],
     efforts: ["high"],
     scenarioNames: ["vitest-generation"],

--- a/tests/tools/remote-ollama-content-gen-resume.test.js
+++ b/tests/tools/remote-ollama-content-gen-resume.test.js
@@ -198,3 +198,44 @@ test("setup still runs exactly once for a configuration that has work left", asy
   });
   assert.deepEqual(prepared, ["cfg-a"], "setup must happen once, before the first attempt that needs it");
 });
+
+test("a diagnostic run keeps every pass, because early stop would delete the repeats it needs", async () => {
+  // An adversarial subset cannot qualify by construction — the first miss makes the 99% gates
+  // arithmetically unreachable — so early stop ends every configuration after one pass. That is
+  // correct for qualification and useless for diagnosis, where the repeats ARE the measurement.
+  const failing = SCENARIOS.map((scenario) => ({
+    recordKind: "content_gen_attempt",
+    runId: `cg--cfg-a--s00${scenario.index}--r1`,
+    configurationId: "cfg-a",
+    scenarioIndex: scenario.index,
+    scenarioTier: "simple",
+    repeat: 1,
+    toolCallProduced: true,
+    execSucceeded: false,
+    score: 0,
+    executionOutcome: "execution_failed",
+    failureClass: null,
+    scenarioVerdict: { passed: false, expected: "success", actual: "execution_failed" },
+  }));
+  const attempted = [];
+  await executeContentGenMatrix({
+    matrix: MATRIX,
+    scenarios: SCENARIOS,
+    priorRecords: failing,
+    stopWhenHopeless: false,
+    runAttempt: async ({ runId }) => {
+      attempted.push(runId);
+      return { toolCallProduced: true, execSucceeded: false, score: 0, executionOutcome: "execution_failed", failureClass: null };
+    },
+  });
+  assert.deepEqual(attempted, ["cg--cfg-a--s001--r2", "cg--cfg-a--s002--r2"],
+    "pass 2 must still run when early stop is disabled");
+});
+
+test("a diagnostic run says so in its manifest, so it cannot be quoted as qualification later", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cg-diag-"));
+  writeRunManifest(dir, { route: "internal", diagnostic: true, ...IDENTITY });
+  assert.equal(readRunManifest(dir).diagnostic, true);
+  writeRunManifest(dir, { route: "internal", ...IDENTITY });
+  assert.equal(readRunManifest(dir).diagnostic, false, "a normal run must record diagnostic:false, not undefined");
+});

--- a/tests/tools/remote-ollama-content-gen-resume.test.js
+++ b/tests/tools/remote-ollama-content-gen-resume.test.js
@@ -1,0 +1,146 @@
+const assert = require("node:assert/strict");
+const { mkdtempSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
+
+const {
+  assertResumable,
+  readCompletedRunIds,
+  readPriorRecords,
+  writeRunManifest,
+  readRunManifest,
+} = require("../../tools/remote-ollama-control/scripts/lib/content-gen-checkpoint");
+const { executeContentGenMatrix } = require("../../tools/remote-ollama-control/scripts/lib/ak-matrix");
+
+const MATRIX = {
+  sha256: "matrix-hash",
+  repeatPolicy: { minimumCompletePasses: 1, maximumPasses: 2, earlyStop: "mathematically_lossless" },
+  configurations: [
+    {
+      configurationId: "cfg-a",
+      profile: { id: "primary", hardwareClass: "single", gpuCount: 1, capacityRank: 1 },
+      model: { id: "model-a", family: "a", parameterBillions: 7 },
+      settings: { contextTokens: 4096, outputTokens: 1024 },
+      resourceOrder: { gpuCount: 1, capacityRank: 1, modelSizeBillions: 7, contextTokens: 4096, outputTokens: 1024 },
+    },
+  ],
+};
+const SCENARIOS = [
+  { index: 1, title: "one", tier: "simple", expectedOutcome: "success" },
+  { index: 2, title: "two", tier: "simple", expectedOutcome: "success" },
+];
+const IDENTITY = {
+  scenarioSet: { count: 100, sha256: "catalog-hash", tierCounts: { simple: 25 } },
+  matrix: { sha256: "matrix-hash", maximumPasses: 2, configurationIds: ["cfg-a"] },
+  scenarioIds: [1, 2],
+};
+
+function passingAttempt() {
+  return {
+    toolCallProduced: true,
+    execSucceeded: true,
+    score: 100,
+    executionOutcome: "success",
+    failureClass: null,
+  };
+}
+
+test("a completed attempt is not run again, and still counts toward the result", async () => {
+  const prior = [{
+    recordKind: "content_gen_attempt",
+    runId: "cg--cfg-a--s001--r1",
+    configurationId: "cfg-a",
+    scenarioIndex: 1,
+    scenarioTier: "simple",
+    repeat: 1,
+    ...passingAttempt(),
+    scenarioVerdict: { passed: true, expected: "success", actual: "success" },
+  }];
+  const attempted = [];
+  const announced = [];
+  const records = await executeContentGenMatrix({
+    matrix: MATRIX,
+    scenarios: SCENARIOS,
+    priorRecords: prior,
+    runAttempt: async ({ runId }) => {
+      attempted.push(runId);
+      return passingAttempt();
+    },
+    onRecord: async (record) => { announced.push(record.runId); },
+  });
+
+  assert.ok(!attempted.includes("cg--cfg-a--s001--r1"), "the completed attempt was run a second time");
+  assert.equal(attempted.length, 3, "the three outstanding attempts should run");
+  assert.ok(!announced.includes("cg--cfg-a--s001--r1"), "a skipped attempt must not be written again");
+  assert.equal(records.length, 4, "the returned set must cover the whole run, prior work included");
+  assert.equal(records[0].runId, "cg--cfg-a--s001--r1", "prior records come first, in order");
+});
+
+test("early stop reads prior records, so a doomed configuration stops without re-running it", async () => {
+  const prior = [1, 2].map((index) => ({
+    recordKind: "content_gen_attempt",
+    runId: `cg--cfg-a--s00${index}--r1`,
+    configurationId: "cfg-a",
+    scenarioIndex: index,
+    scenarioTier: "simple",
+    repeat: 1,
+    toolCallProduced: true,
+    execSucceeded: false,
+    score: 0,
+    executionOutcome: "execution_failed",
+    failureClass: null,
+    scenarioVerdict: { passed: false, expected: "success", actual: "execution_failed" },
+  }));
+  const attempted = [];
+  await executeContentGenMatrix({
+    matrix: MATRIX,
+    scenarios: SCENARIOS,
+    priorRecords: prior,
+    runAttempt: async ({ runId }) => {
+      attempted.push(runId);
+      return passingAttempt();
+    },
+  });
+  assert.deepEqual(attempted, [], "a configuration already past saving must not burn a second pass");
+});
+
+test("resume refuses evidence that cannot be merged", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cg-resume-"));
+  writeRunManifest(dir, { route: "internal", ...IDENTITY });
+  const manifest = readRunManifest(dir);
+  assert.equal(manifest.scenarioSet.sha256, "catalog-hash");
+
+  assert.doesNotThrow(() => assertResumable(manifest, IDENTITY));
+  assert.throws(
+    () => assertResumable(manifest, { ...IDENTITY, scenarioSet: { ...IDENTITY.scenarioSet, sha256: "other" } }),
+    /scenario catalog/i,
+    "a different catalog must not merge into an existing run",
+  );
+  assert.throws(
+    () => assertResumable(manifest, { ...IDENTITY, matrix: { ...IDENTITY.matrix, sha256: "other" } }),
+    /matrix/i,
+    "a different matrix must not merge into an existing run",
+  );
+  assert.throws(
+    () => assertResumable(manifest, { ...IDENTITY, scenarioIds: [1, 2, 3] }),
+    /scenario/i,
+    "resuming must not silently widen the scenario set",
+  );
+});
+
+test("a run killed mid-write resumes from its last intact record", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cg-resume-"));
+  const path = join(dir, "runs.jsonl");
+  writeFileSync(path, [
+    JSON.stringify({ runId: "cg--cfg-a--s001--r1", configurationId: "cfg-a", score: 100 }),
+    JSON.stringify({ runId: "cg--cfg-a--s002--r1", configurationId: "cfg-a", score: 90 }),
+    '{"runId":"cg--cfg-a--s003--r1","configu',   // the process died here
+  ].join("\n"));
+
+  assert.deepEqual(
+    [...readCompletedRunIds(path)],
+    ["cg--cfg-a--s001--r1", "cg--cfg-a--s002--r1"],
+    "a torn final line is not a completed attempt",
+  );
+  assert.equal(readPriorRecords(path).length, 2);
+});

--- a/tests/tools/remote-ollama-content-gen-resume.test.js
+++ b/tests/tools/remote-ollama-content-gen-resume.test.js
@@ -144,3 +144,57 @@ test("a run killed mid-write resumes from its last intact record", () => {
   );
   assert.equal(readPriorRecords(path).length, 2);
 });
+
+test("a configuration with nothing left to run does not pay for a profile reset", async () => {
+  // Resume reset the remote profile and loaded a 7B model for a configuration whose 31 attempts
+  // were all already recorded, then ran nothing — minutes of model load per finished configuration.
+  // Setup must be demanded by an attempt, not by reaching the configuration in the loop.
+  // The real shape: every scenario has a repeat-1 record and they failed, so early stop ends the
+  // configuration immediately. maximumPasses is the default 2, so a naive "have I recorded
+  // scenarios x maximumPasses attempts?" guard does not fire — which is exactly what happened.
+  const prior = SCENARIOS.map((scenario) => ({
+    recordKind: "content_gen_attempt",
+    runId: `cg--cfg-a--s00${scenario.index}--r1`,
+    configurationId: "cfg-a",
+    scenarioIndex: scenario.index,
+    scenarioTier: "simple",
+    repeat: 1,
+    toolCallProduced: true,
+    execSucceeded: false,
+    score: 0,
+    executionOutcome: "execution_failed",
+    failureClass: null,
+    scenarioVerdict: { passed: false, expected: "success", actual: "execution_failed" },
+  }));
+  const prepared = [];
+  await executeContentGenMatrix({
+    matrix: MATRIX,
+    scenarios: SCENARIOS,
+    priorRecords: prior,
+    beforeConfiguration: async (configuration) => { prepared.push(configuration.configurationId); },
+    runAttempt: async () => passingAttempt(),
+  });
+  assert.deepEqual(prepared, [], "no attempt remained, so nothing should have been prepared");
+});
+
+test("setup still runs exactly once for a configuration that has work left", async () => {
+  const prior = [{
+    recordKind: "content_gen_attempt",
+    runId: "cg--cfg-a--s001--r1",
+    configurationId: "cfg-a",
+    scenarioIndex: 1,
+    scenarioTier: "simple",
+    repeat: 1,
+    ...passingAttempt(),
+    scenarioVerdict: { passed: true, expected: "success", actual: "success" },
+  }];
+  const prepared = [];
+  await executeContentGenMatrix({
+    matrix: MATRIX,
+    scenarios: SCENARIOS,
+    priorRecords: prior,
+    beforeConfiguration: async (configuration) => { prepared.push(configuration.configurationId); },
+    runAttempt: async () => passingAttempt(),
+  });
+  assert.deepEqual(prepared, ["cfg-a"], "setup must happen once, before the first attempt that needs it");
+});

--- a/tools/remote-ollama-control/config/models.json
+++ b/tools/remote-ollama-control/config/models.json
@@ -3,7 +3,10 @@
     "Model availability is checked on the remote Ollama endpoint at runtime.",
     "Add new installed models here with the profiles they can realistically run on.",
     "Qwen 3.8 currently ships only as 27B; primary runs it with CPU/GPU hybrid offload while dual is the preferred higher-GPU-residency profile.",
-    "Single-GPU benchmarks run only on the primary profile; the secondary card is reserved for dual."
+    "Single-GPU benchmarks run only on the primary profile; the secondary card is reserved for dual.",
+    "qwen3-coder:30b was removed 2026-08-22: `ollama list` gives it and qwen3-coder:30b-a3b-q4_K_M the same digest (06c1097efce0, 18 GB). They were one model under two tags, so the matrix measured it twice. The 2.5-point spread between those two runs is the noise floor at one pass \u2014 treat any narrower difference as nothing.",
+    "qwen2.5-coder:14b was removed the same day: it scored 33.4 against a 75 bar, BELOW the 7b's 37.7, so it was measuring tool-call formatting noise rather than capability. qwen2.5-coder:7b stays as the cheap control \u2014 a uniform drop across the whole matrix says harness, not model.",
+    "qwen3.5:27b mirrors qwen3.8:27b's profiles and settings on purpose. Same parameter count, same context and output, one variable: generation. Cross-profile rows are NOT comparable \u2014 primary is 32k/4k and dual is 64k/32k, so GPU count, context and output all change together."
   ],
   "benchmark": {
     "defaultScenarios": [
@@ -48,6 +51,16 @@
       "family": "qwen3.8",
       "use": "preferred Qwen 3.8 tool-calling model; hybrid CPU/GPU on primary and high GPU residency on dual"
     },
+    "qwen3.5:27b": {
+      "profiles": [
+        "primary",
+        "dual"
+      ],
+      "parameterBillions": 27,
+      "sizeGb": 17.0,
+      "family": "qwen3.5",
+      "use": "previous-generation reference at the same size and settings as qwen3.8:27b \u2014 the controlled generation comparison"
+    },
     "qwen3-coder:30b-a3b-q4_K_M": {
       "profiles": [
         "dual"
@@ -57,15 +70,6 @@
       "family": "qwen3-coder",
       "use": "30B coding model candidate across both GPUs"
     },
-    "qwen3-coder:30b": {
-      "profiles": [
-        "dual"
-      ],
-      "parameterBillions": 30,
-      "sizeGb": 18,
-      "family": "qwen3-coder",
-      "use": "larger coding model across both GPUs"
-    },
     "qwen3:14b": {
       "profiles": [
         "primary"
@@ -74,15 +78,6 @@
       "sizeGb": 9.3,
       "family": "qwen3",
       "use": "single 12GB GPU general reasoning and structured output"
-    },
-    "qwen2.5-coder:14b": {
-      "profiles": [
-        "primary"
-      ],
-      "parameterBillions": 14,
-      "sizeGb": 9,
-      "family": "qwen2.5-coder",
-      "use": "single 12GB GPU coding and test generation"
     },
     "qwen2.5-coder:7b": {
       "profiles": [

--- a/tools/remote-ollama-control/config/models.json
+++ b/tools/remote-ollama-control/config/models.json
@@ -5,8 +5,8 @@
     "Qwen 3.8 currently ships only as 27B; primary runs it with CPU/GPU hybrid offload while dual is the preferred higher-GPU-residency profile.",
     "Single-GPU benchmarks run only on the primary profile; the secondary card is reserved for dual.",
     "qwen3-coder:30b was removed 2026-08-22: `ollama list` gives it and qwen3-coder:30b-a3b-q4_K_M the same digest (06c1097efce0, 18 GB). They were one model under two tags, so the matrix measured it twice. The 2.5-point spread between those two runs is the noise floor at one pass \u2014 treat any narrower difference as nothing.",
-    "qwen2.5-coder:14b was removed the same day: it scored 33.4 against a 75 bar, BELOW the 7b's 37.7, so it was measuring tool-call formatting noise rather than capability. qwen2.5-coder:7b stays as the cheap control \u2014 a uniform drop across the whole matrix says harness, not model.",
-    "qwen3.5:27b mirrors qwen3.8:27b's profiles and settings on purpose. Same parameter count, same context and output, one variable: generation. Cross-profile rows are NOT comparable \u2014 primary is 32k/4k and dual is 64k/32k, so GPU count, context and output all change together."
+    "qwen3.5:27b mirrors qwen3.8:27b's profiles and settings on purpose. Same parameter count, same context and output, one variable: generation. Cross-profile rows are NOT comparable \u2014 primary is 32k/4k and dual is 64k/32k, so GPU count, context and output all change together.",
+    "The canary moved from qwen2.5-coder:7b to qwen3.5:9b on 2026-08-22. qwen2.5-coder:14b was dropped first (33.4 against a 75 bar, BELOW the 7b's 37.7 \u2014 formatting noise, not capability), and the 7b followed once a current small model was available: at 3 months old it was drifting away from the generation everything else in the matrix belongs to, which makes a uniform drop harder to read as 'harness' rather than 'the old model finally fell over'."
   ],
   "benchmark": {
     "defaultScenarios": [
@@ -79,14 +79,14 @@
       "family": "qwen3",
       "use": "single 12GB GPU general reasoning and structured output"
     },
-    "qwen2.5-coder:7b": {
+    "qwen3.5:9b": {
       "profiles": [
         "primary"
       ],
-      "parameterBillions": 7,
-      "sizeGb": 4.7,
-      "family": "qwen2.5-coder",
-      "use": "single 12GB GPU background tool-use or smaller coding tests"
+      "parameterBillions": 9.7,
+      "sizeGb": 6.6,
+      "family": "qwen3.5",
+      "use": "cheap control (canary): a uniform drop across the whole matrix says harness, not model"
     }
   }
 }

--- a/tools/remote-ollama-control/scripts/lib/ak-matrix.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-matrix.js
@@ -17,6 +17,10 @@ async function executeContentGenMatrix({
   onRecord = () => {},
   beforeConfiguration = async () => {},
   thresholds,
+  // Diagnostic runs turn this off. Early stop exists to save GPU time on a configuration that
+  // can no longer qualify — but an adversarial subset can NEVER qualify, so on those runs it
+  // deletes precisely the repeats the run exists to collect.
+  stopWhenHopeless = true,
   // Attempts already on disk from an interrupted run of the SAME catalog and matrix. They are not
   // re-run, they are not re-announced through onRecord (they are already in runs.jsonl), and they
   // are returned with the new ones so aggregation still sees a whole run. Early stop reads them
@@ -83,7 +87,8 @@ async function executeContentGenMatrix({
         }
       }
       const remainingAttempts = (maximumPasses - repeat) * scenarios.length;
-      if (remainingAttempts > 0 && !canStillQualify(configurationRecords, { remainingAttempts, thresholds })) {
+      if (stopWhenHopeless && remainingAttempts > 0
+        && !canStillQualify(configurationRecords, { remainingAttempts, thresholds })) {
         break;
       }
     }

--- a/tools/remote-ollama-control/scripts/lib/ak-matrix.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-matrix.js
@@ -16,19 +16,35 @@ async function executeContentGenMatrix({
   runAttempt,
   onRecord = () => {},
   beforeConfiguration = async () => {},
-  thresholds
+  thresholds,
+  // Attempts already on disk from an interrupted run of the SAME catalog and matrix. They are not
+  // re-run, they are not re-announced through onRecord (they are already in runs.jsonl), and they
+  // are returned with the new ones so aggregation still sees a whole run. Early stop reads them
+  // too: a configuration that was already doomed before the interruption must not buy a fresh pass.
+  priorRecords = []
 }) {
   const records = [];
+  const completed = new Set(priorRecords.map((record) => record.runId).filter(Boolean));
+  const priorByConfiguration = new Map();
+  for (const record of priorRecords) {
+    const bucket = priorByConfiguration.get(record.configurationId) || [];
+    bucket.push(record);
+    priorByConfiguration.set(record.configurationId, bucket);
+    records.push(record);
+  }
   const maximumPasses = matrix.repeatPolicy.maximumPasses;
   for (const configuration of matrix.configurations) {
+    const resumed = priorByConfiguration.get(configuration.configurationId) || [];
+    if (resumed.length >= scenarios.length * maximumPasses) continue;
     await beforeConfiguration(configuration);
-    const configurationRecords = [];
+    const configurationRecords = [...resumed];
     for (let repeat = 1; repeat <= maximumPasses; repeat += 1) {
       for (const scenario of scenarios) {
         const runId = [
           'cg', configuration.configurationId,
           `s${String(scenario.index).padStart(3, '0')}`, `r${repeat}`
         ].join('--');
+        if (completed.has(runId)) continue;
         const attempt = await runAttempt({ configuration, scenario, repeat, runId });
         const actual = attempt.executionOutcome || (attempt.execSucceeded ? 'success' : 'execution_failed');
         const record = {

--- a/tools/remote-ollama-control/scripts/lib/ak-matrix.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-matrix.js
@@ -35,8 +35,17 @@ async function executeContentGenMatrix({
   const maximumPasses = matrix.repeatPolicy.maximumPasses;
   for (const configuration of matrix.configurations) {
     const resumed = priorByConfiguration.get(configuration.configurationId) || [];
-    if (resumed.length >= scenarios.length * maximumPasses) continue;
-    await beforeConfiguration(configuration);
+    // Setup is demanded by the first attempt that actually runs, never by reaching the
+    // configuration. On resume a finished configuration would otherwise reset the remote profile
+    // and load its model before discovering it has nothing to do — minutes of GPU time per
+    // configuration, and "how many attempts have I recorded?" cannot predict it, because early
+    // stop means a complete configuration can hold far fewer records than scenarios x passes.
+    let prepared = false;
+    const prepare = async () => {
+      if (prepared) return;
+      prepared = true;
+      await beforeConfiguration(configuration);
+    };
     const configurationRecords = [...resumed];
     for (let repeat = 1; repeat <= maximumPasses; repeat += 1) {
       for (const scenario of scenarios) {
@@ -45,6 +54,7 @@ async function executeContentGenMatrix({
           `s${String(scenario.index).padStart(3, '0')}`, `r${repeat}`
         ].join('--');
         if (completed.has(runId)) continue;
+        await prepare();
         const attempt = await runAttempt({ configuration, scenario, repeat, runId });
         const actual = attempt.executionOutcome || (attempt.execSucceeded ? 'success' : 'execution_failed');
         const record = {

--- a/tools/remote-ollama-control/scripts/lib/content-gen-checkpoint.js
+++ b/tools/remote-ollama-control/scripts/lib/content-gen-checkpoint.js
@@ -22,12 +22,15 @@ function manifestPath(resultDir) {
   return path.join(resultDir, MANIFEST_NAME);
 }
 
-function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, startedAt }) {
+function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, startedAt, diagnostic }) {
   fs.mkdirSync(resultDir, { recursive: true });
   const manifest = {
     schemaVersion: MANIFEST_SCHEMA,
     startedAt: startedAt || new Date().toISOString(),
     route: route || null,
+    // Explicitly false rather than absent: a reader six weeks from now must be able to tell
+    // 'this was a qualification run' from 'this field did not exist yet'.
+    diagnostic: diagnostic === true,
     scenarioSet,
     matrix,
     scenarioIds: [...scenarioIds].sort((left, right) => left - right)

--- a/tools/remote-ollama-control/scripts/lib/content-gen-checkpoint.js
+++ b/tools/remote-ollama-control/scripts/lib/content-gen-checkpoint.js
@@ -1,0 +1,124 @@
+'use strict';
+
+// Checkpointing for run-content-gen.
+//
+// A content-gen run is hours long and, until this module existed, entirely disposable: the result
+// directory carried no record of WHAT was being run until the final result.json was written, so a
+// run that was interrupted left attempts on disk with nothing to say which catalog or matrix had
+// produced them. Resuming meant re-running everything, or hand-assembling evidence from separate
+// directories and hoping the inputs matched.
+//
+// The manifest is written before the first attempt, so an interrupted run is still self-describing.
+// Resume then requires the identity to match exactly — merging attempts from two different catalogs
+// into one result.json would produce a number nobody could interpret, which is worse than re-running.
+
+const fs = require('fs');
+const path = require('path');
+
+const MANIFEST_SCHEMA = 'agent-kernel-content-gen-run-manifest/v1';
+const MANIFEST_NAME = 'run-manifest.json';
+
+function manifestPath(resultDir) {
+  return path.join(resultDir, MANIFEST_NAME);
+}
+
+function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, startedAt }) {
+  fs.mkdirSync(resultDir, { recursive: true });
+  const manifest = {
+    schemaVersion: MANIFEST_SCHEMA,
+    startedAt: startedAt || new Date().toISOString(),
+    route: route || null,
+    scenarioSet,
+    matrix,
+    scenarioIds: [...scenarioIds].sort((left, right) => left - right)
+  };
+  fs.writeFileSync(manifestPath(resultDir), `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+function readRunManifest(resultDir) {
+  const file = manifestPath(resultDir);
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `${resultDir} has no ${MANIFEST_NAME}, so there is no record of what it was running. `
+      + 'It predates checkpointing, or was not produced by run-content-gen. Start a fresh run.'
+    );
+  }
+  const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (manifest.schemaVersion !== MANIFEST_SCHEMA) {
+    throw new Error(`${file} declares ${manifest.schemaVersion}, not ${MANIFEST_SCHEMA}`);
+  }
+  return manifest;
+}
+
+// Refuse anything that would merge incomparable evidence into one result. The failure messages name
+// the mismatched field on purpose: "cannot resume" without the reason sends the reader to the code.
+function assertResumable(manifest, current) {
+  if (manifest.scenarioSet.sha256 !== current.scenarioSet.sha256) {
+    throw new Error(
+      'cannot resume: the scenario catalog changed since this run started '
+      + `(${manifest.scenarioSet.sha256.slice(0, 12)}… → ${current.scenarioSet.sha256.slice(0, 12)}…). `
+      + 'Attempts from two catalogs cannot share one result.'
+    );
+  }
+  if (manifest.matrix.sha256 !== current.matrix.sha256) {
+    throw new Error(
+      'cannot resume: the configuration matrix changed since this run started '
+      + `(${manifest.matrix.sha256.slice(0, 12)}… → ${current.matrix.sha256.slice(0, 12)}…).`
+    );
+  }
+  const known = new Set(manifest.scenarioIds);
+  const added = current.scenarioIds.filter((index) => !known.has(index));
+  if (added.length > 0) {
+    throw new Error(
+      `cannot resume: scenario ${added.join(', ')} was not part of the original run. `
+      + 'Resume finishes outstanding work; it does not widen the scenario set.'
+    );
+  }
+  const unknownConfigurations = current.matrix.configurationIds
+    .filter((id) => !manifest.matrix.configurationIds.includes(id));
+  if (unknownConfigurations.length > 0) {
+    throw new Error(`cannot resume: configuration ${unknownConfigurations.join(', ')} was not part of the original run.`);
+  }
+  return true;
+}
+
+// A killed process can leave a half-written final line. Treat only parseable lines as evidence:
+// a torn record means that attempt did not finish, so resume should run it again.
+function readPriorRecords(runsJsonlPath) {
+  if (!fs.existsSync(runsJsonlPath)) return [];
+  const records = [];
+  for (const line of fs.readFileSync(runsJsonlPath, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch {
+      // Only the last line can legitimately be torn; anything earlier means a corrupt file,
+      // and re-running those attempts is still the safe response.
+    }
+  }
+  return records;
+}
+
+function readCompletedRunIds(runsJsonlPath) {
+  return new Set(readPriorRecords(runsJsonlPath).map((record) => record.runId).filter(Boolean));
+}
+
+function latestResultDir(resultsDir, suffix = '-content-gen') {
+  if (!fs.existsSync(resultsDir)) return null;
+  const candidates = fs.readdirSync(resultsDir)
+    .filter((name) => name.endsWith(suffix))
+    .sort();
+  return candidates.length > 0 ? path.join(resultsDir, candidates[candidates.length - 1]) : null;
+}
+
+module.exports = {
+  MANIFEST_NAME,
+  MANIFEST_SCHEMA,
+  assertResumable,
+  latestResultDir,
+  readCompletedRunIds,
+  readPriorRecords,
+  readRunManifest,
+  writeRunManifest
+};

--- a/tools/remote-ollama-control/scripts/remote-ollama-mac.js
+++ b/tools/remote-ollama-control/scripts/remote-ollama-mac.js
@@ -42,7 +42,7 @@ function usage() {
   remote-ollama-mac project-push-main [--branch main]
   remote-ollama-mac run-abstract-plan [--abstract-set pilot|parallel] [--profile NAME] [--model MODEL] [--runs N] [--scenario-ids 1] [--route auto|internal|external] [--no-start] [--no-reset] [--dry-run]
   remote-ollama-mac run-abstract-plan --local --model MODEL [--runs N] [--scenario-ids 1] [--dry-run]
-  remote-ollama-mac run-content-gen [--profiles a,b,c] [--model MODEL] [--runs N] [--scenario-ids 1,3,5] [--route auto|internal|external] [--resume [DIR]] [--no-start] [--no-reset] [--dry-run]
+  remote-ollama-mac run-content-gen [--profiles a,b,c] [--model MODEL] [--runs N] [--scenario-ids 1,3,5] [--route auto|internal|external] [--resume [DIR]] [--no-early-stop] [--no-start] [--no-reset] [--dry-run]
   remote-ollama-mac run-content-gen --local --model MODEL [--runs N] [--scenario-ids 1,3,5] [--dry-run]
   remote-ollama-mac dry-run start --profile dual --model qwen3-coder:30b-a3b-q4_K_M
 
@@ -116,6 +116,7 @@ function parseArgs(argv) {
     runs: 1,
     scenarioIds: [],
     resume: null,
+    earlyStop: true,
     abstractSet: 'pilot',
     extra: []
   };
@@ -229,6 +230,8 @@ function parseArgs(argv) {
     } else if (arg === '--scenario-ids') {
       options.scenarioIds = parseList(readOptionValue(args, index, arg)).map(Number).filter((v) => Number.isFinite(v) && v > 0);
       index += 1;
+    } else if (arg === '--no-early-stop') {
+      options.earlyStop = false;
     } else if (arg === '--resume') {
       // Optional value: `--resume` alone continues the newest content-gen directory.
       const next = args[index + 1];
@@ -1344,7 +1347,7 @@ async function runContentGen(options) {
       + `${executionMatrix.repeatPolicy.maximumPasses} passes\n`
     );
   } else {
-    writeRunManifest(resultDir, { route: options.route, ...runIdentity });
+    writeRunManifest(resultDir, { route: options.route, diagnostic: !options.earlyStop, ...runIdentity });
   }
 
   try {
@@ -1352,6 +1355,7 @@ async function runContentGen(options) {
       matrix: executionMatrix,
       scenarios,
       priorRecords,
+      stopWhenHopeless: options.earlyStop,
       beforeConfiguration: async (configuration) => {
         const profileName = configuration.profile.id;
         const model = configuration.model.id;

--- a/tools/remote-ollama-control/scripts/remote-ollama-mac.js
+++ b/tools/remote-ollama-control/scripts/remote-ollama-mac.js
@@ -1332,11 +1332,16 @@ async function runContentGen(options) {
   if (options.resume) {
     assertResumable(readRunManifest(resultDir), runIdentity);
     priorRecords = readPriorRecords(jsonlPath);
-    const planned = scenarios.length * executionMatrix.repeatPolicy.maximumPasses
-      * executionMatrix.configurations.length;
+    // Report the honest bounds. One complete pass per configuration is the floor; early stop
+    // decides the rest, so a single "outstanding" number would be wrong either way.
+    const configurations = executionMatrix.configurations.length;
+    const floor = Math.max(0, scenarios.length * configurations - priorRecords.length);
+    const ceiling = Math.max(0, scenarios.length * executionMatrix.repeatPolicy.maximumPasses
+      * configurations - priorRecords.length);
     process.stdout.write(
-      `Resuming ${resultDir}\n  ${priorRecords.length} attempt(s) already recorded, `
-      + `up to ${planned - priorRecords.length} outstanding\n`
+      `Resuming ${resultDir}\n  ${priorRecords.length} attempt(s) already recorded; `
+      + `${floor} outstanding at one pass each, up to ${ceiling} if every configuration runs all `
+      + `${executionMatrix.repeatPolicy.maximumPasses} passes\n`
     );
   } else {
     writeRunManifest(resultDir, { route: options.route, ...runIdentity });

--- a/tools/remote-ollama-control/scripts/remote-ollama-mac.js
+++ b/tools/remote-ollama-control/scripts/remote-ollama-mac.js
@@ -42,7 +42,7 @@ function usage() {
   remote-ollama-mac project-push-main [--branch main]
   remote-ollama-mac run-abstract-plan [--abstract-set pilot|parallel] [--profile NAME] [--model MODEL] [--runs N] [--scenario-ids 1] [--route auto|internal|external] [--no-start] [--no-reset] [--dry-run]
   remote-ollama-mac run-abstract-plan --local --model MODEL [--runs N] [--scenario-ids 1] [--dry-run]
-  remote-ollama-mac run-content-gen [--profiles a,b,c] [--model MODEL] [--runs N] [--scenario-ids 1,3,5] [--route auto|internal|external] [--no-start] [--no-reset] [--dry-run]
+  remote-ollama-mac run-content-gen [--profiles a,b,c] [--model MODEL] [--runs N] [--scenario-ids 1,3,5] [--route auto|internal|external] [--resume [DIR]] [--no-start] [--no-reset] [--dry-run]
   remote-ollama-mac run-content-gen --local --model MODEL [--runs N] [--scenario-ids 1,3,5] [--dry-run]
   remote-ollama-mac dry-run start --profile dual --model qwen3-coder:30b-a3b-q4_K_M
 
@@ -115,6 +115,7 @@ function parseArgs(argv) {
     tail: 120,
     runs: 1,
     scenarioIds: [],
+    resume: null,
     abstractSet: 'pilot',
     extra: []
   };
@@ -228,6 +229,15 @@ function parseArgs(argv) {
     } else if (arg === '--scenario-ids') {
       options.scenarioIds = parseList(readOptionValue(args, index, arg)).map(Number).filter((v) => Number.isFinite(v) && v > 0);
       index += 1;
+    } else if (arg === '--resume') {
+      // Optional value: `--resume` alone continues the newest content-gen directory.
+      const next = args[index + 1];
+      if (next && !next.startsWith('--')) {
+        options.resume = next;
+        index += 1;
+      } else {
+        options.resume = 'latest';
+      }
     } else if (arg === '--abstract-set') {
       options.abstractSet = readOptionValue(args, index, arg);
       if (!['pilot', 'parallel'].includes(options.abstractSet)) fail(`${arg} must be pilot or parallel`);
@@ -1220,6 +1230,9 @@ async function runContentGen(options) {
   const { classifyExecutionOutcome, runScenario } = require('./lib/ak-runner');
   const { aggregateContentGenResults, scoreRun, writeContentResult, writeContentSummary } = require('./lib/ak-compare');
   const { executeContentGenMatrix } = require('./lib/ak-matrix');
+  const {
+    assertResumable, latestResultDir, readPriorRecords, readRunManifest, writeRunManifest
+  } = require('./lib/content-gen-checkpoint');
 
   const catalog = loadScenarioCatalog();
   let scenarios = catalog.scenarios;
@@ -1238,7 +1251,13 @@ async function runContentGen(options) {
     : (options.profiles.length > 0 ? options.profiles : ['dual']);
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const resultDir = path.join(config.host.resultsDir, `${timestamp}-content-gen`);
+  let resultDir = path.join(config.host.resultsDir, `${timestamp}-content-gen`);
+  if (options.resume) {
+    resultDir = options.resume === 'latest'
+      ? latestResultDir(config.host.resultsDir)
+      : path.resolve(options.resume);
+    if (!resultDir) fail('--resume found no previous content-gen result directory.');
+  }
   const matrix = options.local ? null : buildContentGenMatrix(config, {
     models: options.models.length > 0 ? options.models : (options.model ? [options.model] : []),
     profileNames: options.profiles,
@@ -1298,10 +1317,36 @@ async function runContentGen(options) {
   };
   const executionProfiles = [...new Set(executionMatrix.configurations.map((entry) => entry.profile.id))];
 
+  // Record what this run IS before the first attempt, so an interrupted run stays self-describing
+  // and a resume can prove it is finishing the same work rather than blending two runs.
+  const runIdentity = {
+    scenarioSet: { count: catalog.count, sha256: catalog.sha256, tierCounts: catalog.tierCounts },
+    matrix: {
+      sha256: executionMatrix.sha256,
+      maximumPasses: executionMatrix.repeatPolicy.maximumPasses,
+      configurationIds: executionMatrix.configurations.map((entry) => entry.configurationId)
+    },
+    scenarioIds: scenarios.map((scenario) => scenario.index)
+  };
+  let priorRecords = [];
+  if (options.resume) {
+    assertResumable(readRunManifest(resultDir), runIdentity);
+    priorRecords = readPriorRecords(jsonlPath);
+    const planned = scenarios.length * executionMatrix.repeatPolicy.maximumPasses
+      * executionMatrix.configurations.length;
+    process.stdout.write(
+      `Resuming ${resultDir}\n  ${priorRecords.length} attempt(s) already recorded, `
+      + `up to ${planned - priorRecords.length} outstanding\n`
+    );
+  } else {
+    writeRunManifest(resultDir, { route: options.route, ...runIdentity });
+  }
+
   try {
     const allResults = await executeContentGenMatrix({
       matrix: executionMatrix,
       scenarios,
+      priorRecords,
       beforeConfiguration: async (configuration) => {
         const profileName = configuration.profile.id;
         const model = configuration.model.id;


### PR DESCRIPTION
> **Stacked on #81.** Base is `fix/benchmark-resource-schema-drift`, so this PR shows only its own five commits. It retargets to `main` automatically when #81 merges.

Five changes, each driven by something that went wrong in a real run on 2026-08-22.

## 1. A run records what it is, and can be resumed (`efc97c0`)

A content-gen run is hours long and was entirely disposable: the result directory said nothing about what was being run until `result.json` was written at the end. An interrupted run left attempts on disk with no record of which catalog or matrix produced them.

- `run-manifest.json` is written **before the first attempt** — scenario-set hash, tier counts, matrix hash, `maximumPasses`, configuration ids, scenario ids.
- `--resume [DIR]` continues an existing directory (bare `--resume` takes the newest). It validates identity before appending: a different catalog hash, matrix hash, widened scenario set, or unknown configuration each refuse **by name**, before any SSH. Merging attempts from two catalogs into one `result.json` produces a number nobody can interpret — worse than re-running.
- `executeContentGenMatrix({ priorRecords })` skips attempts by deterministic `runId`, doesn't re-announce them, returns them so aggregation sees a whole run, and feeds them to early stop so a doomed configuration doesn't buy a fresh pass.
- Torn final lines are handled where they occur: only parseable records count, so the interrupted attempt simply re-runs.

This paid for itself the same day — a 217-attempt run was paused at 103 and resumed without losing any of them.

## 2. Resume stops paying for configurations with nothing to run (`58a6e3b`)

Watching the first real resume: it reset the remote profile and loaded models for two configurations already complete at 31/31, then ran nothing. My first guard couldn't catch it — a configuration that *early-stopped* is complete while holding a third of the expected record count, so no attempt-count arithmetic distinguishes "finished early" from "interrupted". Setup is now demanded by the first attempt that actually runs.

The test I wrote for this initially **passed against the broken code** (`maximumPasses: 1`, where the naive guard happens to fire). Reproducing the real shape turned it red.

## 3. The matrix stops measuring one model twice (`493aed2`)

`ollama list` gives `qwen3-coder:30b` and `qwen3-coder:30b-a3b-q4_K_M` the **same digest** — one blob, two tags. A seventh of every run was measuring the same weights twice. The 58.8 vs 61.3 spread between those "two configurations" is the **noise floor at one pass**; treat anything narrower as nothing.

`qwen2.5-coder:14b` also removed (33.4 against a 75 bar, *below* the 7b's 37.7 — formatting noise, not capability). `qwen3.5:27b` added, mirroring `qwen3.8:27b`'s profiles and settings exactly, which makes generation the only variable between them — the only controlled old-vs-new comparison the matrix can support.

## 4. The canary is a current model again (`2b264aa`)

`qwen3.5:9b` replaces `qwen2.5-coder:7b`. The control's job is to make a harness fault legible — when everything drops together, the cause is the harness. At three months old the 7b made that reading ambiguous between "harness broke" and "the old model finally fell over".

## 5. `--no-early-stop`, for diagnostic runs (`6ae33d2`)

Early stop is right for qualification and destructive for diagnosis: an adversarial subset can never qualify, so every configuration halts after one pass and `--runs 3` changes nothing. The repeats *are* the measurement when the question is "can this model do it at all, or only sometimes". The manifest now stamps `diagnostic: true|false` — explicitly false on normal runs, so a diagnostic result can't be quoted as a baseline later by someone who wasn't here.

## Evidence this produced

A 252-attempt diagnostic run over the twelve worst scenarios, three forced passes each, all seven configurations:

- Six budget-denial scenarios: **0 for 21**, every configuration from 9B to 30B. Scenario 92 was 21 attempts, 21 denials, no other outcome. **59 of 103 denials had budget remaining**, concentrated on warden lines (`actor:actor_spawn:wardens` and three affinity categories, 67 occurrences each). That is an Allocator property, not a capability floor.
- The #81 fix confirmed: scenario 14 went 0/7 → **20/21**.

## Gates

tests/tools 22 files / 203 passed, 11 skipped. No production code touched — this is all under `tools/remote-ollama-control` and `tests/tools`. Zero file overlap with `codex/benchmark-integrity-remediation`; `git merge-tree` reports a clean merge against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)