### PR TITLE
docs: one owner per rule in AGENTS.md and CLAUDE.md, and Syncthing removed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-# Environment Variables
-
-# Google Stitch API Key
-# Generate your key at: https://stitch.withgoogle.com (Profile Picture → Stitch settings → API key)
-# This key is used by the Stitch MCP server for AI-assisted UI design and development
-STITCH_API_KEY=your-stitch-api-key-here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,63 +1,32 @@
 # AGENTS.md
 
-This file defines how the solo developer and the agent team work together on this repo.
-Keep it short, strict, and easy to follow.
+How the solo developer and the agent team work together on this repo. Short, strict, easy to follow.
 
-## Session-Start Checklist (run before any coding in a new session)
+**Scope split with `CLAUDE.md` — neither file restates the other.** This one owns the roster, the workflow, per-agent scope, review reality, test and benchmark strategy, file placement, naming, and the pre-handoff checklist. `CLAUDE.md` owns reporting, the session-start protocol, code navigation, commands, the architecture summary, and the enforcement checklist. Change a rule in its owning file only.
 
-Every agent that writes code must complete this checklist at the start of each session, before touching any source file. Do not skip steps or reorder them.
-
-| Step | Command / Action | Confirms |
-|------|-----------------|---------|
-| 1. Prior context | Read `~/vault/plans/active/Plan.md` (START HERE block); read `~/vault/index.md` only if it is sparse | Last-session context loaded |
-| 2. Latest source | `git pull --ff-only` | Working from HEAD, no stale files |
-| 3. Dependencies | `pnpm install --frozen-lockfile` | All packages match lockfile |
-| 4. Tests baseline | `pnpm run test` | No pre-existing failures before changes begin |
-| 5. Agent context refresh | `bash scripts/setup/agent-context.sh` | Branch-local Graphify + CodeContext snapshot refreshed and mirrored |
-| 6. Serena scope check | `python3 scripts/setup/patch-serena-ignored-dirs.py --check` | Serena's hardcoded `build`/`dist` blind spot remains patched |
-| 7. Serena reachable | Any `mcp__serena__*` tool responds | Structural queries available (live LSP — nothing to index, watch, or canary-check) |
-| 8. Orient from graphify | Read `local-codex/CodeContext.md`, then the mirrored Graphify report it names | High-level semantic map loaded before structural queries |
-
-Steps 5–8 are cheap (seconds). Never skip them to save time. Re-run
-`python3 scripts/setup/patch-serena-ignored-dirs.py` after every `uv tool upgrade serena-agent`; an upgrade
-silently restores the blind spot.
-
-> Historical note: the corresponding structural-tool steps used to be "start the CodeContextGraph watch"
-> and "run graph-sanity-check.sh". CodeGraphContext was retired 2026-07-28 after its persistent index went
-> stale-but-confident twice (PT.1's `IGNORE_DIRS` build-plane blindness, then a skipped re-index that dropped
-> all of `tests/`). Serena's language-server answers are computed live from the working tree, so that failure
-> class — and the canary apparatus that guarded it — is gone.
+**Before any coding in a new session**, complete `CLAUDE.md → Session-Start Protocol` in order. It is mandatory for every agent that writes code, not just Claude.
 
 ---
 
-## Agent roster and responsibilities
+## Agent roster
 
 | Agent | Model / Effort | Responsibility |
 |-------|---------------|----------------|
 | **Codex** | GPT-5 tier / high | Ideation, plan authoring, adversarial verification, **implementation of well-specified mechanical milestones** |
 | **Claude Opus** | Opus tier / high | Orchestration — split plans into milestones, assign to agents |
+| **Claude Opus** | Opus tier / high | Normative docs — `docs/architecture-charter.md`, `docs/vision-contract.md`, `docs/architecture/diagram.mmd` (architectural law; maintainer sign-off required) |
 | **Claude Sonnet** | Sonnet tier / high | Implementation — all production code and architecture refactors |
-| **Claude Sonnet** | Sonnet tier / medium | Base test authoring — writes test files with TODO permutation stubs |
-| **Ollama** (local model) | local / — | Test permutation expansion from TODO stubs (`/local-test-gen`), artifact summarization, schema classification (`local_*` MCP) |
-| ~~**Remote Ollama** (GPU node)~~ | — | ~~Content-gen benchmark~~ — **removed from the roster 2026-08-13.** Benchmarking is a standalone nightly tool outside the development process; no agent runs it and no work is delegated to it. |
-| **fast-pass** (subagent) | Haiku (pinned in `.claude/agents/fast-pass.md`) | Test-suite failure detection via Vitest JSON reporter; returns structured failure list; tools: Bash, Read only |
-| **fix-pass** (subagent) | Opus (pinned in `.claude/agents/fix-pass.md`) | Failure diagnosis + minimal fixes; queries Serena on architectural categories; escalates boundary changes; full tools |
-| **codex-reviewer** (subagent) | Sonnet | Review-only wrapper around the Codex adversarial flow; tools: Read, Glob, Grep, Bash — **no Edit/Write** |
-| **Claude Sonnet** | Sonnet tier / medium | Descriptive docs — package / persona READMEs, `docs/README.md`, `docs/readme-index.md`, CLI README — plus commit messages and PR authoring |
-| **Claude Opus** | Opus tier / high | Normative docs — `docs/architecture-charter.md`, `docs/vision-contract.md`, `docs/architecture/diagram.mmd` (architectural law; maintainer sign-off still required) |
+| **Claude Sonnet** | Sonnet tier / medium | Base test authoring (with TODO permutation stubs); descriptive docs — package and persona READMEs, `docs/README.md`, `docs/readme-index.md`, CLI README; commit messages and PRs |
+| **Ollama** (local or remote GPU) | local / — | Test permutation expansion from TODO stubs (`/local-test-gen`); summarization, classification, extraction (`local_*` MCP) |
+| **fast-pass** (subagent) | Haiku tier, pinned in `.claude/agents/fast-pass.md` | Vitest run via JSON reporter → structured failure list `{test, file, category, message}`. Detection only. Tools: Bash, Read |
+| **fix-pass** (subagent) | Opus tier, pinned in `.claude/agents/fix-pass.md` | Diagnosis + minimal fixes, one category at a time, most-architectural first; Serena lookups; escalates boundary changes. Full tools |
+| **codex-reviewer** (subagent) | Sonnet tier | Review-only wrapper around the Codex adversarial flow; verifies claims, relays the verdict. Tools: Read, Glob, Grep, Bash — **no Edit/Write** |
 
-> **Model names, not versions.** This table names model *tiers* (Opus, Sonnet, Haiku, GPT-5), never dated
-> IDs — those churn, and a pinned ID goes stale silently while still looking authoritative. Use the latest
-> release in each tier; pick the exact ID with `/model` or the API. **The effort level (high / medium) is
-> the load-bearing part of each row** and must be preserved when a tier is updated. `CLAUDE.md` states the
-> same policy; the two files must agree.
->
-> ~~The one deliberate exception is the Remote Ollama row: `qwen3-coder:30b-a3b-q4_K_M` is pinned on purpose
-> because the content-gen benchmark baseline is only comparable against that exact model.~~
-> **Retired 2026-08-13 with the row itself.** Model pinning for benchmark comparability is now the
-> nightly tool's concern, not this table's — no agent tier depends on it.
+> **Model names, not versions** — see the note in `CLAUDE.md`. **The effort level (high / medium) is the load-bearing part of each row** and must be preserved when a tier is updated.
 
-Claude's full enforcement rules are in `CLAUDE.md`. Read it to understand what will be changed and why.
+**Repo-owned skills** (`.claude/skills/`): `local-test-gen` (Ollama permutation expansion), `structured-test-authoring` (use the `ak_test_*` MCP tools before hand-writing a test), `tiered-test-optimizer` (the fast-pass → fix-pass recipe). Escalations from `fix-pass` reach the maintainer verbatim; the orchestrator never approves a boundary change itself.
+
+**MCP surfaces:** `agent-kernel-cli` (`ak_*` — authoring, simulation, inspection, LLM planning, IPFS, blockchain, and the `ak_test_*` test harness; `pnpm run mcp:serve`) and `serena` (structural code queries). Prefer `ak_*` tools over shelling out to `ak.mjs`. Registration for both harnesses is documented in `packages/adapters-cli/src/mcp/README.md`.
 
 ---
 
@@ -67,230 +36,135 @@ Claude's full enforcement rules are in `CLAUDE.md`. Read it to understand what w
 Codex (ideation/plan)
     ↓
 Claude Opus (orchestrate: milestone split + agent assignment)
-    ↓  ← generates local-codex/CodeContext.md snapshot before each Codex handoff
+    ↓  ← runs agent-context.sh to regenerate local-codex/CodeContext.md before each Codex handoff
 Claude Sonnet/high (implement)  ← queries Serena MCP for structural lookups
     ↓
 Claude Sonnet/medium (write base tests + TODO permutation stubs)
     ↓
-Ollama (expand permutations in place via /local-test-gen)   ← unit/integration correctness
+Ollama (expand permutations in place via /local-test-gen)
     ↓
 Claude (docs in the SAME diff as the code — Sonnet/medium descriptive, Opus/high normative; then commit + PR)
 ```
 
-**The benchmark is not a step in this pipeline** and was removed from it on 2026-08-13. It runs
-nightly, offline, as a standalone tool; nothing in the flow above waits on it.
+**Docs are not a trailing step.** The agent that changes behavior updates the affected docs in the same diff: it already holds the context, and a doc that contradicts the code is a live hazard, not cosmetic debt — 7 persona READMEs named `.mts` as the canonical source long after `.js` became it, so anyone following them would have edited a re-export shim and their change would silently never run.
 
-**Docs are not a trailing step.** The agent that changes behavior updates the affected docs in the same
-diff, because it already holds the context and a doc that contradicts the code is a live hazard rather
-than cosmetic debt — 7 persona READMEs named `.mts` as the canonical source long after `.js` became it,
-so anyone following them would have edited a re-export shim and their change would silently never run.
+**Benchmarks are not a step in this pipeline** and were removed from it on 2026-08-13.
 
-**Tests vs. benchmarks:**
-- **Tests** (`pnpm run test`) — deterministic correctness: does the code behave as specified? Vitest, fixture-backed, no external services.
-- **Benchmarks** — LLM tool-call surface under load: does the model produce valid tool calls across the scenario permutations? **Run by a standalone nightly tool, offline, outside the development process (2026-08-13).** Not a substitute for tests, not a gate on any diff, and never run from a session. See "Benchmark strategy" below.
+### Codex — ideation, planning, adversarial verification, mechanical implementation
 
-## Serena — shared structural code understanding
+- Produces `local-codex/Plan.md` from a prompt or spec; runs adversarial review on completed diffs.
+- Every adversarial review answers two questions: (1) **Correctness** — does the diff satisfy the milestone spec? (2) **Simplicity** — is it 3× more complex than the simplest solution, and if so what is the specific rewrite?
+- **Implements well-specified mechanical milestones** (decided 2026-07-18): call-site threading behind an already-designed controller API, lint/guard sweeps, bulk test migration to the persona naming scheme, characterization tests written to an explicit spec. The spec must name target files, the exact API to call, validation commands, and a stop condition; Claude verifies the output against those commands before it counts as done.
+- Does **not** design persona controller APIs, change artifact schemas, or make pricing-policy decisions — those stay with Claude, escalating to the maintainer per `CLAUDE.md`.
+- Uses Serena for structural navigation and `rg` for literal text; if Serena is unavailable it says so and reads the files rather than guessing from filenames.
 
-Serena (MCP, language-server-backed) answers structural questions — definitions, callers, references, file symbol maps — **live from the working tree**. There is no persistent index, so there is no rebuild to schedule and no watch to keep alive.
+### Claude Opus — orchestration
 
-**Serena has a patched third-party scope defect.** Its TypeScript adapter hardcodes `node_modules`, `dist`,
-and `build` as ignored directory names before project configuration or `.gitignore` is consulted. The repo's
-`scripts/setup/patch-serena-ignored-dirs.py` removes `dist` and `build` from that list while keeping
-`node_modules`; Serena then applies the project's own `.gitignore`. A restart does **not** fix the hardcoded
-list — run the patch after every Serena upgrade and verify it with `--check` at session start. `.gitignore`
-still affects Serena after that layer, so audit it when a tracked defining file is unexpectedly invisible.
+- Reads the plan, sizes milestones, assigns each to the right agent, and identifies dependency order before any coding starts.
+- Size bands: `XS` ≤ 30 min / ≤ 100 LOC / ≤ 2 files · `S` ≤ 1 hr / ≤ 250 LOC / ≤ 5 files · `M` ≤ 2 hr / ≤ 500 LOC / ≤ 8 files. Anything larger, crossing multiple packages, or changing architecture is split first.
+- At most one `M` or two `S` milestones per Codex task, then stop and produce a handoff summary.
+- Each milestone names: target files, tests, validation commands, and an explicit stop condition.
 
-**An empty or thin result is not proof of absence.** Pass `relative_path` to `find_symbol` when the defining
-file is known, and confirm that file is visible with `get_symbols_overview` before concluding "no callers"
-or "dead code". Definitions are syntactic while references are language-server semantic results; if a
-definition resolves but references do not, verify the file is included in the TypeScript program before
-trusting the result.
+### Claude Sonnet/high — implementation
 
-**Scope:** Serena is for relational/structural queries (`find_symbol`, `find_referencing_symbols`, `find_declaration`, `find_implementations`, `get_symbols_overview`). `grep`/`rg` are legitimate for literal text — prose, fixture strings, exact error messages — and for pattern search, which Serena does not offer; no prior-query justification is required.
+- Implements production code from the milestone spec; refactors clear violations of the enforcement checklist without asking. Preserves intent, corrects structure.
 
-**Failure policy:** if Serena is unavailable, say so explicitly and fall back to reading files; do not guess structure from filenames.
+### Claude Sonnet/medium — base tests
 
-**Documentation agents:** verify a claim against Serena (or the file itself) before writing it down. `local-codex/CodeContext.md`, the snapshot generated by `scripts/setup/agent-context.sh`, remains the cold-start context for Codex handoffs.
-
-### Snapshot generation (before each Codex handoff)
-
-Run `bash scripts/setup/agent-context.sh` before every Codex task. This writes a fresh `local-codex/CodeContext.md` and mirrors branch-local Graphify output under `~/vault/codex-context/agent-kernel/worktrees/<id>/`. Codex reads the snapshot first, then verifies structural detail with Serena against the live tree. Do not reuse a snapshot from a prior milestone.
-
-## Subagent roster (`.claude/agents/`)
-
-| Subagent | Model | Scope | Tools |
-|---|---|---|---|
-| `fast-pass` | Haiku 4.5 (pinned) | Run Vitest via JSON reporter; return structured failure list `{test, file, category, message}`; never edits | Bash, Read |
-| `fix-pass` | Opus 5 (pinned) | Diagnose + fix categorized failures; Serena lookups on Dependency Inversion / Effect Routing; escalates boundary changes to the maintainer | full |
-| `codex-reviewer` | Sonnet | Run Codex adversarial review via the plugin runtime; verify claims; relay verdict; review-only | Read, Glob, Grep, Bash (no Edit/Write) |
-
-Orchestration recipe: `.claude/skills/tiered-test-optimizer/SKILL.md`. Escalations from `fix-pass` go to the maintainer verbatim; the orchestrator never approves boundary changes itself.
-
----
-
-## Codex — ideation, planning, adversarial verification, mechanical implementation
-
-- Produces `local-codex/Plan.md` from a prompt or spec.
-- Runs adversarial review on completed diffs to stress-test design decisions.
-- Uses Serena for structural code navigation: definitions, callers, references, implementations, and symbol
-  maps. Uses `rg` only for literal text and pattern searches. If Serena is unavailable, says so explicitly
-  and reads the relevant files directly rather than guessing structure from filenames.
-- **Implements well-specified mechanical milestones** (decided 2026-07-18 for the Persona
-  Enforcement Program): call-site threading behind an already-designed controller API, lint/guard
-  sweeps, bulk test migration to the persona naming scheme, and characterization tests written to
-  an explicit spec. The milestone spec must name target files, the exact API to call, validation
-  commands, and a stop condition; Claude verifies Codex output against the validation commands
-  before it counts as done.
-- Does **not** design persona controller APIs, change artifact schemas, or make pricing-policy
-  decisions — those stay with Claude, with escalation to the maintainer per `CLAUDE.md`.
-
-## Claude Opus — orchestration
-
-- Reads the plan, sizes milestones (XS / S / M), and assigns each to the correct agent.
-- Identifies dependency order between milestones.
-- Does not begin coding until the plan is decomposed.
-- Milestone size bands:
-  - `XS`: ≤ 30 min, ≤ 100 LOC, ≤ 2 files.
-  - `S`: ≤ 1 hr, ≤ 250 LOC, ≤ 5 files.
-  - `M`: ≤ 2 hr, ≤ 500 LOC, ≤ 8 files.
-  - Anything larger than `M`, crossing multiple packages, or changing architecture must be split before implementation.
-- Execute at most one `M` or two `S` milestones per Codex task; stop and produce a handoff summary after.
-- Each milestone must name: target files, tests, validation commands, and an explicit stop condition.
-
-## Claude Sonnet/high — implementation
-
-- Implements all production code from the milestone spec.
-- Refactors any code that violates the architecture checklist in `CLAUDE.md` — no permission needed for clear violations.
-- Preserves intent; corrects structure.
-
-## Claude Sonnet/medium — base test authoring
-
-- Writes the base test file for each coding milestone.
-- Every base test file **must** end with a `## TODO: Test Permutations` section listing edge cases and boundary conditions as plain-language stubs. This section is the handoff signal to Ollama.
-- For delegated low-complexity permutation work, point the harness at `tests/README.md` first. That file is the repo-local playbook for MCP-backed test expansion by Ollama/local models.
-- Example stub format:
+- Writes the base test file for each coding milestone, ending with a `## TODO: Test Permutations` section — plain-language stubs for edge cases and boundary conditions. That section is the handoff signal to Ollama.
   ```
   ## TODO: Test Permutations
   // - advance() with empty payload should return idle state
   // - advance() with null correlationId should throw validation error
   // - context with circular reference should fail serialization guard
   ```
+- Read `tests/README.md` (the repo-local playbook) before delegating expansion work.
 
-## Ollama — test permutation expansion
+### Ollama — permutation expansion
 
-- Triggered by `/local-test-gen` (repo-owned skill, `.claude/skills/local-test-gen/`), launched via Claude Code harness. Auto-detects the warm Ollama model; remote GPU runs go through `remote-ollama-mac run-local --profile dual`.
-- Reads `## TODO: Test Permutations` stubs and generates concrete test cases in place.
-- Must read `tests/README.md` before expanding permutations or building bounded CLI-option matrices.
-- Should use the test-harness MCP to discover patterns, scaffold or insert cases, and run narrow scopes.
+- Triggered by `/local-test-gen`; auto-detects the warm model, `--model` overrides, remote GPU via `remote-ollama-mac run-local --profile dual`.
+- Must read `tests/README.md` first. Uses the `ak_test_*` MCP tools to discover patterns, scaffold or insert cases, and run narrow scopes.
 - May run bounded CLI argument/option permutations around one command family at a time, then build tests from the distinct failure classes it finds.
-- Does not make architecture decisions or modify production code.
+- Does not make architecture decisions and does not modify production code.
 
-## Documentation and commits — Claude
+### Documentation and commits — Claude
 
-Documentation moved from GitHub Copilot to Claude on 2026-07-27. Docs ship in the **same diff** as the
-code that changes them, not as a trailing pass after merge.
-
-- **Descriptive docs — Sonnet / medium.** Package and persona READMEs, `docs/README.md`,
-  `docs/readme-index.md`, `packages/adapters-cli/README.md`. The content follows from a diff that already
-  exists; the work is accuracy and concision, not design.
-- **Normative docs — Opus / high.** `docs/architecture-charter.md`, `docs/vision-contract.md`,
-  `docs/architecture/diagram.mmd`. These are architectural law: they encode decisions rather than describe
-  code, every later agent obeys them, and an error propagates silently. Maintainer sign-off required.
-- **Commit messages and PRs — Sonnet / medium.** Commit or push only when the maintainer asks.
-- A doc that contradicts the code is a **blocking** defect, not a follow-up — fix it in the diff that made
-  it wrong.
+Documentation moved from GitHub Copilot to Claude on 2026-07-27. Two tiers by stakes: **descriptive** (Sonnet/medium — the content follows from a diff that already exists; the work is accuracy and concision) and **normative** (Opus/high — architectural law that every later agent obeys, where an error propagates silently; maintainer sign-off required). Which files fall in which tier is in `CLAUDE.md → Enforcement Checklist → Documentation`. Commit or push only when the maintainer asks.
 
 ---
 
-## Review — this is a solo project, and self-merge is the normal path
+## Review — solo project, self-merge is the normal path
 
-**There is no second reviewer, and there never will be.** Do not write, plan, or report as though a
-PR is waiting on one.
+**No human second reviewer exists, and none is coming.** Do not write, plan, or report as though a PR is waiting on one.
 
-- **`main` is not review-gated.** The `Protect Main` ruleset carries `deletion` and
-  `non_fast_forward` only — **no `pull_request` rule and no required approving reviews** — plus an
-  admin bypass. Verified 2026-08-14 via `gh api repos/.../rulesets`.
-- ⇒ *An unreviewed PR may be merged by the maintainer at any time.* The recurring note that
-  "GitHub refuses the PR author, so a second account is needed" was **wrong**: nothing was ever
-  requiring the approval it described. It appeared in the plan, was repeated into PR bodies, and was
-  never checked against the actual ruleset.
-- A PR is still worth opening — it is the reviewable unit and the place the reasoning is indexed —
-  but it is a **record, not a gate**. Never block on, or ask the maintainer to arrange, a review.
+- **`main` is not review-gated.** The `Protect Main` ruleset carries `deletion` and `non_fast_forward` only — no `pull_request` rule, no required approving reviews — plus a repository-role bypass. Re-verified 2026-08-21 via `gh api repos/KomplexMojo/agent-kernel/rulesets`.
+- **There is no CI test job.** `.github/workflows/` holds the `@claude` responder and `claude-code-review.yml`, an automated advisory review that comments on every PR. Advisory: it blocks nothing, and it does not run the suite. **The local gates are the only gates that run.**
+- A PR is still worth opening — it is the reviewable unit and where the reasoning is indexed — but it is a **record, not a gate**. Never block on, or ask the maintainer to arrange, a review.
 
-**What replaces review here, and is therefore not optional:**
+**What replaces a reviewer, and is therefore not optional:**
 
 | Instead of a reviewer | The obligation |
 |---|---|
-| a second pair of eyes on correctness | the **gates**: `pnpm run test`, `pnpm run typecheck` at zero, architecture guards, allowlist |
+| a second pair of eyes on correctness | the **gates**: `pnpm run test`, `pnpm run typecheck` at zero, the `tests/architecture/` guards, the persona-boundary allowlist |
 | someone asking "does this test actually work?" | a **perturbation check** per milestone — the specific change that must turn the test red, run and reported |
 | a reviewer noticing a judgement call | judgement calls stated **in the commit message**, not left implicit |
-| a reviewer catching a stale claim | any factual claim about repo or GitHub state is **checked before it is written**, not carried forward from an earlier note |
+| a reviewer catching a stale claim | any factual claim about repo or GitHub state is **checked before it is written**, never carried forward from an earlier note |
 
-⇒ *Losing the reviewer raises the bar on the evidence, it does not lower it.* The commit message is
-where a future reader — who will be an agent, not a human reviewer — reconstructs why.
+⇒ *Losing the reviewer raises the bar on the evidence; it does not lower it.* The commit message is where a future reader — an agent, not a human — reconstructs why.
+
+---
 
 ## Working agreement
 
-- Always connect requirements → tests → code in the same change set when feasible.
+- Connect requirements → tests → code in the same change set whenever feasible.
 - Prefer small, reviewable diffs over large refactors.
-- If a change alters architecture boundaries, the charter + diagram are updated in the SAME diff (Claude Opus/high, maintainer sign-off).
-- Produce code that conforms to the architecture checklist in `CLAUDE.md` before handoff.
+- Architecture boundary changes update the charter + diagram in the SAME diff (Opus/high, maintainer sign-off).
+- Conform to the enforcement checklist in `CLAUDE.md` before handoff.
+- Guardrails, restated because they are absolute: dependency direction is adapters/ui → runtime → core-ts · `core-ts` performs no IO and imports nothing outside itself · external IO only through adapters at the ports boundary.
 
-## Architecture guardrails
+## File placement
 
-- Allowed dependency direction: adapters/ui → runtime → core-ts.
-- `core-ts` performs no IO and imports nothing outside itself.
-- External IO is only via adapters (ports boundary).
-
-## File placement rules
-
-- Runtime code: `packages/runtime/src/`
-- Core logic: `packages/core-ts/src/`
-- Web adapters: `packages/adapters-web/src/adapters/`
-- UI code: `packages/ui-web/src/` (views, panels, templates)
-- CLI adapters and commands: `packages/adapters-cli/src/`
-- Test adapters: `packages/adapters-test/src/`
-- Tests: `tests/**`
-- Shared fixtures: `tests/fixtures/**`
-
-## UI development
-
-- For UI design and development, reference `Design.md` for design principles and Stitch MCP integration.
-- Use Google Stitch MCP server for AI-assisted UI design via `@_davideast/stitch-mcp`.
-- Configure Stitch API key in `.env` (see `.env.example` for template).
-- All UI code must follow the ports & adapters pattern and reside in `packages/ui-web/`.
-- UI tests belong in `tests/ui-web/` and should be fixture-based.
+| What | Where |
+|---|---|
+| Runtime code (personas, ports, runner, contracts) | `packages/runtime/src/` |
+| Core deterministic logic | `packages/core-ts/src/` |
+| Web adapters | `packages/adapters-web/src/adapters/` |
+| CLI adapters, commands, MCP server | `packages/adapters-cli/src/` |
+| Test adapters (fixture doubles) | `packages/adapters-test/src/` |
+| UI code | `packages/ui-web/src/` (`views/` plus panel and controller modules) |
+| Tests | `tests/**` — persona behavior in `tests/personas/<persona>/`, boundary guards in `tests/architecture/` |
+| Shared fixtures | `tests/fixtures/**` (negative cases in `tests/fixtures/artifacts/invalid/`) |
 
 ## Naming conventions
 
 - Artifacts and schemas follow `packages/runtime/src/contracts/artifacts.ts`.
-- Fixture files: `<schema>-v1-<label>.json` (e.g., `intent-envelope-v1-basic.json`).
-- CLI flags mirror `packages/adapters-cli/src/cli/ak.mjs` and README examples.
+- Fixture files: `<schema>-v1-<label>.json` (e.g. `intent-envelope-v1-basic.json`).
+- Persona behavior tests: `tests/personas/<persona>/<persona>-<behavior>.test.*`.
+- CLI flags mirror `packages/adapters-cli/src/cli/ak.mjs` and its README examples.
+
+## UI development
+
+- UI code follows ports & adapters and lives in `packages/ui-web/`; UI tests are fixture-based Vitest suites under `tests/ui-web/`. There is no browser-native runner.
+- Start here: `docs/human-interfaces.md` (offline CLI + UI quickstart) and `RUNME.MD` (Ollama prompt → runtime playback). Serve with `pnpm run serve:ui` (:8001).
+- ⚠️ The Google Stitch MCP integration is **gone** — its POC files were deleted, the `Design.md` this file used to cite has never existed since, and the root `.env.example` (which held nothing but `STITCH_API_KEY`) was removed 2026-08-21. Nothing in the repo reads a Stitch key any more.
 
 ## Test strategy
 
-- Default runner: `pnpm run test` → Vitest for Node-side suites.
-- Use fixture-based tests for deterministic behavior.
-- Add negative fixtures under `tests/fixtures/artifacts/invalid` when adding validation.
-- Base tests are Claude Sonnet/medium's output. Permutations are Ollama's output.
-- **Persona alignment (enforced, per the charter's Persona Model):** persona behavior tests live
-  in `tests/personas/<persona>/` named `<persona>-<behavior>.test.*`. New tests for persona-owned
-  logic go there, not in `tests/runtime/`. A test that asserts only a state label is legacy;
-  legacy tests are removed per migration phase, only after a behavior test replaces them —
-  never before (they are the safety net until then).
+- Default runner: `pnpm run test` → Vitest. Fixture-based for anything deterministic; no test touches a live external service.
+- Add negative fixtures under `tests/fixtures/artifacts/invalid/` when adding validation.
+- Base tests are Sonnet/medium's output; permutations are Ollama's.
+- **Persona alignment (enforced by `tests/architecture/persona-test-layout.test.js`):** persona behavior tests live in `tests/personas/<persona>/`, not `tests/runtime/`. A test that asserts only a state label is legacy — remove it only after a behavior test replaces it, never before; until then it is the safety net.
 
 ## Benchmark strategy
 
-🔴 **BENCHMARKING IS OUTSIDE THE DEVELOPMENT PROCESS (maintainer, 2026-08-13).** It runs as a
-**standalone tool, nightly, against code changes, offline.** The benchmarks have grown complex
-enough that they cannot be run as part of development.
+🔴 **Benchmarking is outside the development process** (maintainer, 2026-08-13). It runs as a standalone tool, against code changes, offline — the benchmarks have grown too complex to run inside the development loop.
 
-Benchmarking is distinct from testing. Tests verify correctness; benchmarks verify that the LLM tool-call surface holds up under permutation load and budget stress. **Only the first of those is an agent's job.**
+Tests verify correctness; benchmarks verify that the LLM tool-call surface holds up under permutation load and budget stress. **Only the first is an agent's job.**
 
-Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`)
+Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`).
 
 - **Never run a benchmark from a session**, and never schedule work around one.
-- **Nothing is "benchmark-gated"** — no milestone, decision, PR or merge waits on a result.
+- **Nothing is benchmark-gated** — no milestone, decision, PR, or merge waits on a result.
 - **Read before running.** Fetch `benchmark-results`, then use `benchmark-result-reader.js` with
   `latest_attempt` for current health or `latest_success` for the last qualifying baseline. The
   reader rejects stale scenario or matrix identities.
@@ -302,47 +176,44 @@ Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`)
   versioned promotion"). A regression is a signal to read and investigate, not routing policy.
 - **The one obligation:** if a change touches the `ak_create` tool schema, `buildArgv`, entity normalization, or CLI arg mapping, say so in the commit message so a nightly result can be attributed to it.
 
+**Where the benchmarks live (verified 2026-08-21):**
+
+🔒 **Hands off until Codex finishes (maintainer, 2026-08-21).** Do not modify the benchmark branches,
+the working clones, or the program docs below while the Codex effort is in flight — that includes
+committing its loose working-tree changes, moving files into git, or tidying. Report state; change nothing.
+
+- **The catalog and harness are under source control**, in this repo on `codex/benchmark-catalog` (working clone `~/Documents/GitHub/agent-kernel-benchmark`). 28 tracked files under `tools/remote-ollama-control/benchmarks/` — the canonical content-gen catalog is **100 scenarios** (25 simple · 25 affinity · 25 complex · 25 constrained) plus the execution and abstract-plan catalogs and their schemas. Results publish to the `benchmark-results` branch.
+- **That branch has not merged**: 9 ahead of `main`, 20 behind. `main` still carries the older harness under `tools/`, so agent-kernel `main` is not where benchmark state is read.
+- `codex/benchmark-e3` exists **only locally** (`~/Documents/GitHub/agent-kernel-benchmark-e3`), with no commits of its own — its E3 work is entirely uncommitted working-tree change.
+- **The program roadmap and execution record are NOT under source control:** `local-codex/Plan-Benchmark.md` and `local-codex/Documentation-Benchmark.md` — `local-codex/` is gitignored, and unlike `Plan.md` these two are real files, not vault symlinks. They exist on one machine with no backup.
+- Run output (`tools/remote-ollama-control/results/`, 7.6 GB) is gitignored by design and stays that way.
+- **Nothing benchmark-related is in the Obsidian vault.** The cross-device-consistency rationale that once justified syncing them no longer applies.
+
 ## Large-change artifacts
 
-- For large deliverables, use `local-codex/Prompt.md`, `local-codex/Plan.md`, `local-codex/Implement.md`, and `local-codex/Documentation.md` as the execution source of truth.
-- Read all four files before making code changes.
-- Execute milestones as requirements → tests → code → validation.
-- Update `local-codex/Documentation.md` (status, decisions, validation log) before handoff.
+- For large deliverables, `local-codex/Prompt.md`, `Plan.md`, `Implement.md`, and `Documentation.md` are the execution source of truth. Read all four before making code changes.
+- Execute milestones as requirements → tests → code → validation, and update `local-codex/Documentation.md` (status, decisions, validation log) before handoff.
 
 ## Pre-handoff checklist (before commit)
 
-- `local-codex/CodeContext.md` regenerated via `agent-context.sh` before this Codex task started.
+- `local-codex/CodeContext.md` regenerated via `agent-context.sh` before this task started.
 - Requirements → tests → code traceable in the diff.
-- Dependency direction: adapters/ui → runtime → core-ts. No inversions.
-- No `core-ts` IO or forbidden imports.
+- Dependency direction intact; no `core-ts` IO or forbidden imports.
 - Personas are pure FSMs: `view()` + `advance(event, payload)`, clock injected, context serializable.
-- Persona boundary respected: no imports of persona internals from outside the persona's directory (controllers/persona.js only); no domain logic in glue code (kernel, card-authoring, orchestrate-build, adapters).
-- All boundary-crossing data uses a versioned artifact schema from `contracts/artifacts.ts`.
-- New files placed in the correct package (see file placement rules above).
-- Base test file present and includes `## TODO: Test Permutations` stubs (or Ollama has already expanded them).
-- Tests pass locally or documented reason for skipping.
-- **If `ak_create` schema, CLI arg mapping, or entity normalization changed:** say so in the commit message so the nightly benchmark result can be attributed to the change. **Do not run a benchmark** — it is a standalone nightly tool outside the development process, and no merge waits on it.
-- Architecture / design / README docs updated IN THIS DIFF if behavior or boundaries changed (not queued for later) — a doc that now contradicts the code is a blocking defect.
+- Persona boundary respected: no imports of persona internals from outside the persona directory; no domain logic in glue code.
+- All boundary-crossing data uses a versioned schema from `contracts/artifacts.ts`.
+- New files in the correct package (see file placement).
+- Base test file present, ending in `## TODO: Test Permutations` stubs (or Ollama has already expanded them).
+- `pnpm run test` and `pnpm run typecheck` pass, or a documented reason for skipping. Perturbation check run and reported.
+- Docs updated IN THIS DIFF if behavior or boundaries changed — a doc that now contradicts the code is a blocking defect.
+- If `ak_create` schema, CLI arg mapping, or entity normalization changed: noted in the commit message. **Do not run a benchmark.**
 
 ---
 
 ## Vault-Backed Knowledge Management
 
-This repo is paired with an Obsidian vault that holds non-load-bearing knowledge. The
-`local-codex/` directory in this repo is **symlinks** into the vault — all reads and writes
-to `local-codex/Plan.md`, `Prompt.md`, `Implement.md`, `Documentation.md`, `Dictation.md`,
-and `CodeContext.md` transparently target `~/vault/plans/active/...` and
-`~/vault/sources/codex-snapshots/...`.
+This repo is paired with an Obsidian vault holding non-load-bearing knowledge. `local-codex/` is **symlinks** into it: reads and writes of `Plan.md`, `Prompt.md`, `Implement.md`, `Documentation.md`, `Dictation.md`, and `CodeContext.md` transparently target `~/vault/plans/active/...` and `~/vault/sources/codex-snapshots/...`.
 
-For Codex specifically:
-- Active plan: `local-codex/Plan.md` (= `~/vault/plans/active/Plan.md`)
-- Active prompt: `local-codex/Prompt.md` (= `~/vault/plans/active/Prompt.md`)
-- Orientation snapshot: `local-codex/CodeContext.md`
-- Cheatsheets: `~/vault/concepts/CODEX-CHEATSHEET.md`,
-  `~/vault/concepts/MODEL-SELECTION-CHEATSHEET.md`
+For Codex specifically: active plan `local-codex/Plan.md`, active prompt `local-codex/Prompt.md`, orientation snapshot `local-codex/CodeContext.md`, cheatsheets `~/vault/concepts/CODEX-CHEATSHEET.md` and `~/vault/concepts/MODEL-SELECTION-CHEATSHEET.md`. Session decisions are saved by Claude's `/save` to `~/vault/decisions/`; Codex reads decisions but does not author them.
 
-Decisions made during a session are saved via Claude's `/save` to `~/vault/decisions/`.
-Codex reads decisions but does not author them directly.
-
-Setup: `bash scripts/setup/setup-km.sh` on each machine. Migration runs once on the Mac
-(primary) and is propagated to the Ubuntu box via `git pull`.
+Setup: `bash scripts/setup/setup-km.sh` on each machine. **Vault storage hazards and the retired session hooks are in `CLAUDE.md → Vault-Backed Knowledge Management` — read them before writing anything into the vault.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,15 @@ Claude is the **orchestration, implementation, and documentation engine**. Codex
 
 **The persona model is enforced** (charter → "Persona Model — ENFORCED"): all domain logic lives in one of the seven personas; everything else is glue; external code imports persona controllers only. The Allocator alone owns pricing.
 
-> **Model names, not versions.** This file names model *tiers* (Opus, Sonnet, Haiku, GPT-5) rather than dated IDs, which churn. Use the latest release in each tier; pick the exact ID with `/model` or the API.
+**Which file owns what — neither file restates the other.** This one owns: reporting, session start, code navigation, commands, architecture summary, the enforcement checklist, escalation. `AGENTS.md` owns: the agent roster and tiers, the handoff workflow, per-agent scope, test and benchmark strategy, file placement, naming, the pre-handoff checklist. Change a rule in its owning file only; a rule copied into both will drift and one copy will be wrong.
+
+> **Model names, not versions.** Both files name model *tiers* (Opus, Sonnet, Haiku, GPT-5), never dated IDs — those churn and go stale while still looking authoritative. Use the latest release in each tier; pick the exact ID with `/model` or the API.
 
 ---
 
 ## Reporting to the Maintainer — SUMMARIZE
 
-The maintainer reads chat for **two things only**: *is this going the right way*, and *is there a decision for me*. Internal mechanics are not wanted in chat — they belong in the durable record.
+The maintainer reads chat for **two things only**: *is this going the right way*, and *is there a decision for me*. Internal mechanics belong in the durable record, not in chat.
 
 **Hard cap: at most 5 bullets, each ≤50 words.** No preamble, no restating the request, no closing summary. Omit any heading with nothing to say — 5 is a ceiling, not a target, and 2 is a good answer. If it will not fit, the overflow belongs in the commit message or the plan, not in a longer reply.
 
@@ -23,84 +25,52 @@ The maintainer reads chat for **two things only**: *is this going the right way*
 
 **Never in chat:** file-by-file mechanics · what a guard or test does · how a refactor was threaded · perturbation narratives · restating the commit message · tables of internals · reasoning already captured elsewhere.
 
-**The detail is relocated, not deleted — this is what licenses the brevity:** *why/what changed* → commit message · *next, blocked, decided* → `~/vault/plans/active/Plan.md` · *architecture rationale* → `~/vault/decisions/`. **Never trade rigor for brevity: do the same work, report less of it.** A shorter report must not mean a shallower check.
+**The detail is relocated, not deleted — that is what licenses the brevity:** *why/what changed* → commit message · *next, blocked, decided* → `~/vault/plans/active/Plan.md` · *architecture rationale* → `~/vault/decisions/`. **Never trade rigor for brevity: do the same work, report less of it.**
 
-**Surface immediately, do not batch:** a failed premise, a milestone discovered to be blocked, scope that grew, or anything that changes what the maintainer would ask for next. Those are direction signals, not progress updates — mid-task is the right time.
+**Surface immediately, do not batch:** a failed premise, a milestone discovered to be blocked, scope that grew, or anything that changes what the maintainer would ask for next. Those are direction signals, not progress updates.
 
-**Depth on request:** "why" / "show me" / "expand" → full reasoning, no summarizing. Assume the short form otherwise.
+**Depth on request:** "why" / "show me" / "expand" → full reasoning, no summarizing. Assume the short form otherwise. **Long or autonomous runs:** report at milestone boundaries, not per step.
 
-**Long or autonomous runs:** report at milestone boundaries, not per step.
+---
 
-## Session-Start Protocol (mandatory before first code change)
+## Session-Start Protocol (mandatory before the first code change)
 
-Run the full checklist in `AGENTS.md → Session-Start Checklist`. Short form — **not optional**; a stale vault or missing deps produce wrong structural answers that compound:
+Not optional — a stale vault or an unpatched tool produces wrong structural answers that compound. Steps 5–8 cost seconds.
 
 1. Read `~/vault/plans/active/Plan.md` — the START HERE block is the last-session handoff; `~/vault/index.md` only if it is sparse
 2. `git pull --ff-only` — confirm on HEAD
 3. `pnpm install --frozen-lockfile` — confirm lockfile match
 4. `pnpm run test` — confirm no pre-existing failures
 5. `bash scripts/setup/agent-context.sh` — refresh branch-local Graphify + `local-codex/CodeContext.md`
-6. `python3 scripts/setup/patch-serena-ignored-dirs.py --check` — Serena's `build/` blind spot; re-apply after any `uv tool upgrade serena-agent`
-7. Confirm the Serena MCP is connected (any `mcp__serena__*` tool responds). Serena answers structural queries live from the language server — there is no index to build, watch, or sanity-check
+6. `python3 scripts/setup/patch-serena-ignored-dirs.py --check` — exits 1 if Serena's hardcoded `build`/`dist` blind spot is back; re-apply after any `uv tool upgrade serena-agent`
+7. Confirm the Serena MCP responds (any `mcp__serena__*` tool). Answers are live from the language server — nothing to index, watch, or canary-check
 8. Read `local-codex/CodeContext.md`, then the Graphify report it names
 
 ---
 
-## Multi-Agent Delegation
+## Delegating work
 
-| Task | Agent / Tier | Mechanism |
-|------|-------|-----------|
-| Ideation, plan authoring | **Codex** (GPT-5, high) | `/codex:review` |
-| Adversarial plan / code verification | **Codex** (GPT-5, high) | `/codex:adversarial-review` |
-| Mechanical implementation from a complete milestone spec | **Codex** (GPT-5, high) | `/codex:rescue` |
-| Orchestration — split plans, assign milestones | **Claude Opus** (high) | Direct |
-| Implementation — write / refactor code | **Claude Sonnet** (high) | Direct |
-| Author base tests (with TODO permutation stubs) | **Claude Sonnet** (medium) | Direct |
-| Test-suite failure detection (structured JSON, no log dumps) | **Claude Haiku** (`fast-pass` subagent) | `/tiered-test-optimizer` |
-| Test-failure diagnosis + fix | **Claude Opus** (`fix-pass` subagent) | `/tiered-test-optimizer` |
-| Adversarial-review relay (review-only, no Edit/Write) | **Claude Sonnet** (`codex-reviewer` subagent) | wraps `/codex:adversarial-review` |
-| Expand test permutations from TODO stubs | **Ollama** (local) | `/local-test-gen` |
-| Summarize / classify / extract structured data | **Ollama** (local) | `local_*` via MCP |
-| ~~Content-gen benchmark~~ — **not delegable work; it left the development loop 2026-08-13.** Runs nightly as a standalone offline tool. | — | — |
-| Descriptive docs — package / persona READMEs, `docs/README.md`, `docs/readme-index.md`, CLI README | **Claude Sonnet** (medium) | Direct |
-| Normative docs — `docs/architecture-charter.md`, `docs/vision-contract.md`, `docs/architecture/diagram.mmd` | **Claude Opus** (high) | Direct |
-| Commit messages, PRs | **Claude Sonnet** (medium) | Direct + `gh` CLI |
+The full roster (models, effort levels, tools, scope limits) is in `AGENTS.md → Agent roster`. The routes Claude invokes directly:
 
-Structural code questions go through the **Serena MCP** (live language-server answers). The **Ollama tier is strategic, not legacy**: local Ollama (via `local_*` MCP tools and `/local-test-gen`) is the no-cost path for decomposable subtasks; the remote dual-GPU box runs heavy batch work. Subagents cannot run on Ollama models, so the low-cost tier stays skill/MCP-mediated by design. **The content-gen benchmark is no longer part of this tiering** — it is a standalone nightly tool outside the development loop.
+| Need | Route |
+|---|---|
+| Ideation, plan authoring | `/codex:review` |
+| Adversarial verification of a plan or diff | `/codex:adversarial-review`, or the `codex-reviewer` subagent |
+| Mechanical implementation from a complete milestone spec | `/codex:rescue` |
+| Full suite run + triage + fix | `/tiered-test-optimizer` (`fast-pass` → `fix-pass` subagents) |
+| Expand `## TODO: Test Permutations` stubs | `/local-test-gen` (Ollama, local or remote GPU) |
+| Author or scaffold a test to an existing recipe | `/structured-test-authoring` + the `ak_test_*` MCP tools |
+| Summarize / classify / extract structured data | `local_*` MCP tools (Ollama) |
 
-- **Codex** — ideation, plan authoring (`local-codex/Plan.md` → `~/vault/plans/active/Plan.md`), adversarial review, and **mechanical implementation** (since 2026-07-18): call-site threading behind an already-designed controller API, guard/lint sweeps, bulk test migration, characterization tests to an explicit spec. Requires a complete milestone spec (target files, exact API, validation commands, stop condition); Claude verifies output against the validation commands. Codex does NOT design persona APIs, change artifact schemas, or decide pricing policy. Every adversarial review answers: (1) **Correctness** — does the diff satisfy the milestone spec? (2) **Simplicity** — is it 3× more complex than the simplest solution? If so, give a specific rewrite.
-- **Claude** — before any milestone code: state assumptions, surface ambiguity (stop and ask rather than guess), present tradeoffs if a simpler path exists. Implementation order: (1) failing tests + `## TODO: Test Permutations` stubs → (2) production code → (3) hand stubs to Ollama.
-- **Ollama** — expands `## TODO: Test Permutations` stubs in place via `/local-test-gen` (auto-detects the warm model; `--model` to override; remote GPU via `remote-ollama-mac run-local`). Read `tests/README.md` first. Not for architecture, enforcement review, or persona FSM design.
-- **Subagents** (`.claude/agents/`) — `fast-pass` (Haiku, detection-only, structured Vitest JSON), `fix-pass` (Opus, diagnosis + minimal fixes, queries Serena on architectural categories, escalates boundary changes), `codex-reviewer` (Sonnet, review-only wrapper around the Codex adversarial flow). Roster details in `AGENTS.md`.
-- **Documentation (Claude, since 2026-07-27 — replaces GitHub Copilot).** Docs are written by the agent that made the change, in the **same diff** as the code: it already holds the context, and a stale doc is a live hazard, not a cosmetic debt (7 persona READMEs asserted `.mts` was the canonical source long after `.js` became it — anyone following them would have edited a re-export shim and their change would silently never run). Two tiers by stakes:
-  - **Descriptive docs → Sonnet (medium).** Package/persona READMEs, `docs/README.md`, `docs/readme-index.md`, `packages/adapters-cli/README.md`. The content follows from a diff that already exists; the work is accuracy and concision, not design — the same tier as authoring base tests. Whoever changes behavior updates these in the same diff.
-  - **Normative docs → Opus (high).** `docs/architecture-charter.md`, `docs/vision-contract.md`, `docs/architecture/diagram.mmd`. These are architectural **law**: every future agent obeys them, they encode decisions rather than describe code, and an error propagates silently across every later milestone. Same tier as orchestration. Charter/vision edits still require maintainer sign-off (see Refactoring and Escalation).
-  - **Commit messages and PRs → Sonnet (medium).** Commit or push only when the maintainer asks.
+**Before any milestone code:** state assumptions, surface ambiguity (stop and ask rather than guess), present the tradeoff if a simpler path exists. Implementation order is (1) failing tests + `## TODO: Test Permutations` stubs → (2) production code → (3) hand the stubs to Ollama.
+
+**The `agent-kernel-cli` MCP server** (`pnpm run mcp:serve`, tools `ak_*`) is the preferred surface for authoring, simulation, inspection, LLM planning, and adapter operations — use it instead of shelling out to `ak.mjs` when it is connected.
+
+**Ollama is strategic, not legacy.** It is the no-cost path for decomposable subtasks; the remote dual-GPU box runs heavy batch work. Subagents cannot run on Ollama models, so that tier stays skill/MCP-mediated by design.
 
 ---
 
-## Code Navigation — Serena (structural) vs graphify (conceptual) vs grep (literal)
-
-Serena replaced CodeGraphContext on 2026-07-28. It wraps the live language server — answers are computed on demand from current file state, so the *index* staleness class (dead watches, a rebuild that silently drops a directory, sanity canaries) no longer exists.
-
-✅ **SERENA'S `build/` BLIND SPOT IS FIXED (2026-08-01) — but the fix lives outside the repo and an upgrade silently undoes it.**
-
-`build` is **hardcoded** in Serena's TypeScript adapter — `solidlsp/language_servers/typescript_language_server.py:199-204` blocks `["node_modules", "dist", "build"]`, and `solidlsp/ls.py:1197-1204` tests **every directory component** of a requested path against that list, returning "ignored" **before** `.gitignore`, `ignored_paths`, or any config is read. There is no config key that reaches it (`ignored_paths` is a different layer; `ls_specific_settings` goes to the language server).
-
-**The fix:** `scripts/setup/patch-serena-ignored-dirs.py` removes `dist` and `build` from that hardcoded list (keeping `node_modules`, whose cost is real). Safe because the list is redundant with `.gitignore` for genuine build output and Serena still applies `.gitignore` afterwards — so the decision defers to the project's own declaration.
-
-- ⚠️ **RE-RUN IT AFTER EVERY `uv tool upgrade serena-agent`** — an upgrade replaces the file and restores the blind spot with no error. `--check` exits 1 when the patch is missing and is step 6 of the session-start checklist.
-- **Never "owe a restart" for this class of problem** — a 26-second-old process failed identically. The verdict came from code, not config.
-- The earlier `.gitignore` `build/` rule was a *real, separate* bug and was correctly fixed by deleting it; it simply was not the whole story.
-- Carry forward: **`find_symbol` errors loudly only when you pass `relative_path`** — otherwise it degrades silently and returns wrong rows (18 test-local consts and never the definition). `find_referencing_symbols` errors loudly.
-
-This is the **fifth** occurrence of the repo's `build`-directory trap (CGC `IGNORE_DIRS` · `.gitignore` hiding tests from CI · dead `.cgcignore` · Serena-via-`.gitignore` · Serena-hardcoded) and the first not fixable by configuration. When adopting any new tool, check not just *what* its ignore list contains but *whether that list is reachable from config at all*.
-
-✅ **THE BIGGER PROBLEM WAS `tsconfig.json`, AND IT IS FIXED (2026-07-31).** Separately from the `build` blind spot, `find_referencing_symbols` used to return `{}` for **every `.js`/`.mjs` symbol in the repo** — 211 of 268 production files, i.e. essentially all canonical source. Cause: `tsconfig.json` had **no `allowJs`** (defaults `false`), so `.js` files were never in the TypeScript program, and `include` covered only `personas/`, `core-ts/`, `contracts/`, `tests/`, `docs/` — leaving `runner/`, `build/`, `commands/`, `ports/`, `adaptive-workflow/`, `render/` and every adapter package outside it. Definitions still resolved (document symbols are syntactic, per-file); **references did not** (semantic, program-wide). That asymmetry is the whole tell.
-
-Fixed by adding `"allowJs": true`, `"checkJs": false` and broadening `include` to `packages/*/src/**/*`. Suite unchanged (348 files / 2691 passed). There is no `tsc`/typecheck script, so `tsconfig.json` is consumed only by editors and language servers — this is a tooling-only change.
-
-⚠️ **THE "`export *` BARRELS ARE NOT TRACED" NOTE IS RETRACTED.** That was a *symptom* of the same `allowJs` gap, not a separate limitation. With `allowJs` on, `find_referencing_symbols("createModeratorPersona", ".../moderator/controller.js")` correctly returns the callers that import through `personas/moderator/persona.js`. Do **not** work around a barrel; the tool handles it.
+## Code Navigation — Serena (structural) · graphify (conceptual) · grep (literal)
 
 | Question | Use |
 |---|---|
@@ -108,50 +78,29 @@ Fixed by adding `"allowJs": true`, `"checkJs": false` and broadening `include` t
 | Who calls / imports X? (port → adapter, blast radius) | Serena `find_referencing_symbols` |
 | What's in this file? | Serena `get_symbols_overview` |
 | What implements this interface / where is it declared? | Serena `find_implementations` / `find_declaration` |
-| How do concepts cluster? / High-level orientation | `graphify-out/GRAPH_REPORT.md` (**not** a wiki — see below) |
-| Literal text: prose, fixture strings, exact commands/messages | `grep`/`rg` — no justification needed |
+| How do concepts cluster? / high-level orientation | `graphify-out/GRAPH_REPORT.md` |
+| Literal text: prose, fixture strings, exact commands or messages | `grep`/`rg` — no justification needed |
 
-- **Scope:** Serena is for relational/structural queries only. grep is legitimate for literal content and needs no prior MCP query — the old "name the query you tried first" rule is retired.
-- **Failure policy:** if Serena is unavailable, say so and fall back to reading files — don't guess structure from filenames.
-- **Re-run `/graphify` only for:** post-milestone docs passes, onboarding a new agent, or a major structural refactor.
+- **Serena answers live from the language server.** There is no index to rebuild, watch, or sanity-check.
+- ⚠️ **Re-run `python3 scripts/setup/patch-serena-ignored-dirs.py` after every `uv tool upgrade serena-agent`.** `build`/`dist` are hardcoded as ignored directories in Serena's TypeScript adapter, *before* config or `.gitignore` is consulted — no config key reaches them, and an upgrade silently restores the blind spot. This was the repo's fifth ignore-list trap: when adopting any tool, check not just *what* its ignore list holds but *whether config can reach it at all*.
+- ⚠️ **`tsconfig.json` must keep `allowJs: true` and `include: packages/*/src/**/*`.** Without them the `.js`/`.mjs` majority of the repo is outside the TypeScript program and `find_referencing_symbols` returns `{}` for it while definitions still resolve — a silent, one-sided failure. `tsconfig.json` is consumed only by editors and language servers; the typecheck gate uses `tsconfig.typecheck.json`.
+- ⚠️ **An empty result is not proof of absence.** Pass `relative_path` to `find_symbol` — without it, it degrades silently and returns wrong rows instead of erroring. `find_referencing_symbols` errors loudly.
+- **Failure policy:** if Serena is unavailable, say so and read the files — never guess structure from filenames.
 
-### graphify — keeping the graph and the picture current
+### graphify
 
-The knowledge graph lives in `graphify-out/`. These rules moved here from
-`/Users/darren/CLAUDE.md` on 2026-08-17: they are **project** instructions, and sitting in a
-home-directory file meant they were machine-local — invisible to a fresh clone, to CI, and to anyone
-but this machine. Only genuinely machine-level facts (which Python has graphify) stay there.
-
-**Rebuild after changing code, and redraw the picture with it:**
+The knowledge graph lives in `graphify-out/`. Rebuild after changing code, and redraw the picture with it:
 
 ```bash
 graphify update . && python3 scripts/setup/regenerate-graph-viz.py
 ```
 
-- `graphify update .` re-extracts every code file and rewrites `graph.json` + `GRAPH_REPORT.md`.
-  No LLM, no network.
-- ⚠️ **A rebuild does NOT redraw `graph.html`.** `to_html` is called only from the full `/graphify`
-  skill flow, and `graph.html` is gitignored — so it drifts with nothing to surface the gap. It was
-  **three months stale** when this was written. That is why the regeneration is chained above.
-- `scripts/setup/regenerate-graph-viz.py` re-execs under the interpreter recorded in
-  `graphify-out/.graphify_python`, so it works whichever `python3` is on PATH. It reads graphify's
-  own `MAX_NODES_FOR_VIZ` rather than restating it, and **skips with exit 0** above that ceiling —
-  a graph too large to draw is not a failed rebuild. Headroom is worth watching: ~3400 of 5000, and
-  it grew ~113 nodes in a single session.
-- ⚠️ **`graphify-out/wiki/` does not exist and never has.** `to_wiki` is a graphify export that has
-  simply never been run here. The navigation table above pointed at `graphify-out/wiki/index.md` for
-  months — permanently inert, and phrased as a live instruction. Navigate `GRAPH_REPORT.md` and
-  `graph.json` instead. If you ever do generate the wiki, say so here and restore the preference.
-- ⚠️ **`graphify-out/manifest.json` is tracked but a rebuild does not refresh it** — it is the
-  watch-mode change-detection cache, not a record of the graph. After a rebuild the graph contains
-  files the manifest does not list. Expected, not drift.
-- `GRAPH_REPORT.md` looks permanently modified because **the report is inside the corpus**, so each
-  rebuild counts the previous report and the word count shifts. A no-op rebuild still dirties it.
-- The visualization is an interactive vis-network view (search, click-to-inspect, community filter).
-  Open `graphify-out/graph.html` directly; no server needed. Community names will be generic
-  `Community N` — naming needs the LLM pass of a full `/graphify` run, which the no-LLM rebuild skips.
-
-**Codex handoffs:** run `bash scripts/setup/agent-context.sh` to write `local-codex/CodeContext.md` and mirror Graphify. Codex reads the snapshot, then verifies structural claims against its own tooling; Claude cites Serena queries when justifying a target area.
+- `graphify update .` re-extracts every code file and rewrites `graph.json` + `GRAPH_REPORT.md`. No LLM, no network. It does **not** redraw `graph.html` — that is why the regeneration is chained above (`graph.html` is gitignored, so drift there surfaces nothing).
+- `regenerate-graph-viz.py` re-execs under the interpreter recorded in `graphify-out/.graphify_python`, and **skips with exit 0** above graphify's own `MAX_NODES_FOR_VIZ` — a graph too large to draw is not a failed rebuild. Headroom is worth watching (~3400 of 5000, growing ~100 nodes per active session).
+- `graphify-out/wiki/` **does not exist** — `to_wiki` has never been run here. Navigate `GRAPH_REPORT.md` and `graph.json`. If you ever generate the wiki, say so here.
+- `graphify-out/manifest.json` is the watch-mode change cache; a rebuild does not refresh it. `GRAPH_REPORT.md` looks permanently modified because the report is inside the corpus. Both are expected, not drift.
+- Full `/graphify` (LLM pass, community naming) is for post-milestone docs passes, onboarding a new agent, or a major structural refactor.
+- **Codex handoffs:** `bash scripts/setup/agent-context.sh` writes `local-codex/CodeContext.md` and mirrors Graphify. Codex reads the snapshot, then verifies structural claims with its own tooling; Claude cites Serena queries when justifying a target area.
 
 ---
 
@@ -162,31 +111,24 @@ pnpm install                                          # Install dependencies
 pnpm run test                                         # Vitest suite
 pnpm run test -- --reporter=json --outputFile=<f>     # Structured results (what fast-pass uses)
 pnpm run test:vitest -- tests/<path>/<name>.test.js   # Single Vitest file
+pnpm run test:coverage:core-ts                        # core-ts coverage report
 pnpm run typecheck                                    # Typecheck gate (core-ts + its tests, strict)
 pnpm run typecheck:report                             # Cost of widening the gate, per package
 pnpm run typecheck:report -- --check-js               # ...including .js: the all-TypeScript size
+pnpm run mcp:serve                                    # agent-kernel-cli MCP server (ak_* tools)
 pnpm run serve:ui                                     # UI dev server :8001
 pnpm run demo:cli                                     # CLI demo
 ```
 
-**Content-gen benchmark — NOT part of development (maintainer, 2026-08-13).** It runs as a **standalone tool, nightly, against code changes, offline**. The benchmarks have grown complex enough that they cannot be run inside the development loop.
+**There is no CI test job.** `.github/workflows/` holds only the `@claude` responder and an advisory PR review. The gates above are local and are the only ones that run — see `AGENTS.md → Review`.
 
-Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`)
-
-- **Do not run `run-content-gen` from a session**, and do not schedule work around one.
-- **Nothing is "benchmark-gated".** No milestone, decision, PR or merge waits on a benchmark result.
-- Pass bars and baselines belong to the nightly tool, not to a diff.
-- Fetch `benchmark-results` and use `benchmark-result-reader.js`: `latest_attempt` reports current
-  health, while `latest_success` reports the last qualifying baseline. Identity mismatch is an error.
-- Compact JSON is source-controlled only on `benchmark-results`; raw benchmark evidence remains local.
-- Benchmark measurements are **offline evidence** (charter: they "cannot rewrite routing policy without an explicit, versioned promotion"). A nightly regression is a signal to read, not a deliverable to produce.
-- **The one obligation:** if a change touches the `ak_create` tool schema, CLI arg mapping, or entity normalization, say so in the commit message so a nightly result can be attributed to it.
+**Benchmarks are outside development** (maintainer, 2026-08-13): a standalone offline tool. Never run one from a session, never gate a diff on one. Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`). Read results rather than producing them — fetch `benchmark-results` and use `benchmark-result-reader.js` (`latest_attempt` for current health, `latest_success` for the last qualifying baseline; identity mismatch is an error). Full rule in `AGENTS.md → Benchmark strategy`.
 
 ---
 
 ## Architecture
 
-Pure-TypeScript simulation kernel using **Ports & Adapters** with deterministic persona state machines. `pnpm` monorepo (`packages/*`). There is no WASM build step — the core runs directly under Node.
+Pure-TypeScript simulation kernel using **Ports & Adapters** with deterministic persona state machines. `pnpm` monorepo (`packages/*`). No WASM build step — the core runs directly under Node.
 
 **Dependency direction (non-negotiable):** `adapters-* / ui-web` → `runtime` (personas) → `core-ts` (pure logic, no IO). Violations are **blocking** — do not approve.
 
@@ -195,23 +137,15 @@ Pure-TypeScript simulation kernel using **Ports & Adapters** with deterministic 
 | `core-ts` | Deterministic simulation: state transitions, validation, effect emission as data. No IO, no clock, no imports outside itself. |
 | `runtime` | Persona FSMs, tick orchestration, artifact contracts, effect routing (ESM). |
 | `adapters-web` | Browser IO (fetch, IndexedDB). |
-| `adapters-cli` | CLI commands (`packages/adapters-cli/src/cli/ak.mjs`). |
+| `adapters-cli` | CLI commands (`packages/adapters-cli/src/cli/ak.mjs`) and the MCP server. |
 | `adapters-test` | Fixture-based deterministic test doubles. |
 | `ui-web` | Browser UI; imports the synchronous TypeScript core via runtime adapters. |
 
-```
-tests/
-  integration/   # end-to-end (UI↔CLI equivalence, LLM)
-  contracts/     # artifact schema validation
-  runtime/       # persona replay, orchestration, budget
-  fixtures/      # shared test data; invalid/ holds negative cases
-```
-
----
+Tests live under `tests/` — `personas/` (persona behavior), `runtime/`, `core-ts/`, `contracts/` (artifact schemas), `architecture/` (the boundary guards), `integration/` (UI↔CLI equivalence, LLM), `adapters-*`, `ui-web/`, `fixtures/` (shared data; `invalid/` holds negative cases).
 
 ## Design Pattern: Ports & Adapters with Persona State Machines
 
-**core-ts** — only deterministic logic (state transitions, validation, render-frame generation, effects as data). No IO, no env access, no clock, no external imports. Any IO/import introduced here must move to the correct layer before the change lands.
+**core-ts** — only deterministic logic (state transitions, validation, render-frame generation, effects as data). No IO, no env access, no clock, no external imports. Any IO or import introduced here moves to the correct layer before the change lands.
 
 **Runtime personas** — each is a deterministic state machine. Clock injected (never read directly). Context serializable (no class instances, no functions). Effects returned as data and routed via `ports/effects.js`, never executed inline.
 
@@ -234,35 +168,33 @@ advance(event, payload): { state, context, effects }
 | Annotator | emit, summarize | Telemetry capture and normalization |
 | Moderator | all | Tick control, ordering strategy, effect fulfillment |
 
-New personas require `controller.js`, `state-machine.js`, `contracts.ts`, and at least one state handler.
+New personas require `controller.js`, `state-machine.js`, `persona.js`, `contracts.ts`, a `README.md`, and at least one state handler.
 
 **Adapters** — all external IO (LLM, IPFS, blockchain, solver, logging) lives only in `adapters-web/-cli/-test`. Adapters receive effects from `runtime/src/ports/effects.js`; they do not pull state. Test adapters are fixture-based and fully deterministic.
 
-**Artifacts** — all boundary-crossing data uses a versioned schema from `packages/runtime/src/contracts/artifacts.ts`: `{ schema: "agent-kernel/ArtifactName", schemaVersion: 1, meta: ArtifactMeta }`. Evolve `schemaVersion` on breaking changes; never remove or rename fields in-place.
+**Artifacts** — all boundary-crossing data uses a versioned schema from `packages/runtime/src/contracts/artifacts.ts`: `{ schema: "agent-kernel/ArtifactName", schemaVersion: 1, meta: ArtifactMeta }`. Evolve `schemaVersion` on breaking changes; never remove or rename fields in place.
 
 ---
 
 ## Enforcement Checklist
 
-Run on every diff. **Fix failures — don't just flag them.**
+Run on every diff. **Fix failures — don't just flag them.** The guards in `tests/architecture/` enforce most of this mechanically; the checklist is what you check before they do.
 
 **Architecture** — dependency flows only adapters/ui → runtime → core-ts · `core-ts` has no IO and no outside imports · all external IO behind an adapter · no adapter code in `runtime`/`core-ts`.
 
-**Personas** — pure FSM (`view()` + `advance`) · clock injected · context serializable · effects returned as data · new persona folders include `controller.js`, `state-machine.js`, `persona.js`, `contracts.ts` · no imports of persona internals from outside the persona directory (controllers only) · no domain logic in glue (kernel, card-authoring, orchestrate-build, adapters) · persona states must gate real behavior — label-only states are defects · all pricing goes through the Allocator (base costs in `base-costs.json`, formulas in Allocator code, no silent fallbacks).
+**Personas** — pure FSM (`view()` + `advance`) · clock injected · context serializable · effects returned as data · new persona folders complete (see above) · no imports of persona internals from outside the persona directory (controllers only) · no domain logic in glue (kernel, card-authoring, orchestrate-build, adapters) · persona states must gate real behavior — label-only states are defects · all pricing goes through the Allocator (base costs in `base-costs.json`, formulas in Allocator code, no silent fallbacks).
 
 **Artifacts** — boundary data uses an `artifacts.ts` schema · `schema`/`schemaVersion`/`meta` present · no field-name conflicts with existing contracts.
 
-**Types** — `pnpm run typecheck` stays at zero (gate: `tsconfig.typecheck.json`, enforced by `tests/architecture/typecheck-gate.test.js`). The gate covers **core-ts and its tests only** — the code genuinely clean under `strict`. Do not widen it casually: the five real `_shared/*.mts` modules carry **180 errors** and leak into every scope importing them, so widening is a fix-first project, not a config change. `pnpm run typecheck:report` prices each scope. ⚠️ Note `checkJs` is **off**: a package that is all `.js` reports 0 because there is nothing to check, which is not the same as clean — read the file count the report prints alongside.
+**Types** — `pnpm run typecheck` stays at zero (gate: `tsconfig.typecheck.json`, enforced by `tests/architecture/typecheck-gate.test.js`). The gate covers **core-ts and its tests only** — the code genuinely clean under `strict`. Do not widen it casually: the five `_shared/*.mts` modules carry **180 errors** that leak into every scope importing them, so widening is a fix-first project, not a config change. ⚠️ `checkJs` is **off**, so an all-`.js` package reports 0 because there is nothing to check — read the file count the report prints alongside.
 
-**Tests** — failing tests written *before* production code · new behavior covered under `tests/` · deterministic behavior uses fixtures · negative cases under `tests/fixtures/artifacts/invalid/` · no test hits live external services · base test file ends with `## TODO: Test Permutations` before Ollama handoff · persona behavior tests live in `tests/personas/<persona>/` named `<persona>-<behavior>.test.*` · label-only persona tests are legacy: replace with behavior tests, then remove (never remove first).
-
-**Benchmarks** — **not a checklist item.** Benchmarking left the development process on 2026-08-13: it is a standalone nightly tool, offline. Never run it from a session and never gate a diff on it. If a change touches the `ak_create` tool schema, CLI arg mapping, or entity normalization, note that in the commit message so the nightly result can be attributed — that is the whole development obligation. Read compact source-pinned evidence from `benchmark-results`; raw results stay out of Git.
+**Tests** — failing tests written *before* production code · new behavior covered under `tests/` · deterministic behavior uses fixtures · negative cases under `tests/fixtures/artifacts/invalid/` · no test hits live external services · base test file ends with `## TODO: Test Permutations` before Ollama handoff · persona behavior tests live in `tests/personas/<persona>/` named `<persona>-<behavior>.test.*` · label-only persona tests are legacy: replace with a behavior test, then remove — never before.
 
 **Code quality** — every changed line traces to the current milestone spec (no drive-by cleanup) · not over-engineered · assumptions stated before implementation.
 
-**File placement** — runtime `packages/runtime/src/` · core `packages/core-ts/src/` · web adapters `packages/adapters-web/src/adapters/` · CLI `packages/adapters-cli/src/` · tests `tests/**` (fixtures `tests/fixtures/**`).
+**Documentation, same diff** — architecture boundaries changed → `docs/architecture-charter.md` + `docs/architecture/diagram.mmd` (Opus/high, maintainer sign-off) · CLI flags or behavior changed → `packages/adapters-cli/README.md` (Sonnet/medium) · a module's canonical file moved or a persona surface changed → that persona's or package's `README.md` (Sonnet/medium). A doc that now contradicts the code is a **blocking** defect: fix it in the diff that made it wrong. `tests/architecture/persona-readme-authority.test.js` enforces part of this.
 
-**Documentation (Claude, same diff)** — architecture boundaries changed → `docs/architecture-charter.md` + `docs/architecture/diagram.mmd` (Opus, high) · CLI flags/behavior changed → `packages/adapters-cli/README.md` (Sonnet, medium) · a module's canonical file/entry point moved or a persona surface changed → that persona's / package's `README.md` (Sonnet, medium). A README that now contradicts the code is a **blocking** defect, not a follow-up: fix it in the diff that made it wrong.
+**Not a checklist item:** benchmarks. If a change touches the `ak_create` tool schema, CLI arg mapping, or entity normalization, note that in the commit message so a result can be attributed — that is the whole development obligation. Read compact source-pinned evidence from `benchmark-results`; raw results stay out of Git.
 
 ---
 
@@ -270,7 +202,7 @@ Run on every diff. **Fix failures — don't just flag them.**
 
 **Refactor without asking** when the fix is clear: preserve intent, move code to the right layer, extract missing ports, change only what conformance requires, update tests in the same pass.
 
-**Escalate** when the correct layer is genuinely ambiguous, the fix needs `docs/architecture-charter.md` or `docs/architecture/diagram.mmd` changes, or the refactor crosses more than one package boundary with unclear intent. On escalation: state the violation and charter rule, propose the minimal fix with tradeoffs, wait for confirmation. Do not silently pass ambiguous code.
+**Escalate** when the correct layer is genuinely ambiguous, the fix needs `docs/architecture-charter.md` or `docs/architecture/diagram.mmd` changes, or the refactor crosses more than one package boundary with unclear intent. On escalation: state the violation and the charter rule, propose the minimal fix with tradeoffs, wait for confirmation. Do not silently pass ambiguous code.
 
 ---
 
@@ -286,39 +218,19 @@ Run on every diff. **Fix failures — don't just flag them.**
 | `packages/runtime/src/ports/effects.js` | Effect dispatch — the adapter boundary |
 | `packages/runtime/src/runner/runtime-fsm.mjs` | Six-phase tick orchestration |
 | `packages/core-ts/src/index.ts` | Core export surface |
+| `tests/architecture/` | Executable form of the enforcement checklist |
+| `tests/README.md` | Test-authoring playbook (read before delegating test work) |
 | `docs/readme-index.md` | Index of all READMEs with one-line summaries |
 
 ---
 
 ## Vault-Backed Knowledge Management
 
-Non-load-bearing knowledge (plans, design rationale, dictation, scratch notes) lives in the Obsidian vault; code-binding contracts stay in the repo. Rule: "would removing this break a build, test, or agent workflow?" — if no, it belongs in the vault. Code, tests, fixtures, build outputs, package READMEs, the architecture charter, vision contract, and CLI runbook stay in the repo.
+Non-load-bearing knowledge (plans, design rationale, dictation, scratch notes) lives in the Obsidian vault; code-binding contracts stay in the repo. Test: "would removing this break a build, test, or agent workflow?" — if no, it belongs in the vault.
 
-- **Paths:** Mac `~/Documents/Obsidian/agent-kernel-vault/` · Linux `~/agent-kernel-vault/` · cite via the `~/vault` symlink.
+- **Paths:** Mac `~/Documents/Obsidian/agent-kernel-vault/` · Linux `~/agent-kernel-vault/` · cite via the `~/vault` symlink. Setup: `bash scripts/setup/setup-km.sh`.
 - `local-codex/{Plan,Prompt,Implement,Documentation,Dictation,CodeContext}.md` are symlinks into `~/vault/plans/active/...` and `~/vault/sources/codex-snapshots/...`.
-- Design decisions → `~/vault/decisions/` via `/save`. Cite vault code links as `[[ccg://<pkg>/<path>]]` or `[[graphify://community/<name>]]` (`wiki-lint` validates on demand).
-- Setup `bash scripts/setup/setup-km.sh` · sync via Syncthing (Mac ↔ Ubuntu). Cross-machine handoff rides on
-  `plans/active/Plan.md`, which syncs like everything else.
-- ⚠️ **The `hot.md` hot cache was removed 2026-08-18 and must not be reintroduced.** Its write side never
-  existed — `km-stop.sh` only `touch`ed the per-machine file, and no agent was ever told to write one — so
-  both caches held nothing but their template header for four months while `hot.md` sat at step 1 of a
-  mandatory checklist. Worse, the SessionStart merge globbed `hot.*.md`, which matched Syncthing's
-  conflict copies **of its own output**: each session re-concatenated every prior snapshot until the file
-  reached 327 KB / 10,941 lines of self-reference. ⇒ *Reading noise and reading nothing look identical, so
-  nothing could ever surface the gap.* The retired files are in `~/vault/.retired/hot-cache-20260818/`.
-- ⚠️ **All three `km-*` session hooks are retired (2026-08-18). None comes back as written.** Swept with
-  `hot.md` because each failed the same way — real machinery, no observable output:
-  | Retired | Why it was a no-op |
-  |---|---|
-  | `km-session-start.sh` | the `hot.md` merge above |
-  | `km-stop.sh` → `log.md` | appended `\| <ts> \| <plat> \| session-stop \| (auto) \|`. **1,217 rows, every one identical.** A log whose only variable field is the clock records that time passed, nothing else. |
-  | `km-stop.sh` + `km-post-tool-use.sh` → vault git | auto-committed to a git repo **inside** the Syncthing folder. `git log` there answers `fatal: your current branch appears to be broken`: `refs/heads/master` was zeroed to a null SHA and 48 sync-conflict copies sit inside `.git`, orphaning **23,167 objects**. |
-  ⇒ *`.git` cannot live in a Syncthing-replicated folder — Syncthing copies files individually with no
-  transactional ordering, so refs and objects arrive interleaved. Repairing the ref only restarts the
-  countdown.* `~/vault/.stignore` now excludes `.git` and `.retired`, and `setup-km.sh` phase 5 writes it
-  (phase 8 verifies it). ⚠️ **The vault therefore has NO backup** beyond Syncthing replication — which
-  zeroed `Plan.md` once already. A real one is a bare repo *outside* the synced tree; not yet built.
-- ⚠️ **This machine only.** The hook files and `~/.claude/settings.json` registrations were removed on the
-  Mac. **The Ubuntu box still has all three registered** and will keep recreating `hot.md` and `log.md`
-  into the shared vault until the same sweep runs there: delete `~/.claude/hooks/km-*.sh` and
-  `jq 'del(.hooks.SessionStart) | del(.hooks.PostToolUse) | del(.hooks.Stop)'` over its settings.
+- Design decisions → `~/vault/decisions/` via `/save`. Cite vault code links as `[[ccg://<pkg>/<path>]]` or `[[graphify://community/<name>]]`.
+- ⚠️ **The vault is machine-local and has no backup of any kind.** Syncthing was removed 2026-08-21 and nothing replaced it: `~/vault` on the Mac and on Ubuntu are now independent directories, so **anything a second machine needs must be in git**. Copy a vault file out before a long edit and verify the result with `file` after writing — replication zeroed `Plan.md` to NUL bytes once, and there is no longer a second copy to recover from. A real backup is a bare repo outside the vault; not yet built.
+- ⚠️ **Do not put `.git` in the vault and do not reintroduce the retired session hooks.** The vault's own git repo was destroyed by file-by-file replication (refs and objects arrive interleaved, so `refs/heads/master` was zeroed and 23,167 objects orphaned). The `hot.md` cache and the three `km-*` hooks were removed 2026-08-18 because each was real machinery with no observable output; retired copies are in `~/vault/.retired/`.
+- ⚠️ **Outstanding on the Ubuntu box:** all three `km-*` hooks are still registered there and keep recreating `hot.md`/`log.md` in the shared vault. Fix: delete `~/.claude/hooks/km-*.sh` and `jq 'del(.hooks.SessionStart) | del(.hooks.PostToolUse) | del(.hooks.Stop)'` over its `settings.json`.

--- a/docs/VAULT.md
+++ b/docs/VAULT.md
@@ -5,7 +5,7 @@ Non-load-bearing knowledge for this project lives in an Obsidian vault outside t
 - **Vault path (Mac):**     `~/Documents/Obsidian/agent-kernel-vault/`
 - **Vault path (Linux):**   `~/agent-kernel-vault/`
 - **Stable symlink:**       `~/vault/` (both machines)
-- **Sync:**                 Syncthing peer-to-peer
+- **Replication:**          none — machine-local since 2026-08-21 (Syncthing removed)
 - **MCP server:**           `@modelcontextprotocol/server-filesystem` pointed at `~/vault`
 
 ## What's in the vault

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -12,25 +12,18 @@ Run this when setting up a new machine, repairing vault symlinks, refreshing Cla
 
 ## What it sets up
 
-1. **Prerequisites** — `git`, `gh`, `jq`, `node`, `syncthing` (via Homebrew on Mac,
-   `apt` on Ubuntu).
+1. **Prerequisites** — `git`, `gh`, `jq`, `node` (via Homebrew on Mac, `apt` on Ubuntu).
 2. **Vault scaffold** at `~/Documents/Obsidian/agent-kernel-vault/` (Mac) or
    `~/agent-kernel-vault/` (Linux), with a `~/vault` symlink for path normalization.
    Layout follows the Karpathy LLM-Wiki pattern: `index.md`, `concepts/`, `decisions/`,
    `plans/{active,completed,backlog}/`, `sources/`, `_templates/`.
    *(The pattern's `hot.md` hot cache and `log.md` operation log were removed 2026-08-18 —
-   see the note in the repo `CLAUDE.md`. Cross-machine handoff rides on
-   `plans/active/Plan.md`.)*
+   see the note in the repo `CLAUDE.md`.)*
 3. **Skills** — clones the Karpathy `claude-obsidian` skills suite (wiki, wiki-ingest,
    wiki-query, wiki-lint, save, autoresearch, …) into `~/.claude/skills-upstream/`
    and symlinks each skill into `~/.claude/skills/`.
 4. **MCP** — registers `@modelcontextprotocol/server-filesystem` against `~/vault`
    in `~/.claude/settings.json` so Claude can query / edit the vault.
-5. **Syncthing guard** — writes `~/vault/.stignore` excluding `.git` and `.retired` from sync.
-   *(This phase used to install three `km-*` session hooks. All three were retired
-   2026-08-18 — the SessionStart hot-cache merge, the `log.md` append, and the vault
-   git auto-commit. The reasons are in the phase-5 comment block in `setup-km.sh`;
-   the short version is that each one failed silently for months.)*
 6. **Repo migration** *(primary only, one-shot)* — moves all non-load-bearing docs out of
    the repo and into the vault:
    - `docs/implementation-plans/` → `vault/plans/completed/`
@@ -46,17 +39,19 @@ Run this when setting up a new machine, repairing vault symlinks, refreshing Cla
    - `.gitignore` updated to keep these from re-entering the repo
    - `docs/VAULT.md` written as a pointer
    - `CLAUDE.md` and `AGENTS.md` patched with vault-aware session-start protocol
-7. **Syncthing** — installs and starts, prints this device's ID. Pairing between machines
-   is manual via http://localhost:8384 (Syncthing's API doesn't have a stable scripted
-   pairing flow).
 8. **Verify** — sanity checks each component.
+
+> **Phases 5 and 7 no longer exist.** Both were Syncthing (the `.stignore` guard and the
+> daemon bootstrap) and were removed 2026-08-21 along with Syncthing itself. The remaining
+> phases keep their original numbers, so `--phase=6` and `--phase=8` still mean what they
+> say; `--phase=5` and `--phase=7` now fail with an explicit message.
 
 ## Usage
 
 Choose exactly one role:
 
 - **Primary Mac**: owns the one-time repo migration and pushes the resulting git changes.
-- **Secondary Ubuntu**: installs the same tooling and waits for Syncthing to fill the vault.
+- **Secondary Ubuntu**: installs the same tooling and gets its **own local vault**. Nothing replicates between machines — see *No replication* below.
 
 ### One-time on the Mac (primary)
 
@@ -68,9 +63,8 @@ bash scripts/setup/setup-km.sh
 The script will:
 - Install prereqs
 - Create the vault and symlinks
-- Install skills + MCP + the Syncthing guard
+- Install skills + MCP
 - **Migrate** the repo (only if working tree is clean)
-- Start Syncthing and print this Mac's device ID
 
 After the script finishes:
 1. Review the repo diff: `git status`
@@ -80,7 +74,6 @@ After the script finishes:
    git commit -m "chore(km): migrate non-essential docs to vault"
    git push
    ```
-3. Pair Syncthing with the Ubuntu box (web UI) and add `~/vault` as a shared folder.
 
 ### One-time on Ubuntu (secondary)
 
@@ -92,12 +85,19 @@ git pull --ff-only
 bash scripts/setup/setup-km.sh --secondary
 ```
 
-This installs prereqs, scaffolds an empty vault locally (Syncthing will fill it), installs
-skills + MCP + the Syncthing guard, and starts Syncthing. **It does *not* re-run the migration** — that
-already happened on the Mac and is now in git.
+This installs prereqs, scaffolds an empty vault locally, and installs skills + MCP. **It does
+*not* re-run the migration** — that already happened on the Mac and is now in git.
 
-Once Syncthing pairs and syncs, the Ubuntu vault will mirror the Mac's, and
-`local-codex/Plan.md` (a symlink in the repo) will resolve to the synced vault file.
+`local-codex/Plan.md` (a symlink in the repo) will resolve to *that machine's* vault file.
+
+### No replication (since 2026-08-21)
+
+Syncthing is gone, and nothing has replaced it. Each machine's `~/vault` is independent:
+a plan edited on the Mac does not appear on Ubuntu. **Anything a second machine needs must
+be in git.** Syncthing was removed because its original justification — keeping benchmark
+material consistent across devices — no longer held (no benchmark content has lived in the
+vault for some time; the catalog is Git-owned on `codex/benchmark-catalog`), while it kept
+producing sync-conflict copies of the very handoff file it existed to carry.
 
 ## Flags
 
@@ -106,8 +106,7 @@ Once Syncthing pairs and syncs, the Ubuntu vault will mirror the Mac's, and
 | `--primary` | Force primary (run migration) |
 | `--secondary` | Force secondary (skip migration) |
 | `--skip-migration` | Skip phase 6 even on primary |
-| `--skip-syncthing` | Skip Syncthing install / start |
-| `--phase=N` | Run only phase N (1..8). Repeatable. |
+| `--phase=N` | Run only phase N (1, 2, 3, 4, 6, 8). Repeatable. |
 | `--dry-run` | Print what would happen, don't execute destructive ops |
 | `--help` | Show usage |
 
@@ -123,9 +122,6 @@ bash scripts/setup/setup-km.sh --phase=8
 
 ## Manual steps the script can't automate
 
-- **Syncthing device pairing** — open http://localhost:8384 on both machines, copy device IDs
-  across, and accept the pairing prompts. Then add `~/vault` as a shared folder pointing at
-  each machine's vault path.
 - **Obsidian app install** (Mac only, optional) — the vault works without Obsidian since MCP
   reads raw markdown. Install Obsidian if you want a GUI for browsing.
 - **`gh auth login`** — if you haven't already, run this so the script's git pushes work.
@@ -139,21 +135,19 @@ git revert <migration-commit>
 rm -rf ~/vault                       # only if you want to discard vault content
 ```
 
-⚠️ **The vault has no git history to recover from.** `~/vault/.git` was a repo *inside* the
-Syncthing-synced folder; Syncthing replicated `.git` file-by-file with no transactional
-ordering, which zeroed `refs/heads/master` and left 48 conflict copies inside `.git`,
-orphaning all 23,167 objects. It was retired 2026-08-18 to
-`~/vault/.retired/km-log-and-git-20260818/` and `.stignore` now keeps `.git` out of sync.
-⇒ *The only vault backup is Syncthing replication plus its sync-conflict copies, and those
-have zeroed a file before. Copy anything important out before a long edit.* A real backup
-would be a bare repo **outside** the synced tree — not yet built.
+⚠️ **The vault has no git history to recover from, and now no replica either.** `~/vault/.git`
+was a repo *inside* the replicated folder and was corrupted by file-by-file replication
+(zeroed `refs/heads/master`, 48 conflict copies inside `.git`, 23,167 objects orphaned); it
+was retired 2026-08-18 to `~/vault/.retired/km-log-and-git-20260818/`. With Syncthing removed
+2026-08-21 the vault has **no backup of any kind** — not even a second machine's copy.
+⇒ *Copy anything important out before a long edit, and keep durable material in git.* A real
+backup would be a bare repo outside the vault — still not built.
 
 ## Troubleshooting
 
 - **`jq: command not found`** — re-run with `--phase=1` to install prereqs
-- **`syncthing --device-id` returns nothing** — Syncthing isn't running yet; start it
-  manually (`brew services start syncthing` / `systemctl --user start syncthing`)
 - **Migration aborts with "working tree dirty"** — commit or stash your changes first
-- **Vault appears empty on Ubuntu** — Syncthing isn't paired yet; check the web UI
+- **Vault appears empty on Ubuntu** — expected: vaults are machine-local and nothing
+  replicates. Populate it from git or copy the files across by hand.
 - **Codex can't find `local-codex/Plan.md`** — verify the symlink: `ls -l local-codex/Plan.md`
   should show `-> /Users/<you>/vault/plans/active/Plan.md`

--- a/scripts/setup/setup-km.sh
+++ b/scripts/setup/setup-km.sh
@@ -2,7 +2,7 @@
 # setup-km.sh — Knowledge Management setup for agent-kernel
 #
 # Sets up an Obsidian vault, Claude wiki skills, MCP filesystem server,
-# the Syncthing guard, Syncthing itself, and migrates non-essential repo docs into the vault.
+# and migrates non-essential repo docs into the vault.
 #
 # Designed to run on:
 #   - macOS (primary)  — runs the migration phase, commits to repo
@@ -34,7 +34,6 @@ skip() { printf '%s[km] skip:%s %s\n' "$c_dim" "$c_reset" "$*"; }
 
 ROLE=""
 SKIP_MIGRATION=0
-SKIP_SYNCTHING=0
 DRY_RUN=0
 PHASES_TO_RUN=()
 
@@ -46,8 +45,7 @@ Options:
   --primary           Force this machine as primary (runs repo migration)
   --secondary         Force this machine as secondary (skips migration)
   --skip-migration    Skip the repo→vault migration phase
-  --skip-syncthing    Skip Syncthing install / start
-  --phase=N           Run only phase N (1..8); repeatable
+  --phase=N           Run only phase N (1,2,3,4,6,8); repeatable
   --dry-run           Print actions without executing destructive ops
   -h, --help          Show this help
 EOF
@@ -59,7 +57,6 @@ parse_args() {
       --primary)        ROLE=primary ;;
       --secondary)      ROLE=secondary ;;
       --skip-migration) SKIP_MIGRATION=1 ;;
-      --skip-syncthing) SKIP_SYNCTHING=1 ;;
       --dry-run)        DRY_RUN=1 ;;
       --phase=*)        PHASES_TO_RUN+=("${1#--phase=}") ;;
       -h|--help)        usage; exit 0 ;;
@@ -150,7 +147,7 @@ phase_1_prereqs() {
   case "$PLATFORM" in
     mac)
       require brew "https://brew.sh"
-      for pkg in git gh jq node syncthing; do
+      for pkg in git gh jq node; do
         if brew list --formula "$pkg" >/dev/null 2>&1; then
           skip "$pkg installed"
         else
@@ -161,7 +158,7 @@ phase_1_prereqs() {
     linux)
       require apt-get "Use a Debian/Ubuntu derivative"
       run sudo apt-get update -qq
-      run sudo apt-get install -y git curl jq syncthing ca-certificates
+      run sudo apt-get install -y git curl jq ca-certificates
       if ! command -v node >/dev/null; then
         run curl -fsSL https://deb.nodesource.com/setup_20.x | run sudo -E bash -
         run sudo apt-get install -y nodejs
@@ -333,27 +330,6 @@ phase_4_mcp() {
   fi
 }
 
-# ============================================================================
-# Phase 5 — Syncthing guard (was: session hooks, all three retired 2026-08-18)
-# ============================================================================
-# The three km-* hooks this phase used to install are GONE, and none should come back
-# as written:
-#   - SessionStart merged `hot.*.md` into `hot.md`. Nothing ever wrote a hot cache, and the
-#     glob matched Syncthing's conflict copies of its own output — 327 KB of self-reference.
-#   - Stop appended `| <ts> | <plat> | session-stop | (auto) |` to `log.md`. 1,217 rows, all
-#     identical: a log with no variable field records nothing.
-#   - PostToolUse auto-committed the vault to a git repo INSIDE the synced folder. Syncthing
-#     replicates `.git` file-by-file with no transactional ordering, so `refs/heads/master`
-#     was zeroed and 48 conflict copies landed inside `.git`, orphaning 23,167 objects. The
-#     "backup" had been a no-op for an unknown stretch, and could not report that.
-# ⇒ A write side that nobody implements, and a backup that its own storage layer corrupts,
-#   both fail silently. What this folder actually needs is the exclusion below.
-phase_5_sync_guard() {
-  log "Phase 5: Syncthing guard (.stignore)"
-  write_if_missing "$VAULT_HOME/.stignore" "$(template_stignore)"
-  ok "Phase 5 done"
-}
-
 # Phase 6 — Repo → Vault migration (PRIMARY ONLY, ONE-SHOT)
 # ============================================================================
 phase_6_migrate() {
@@ -498,37 +474,6 @@ append_to_agents_md() {
 }
 
 # ============================================================================
-# Phase 7 — Syncthing
-# ============================================================================
-phase_7_syncthing() {
-  log "Phase 7: Bootstrap Syncthing"
-  if [[ "$SKIP_SYNCTHING" == "1" ]]; then skip "--skip-syncthing"; return; fi
-  if ! command -v syncthing >/dev/null; then warn "syncthing not installed (skipping)"; return; fi
-
-  case "$PLATFORM" in
-    mac)
-      run brew services start syncthing 2>/dev/null || warn "could not start syncthing via brew"
-      ;;
-    linux)
-      run systemctl --user enable --now syncthing.service 2>/dev/null || \
-        run sudo systemctl enable --now "syncthing@$(whoami).service" 2>/dev/null || \
-        warn "could not start syncthing (start it manually)"
-      ;;
-  esac
-
-  sleep 2
-  local id; id="$(syncthing --device-id 2>/dev/null || true)"
-  if [[ -n "$id" ]]; then
-    ok "Syncthing running. Device ID:"
-    printf '\n     %s\n\n' "$id"
-    log "Next: open http://localhost:8384"
-    log "      Add the OTHER machine's device ID, then add a folder for $VAULT_HOME"
-  else
-    warn "could not read device ID (start syncthing and run 'syncthing --device-id')"
-  fi
-}
-
-# ============================================================================
 # Phase 8 — Verify
 # ============================================================================
 phase_8_verify() {
@@ -546,8 +491,6 @@ phase_8_verify() {
   else
     warn "FAIL: ~/.claude/settings.json missing"; fails=$((fails+1))
   fi
-  command -v syncthing >/dev/null;             check "$?" "syncthing installed"
-  grep -qx '\.git' "$VAULT_LINK/.stignore" 2>/dev/null; check "$?" "vault/.stignore excludes .git from sync"
 
   if [[ "$ROLE" == "primary" ]]; then
     [[ -f "$REPO_ROOT/docs/VAULT.md" ]];       check "$?" "docs/VAULT.md present"
@@ -722,17 +665,6 @@ real skill from the Karpathy LLM-Wiki implementation.
 EOF
 }
 
-template_stignore() { cat <<'EOF'
-// Git metadata must never be synced: Syncthing replicates .git file-by-file with no
-// transactional ordering, which zeroed refs/heads/master and left 48 conflict copies
-// inside .git (retired 2026-08-18). Any future git backup lives OUTSIDE this folder.
-.git
-
-// Retired machinery kept locally for recovery; not worth replicating.
-.retired
-EOF
-}
-
 template_repo_vault_md() { cat <<'EOF'
 # Vault
 
@@ -741,7 +673,7 @@ Non-load-bearing knowledge for this project lives in an Obsidian vault outside t
 - **Vault path (Mac):**     `~/Documents/Obsidian/agent-kernel-vault/`
 - **Vault path (Linux):**   `~/agent-kernel-vault/`
 - **Stable symlink:**       `~/vault/` (both machines)
-- **Sync:**                 Syncthing peer-to-peer
+- **Replication:**          none — machine-local since 2026-08-21
 - **MCP server:**           `@modelcontextprotocol/server-filesystem` pointed at `~/vault`
 
 ## What's in the vault
@@ -806,7 +738,7 @@ moved. The test "would breaking this doc break a build, test, or agent workflow?
 ### Setup / sync
 
 - Initial setup: `bash scripts/setup/setup-km.sh`
-- Sync: Syncthing peer-to-peer between Mac and Ubuntu (manual pairing once)
+- No replication: the vault is machine-local (Syncthing removed 2026-08-21). Anything a second machine needs belongs in git.
 - No hot cache: `hot.md` was removed 2026-08-18 (never written to). Handoff rides on `plans/active/Plan.md`.
 EOF
 }
@@ -841,7 +773,10 @@ EOF
 # Main
 # ============================================================================
 
-PHASES=(phase_1_prereqs phase_2_vault phase_3_skills phase_4_mcp phase_5_sync_guard phase_6_migrate phase_7_syncthing phase_8_verify)
+# Phases 5 (Syncthing .stignore guard) and 7 (Syncthing bootstrap) were removed 2026-08-21 with
+# Syncthing itself. The remaining phases keep their original numbers so every log label, comment,
+# and `--phase=N` note elsewhere stays accurate; the gap is deliberate, not an omission.
+PHASES=(phase_1_prereqs phase_2_vault phase_3_skills phase_4_mcp phase_6_migrate phase_8_verify)
 
 main() {
   parse_args "$@"
@@ -853,9 +788,12 @@ main() {
     local mapped=()
     for p in "${PHASES_TO_RUN[@]}"; do
       if [[ "$p" =~ ^[0-9]+$ ]]; then
-        local idx=$((p-1))
-        [[ "$idx" -ge 0 && "$idx" -lt "${#PHASES[@]}" ]] || err "phase $p out of range (1..${#PHASES[@]})"
-        mapped+=("${PHASES[$idx]}")
+        local match=""
+        for candidate in "${PHASES[@]}"; do
+          [[ "$candidate" == "phase_${p}_"* ]] && match="$candidate"
+        done
+        [[ -n "$match" ]] || err "no phase $p (available: 1 2 3 4 6 8)"
+        mapped+=("$match")
       else
         mapped+=("$p")
       fi
@@ -871,16 +809,15 @@ main() {
   echo
   log "All phases complete."
   log "Next manual steps:"
-  log "  1. Open Syncthing UI on both machines (http://localhost:8384) and pair them"
-  log "  2. Add ~/vault as a shared folder in Syncthing"
   if [[ "$ROLE" == "primary" ]]; then
-    log "  3. Review repo changes:  git -C $REPO_ROOT status"
-    log "  4. Commit & push: git commit -m 'chore(km): migrate non-essential docs to vault' && git push"
-    log "  5. On Ubuntu: git pull, then bash scripts/setup/setup-km.sh --secondary"
+    log "  1. Review repo changes:  git -C $REPO_ROOT status"
+    log "  2. Commit & push: git commit -m 'chore(km): migrate non-essential docs to vault' && git push"
+    log "  3. On Ubuntu: git pull, then bash scripts/setup/setup-km.sh --secondary"
   else
-    log "  3. Verify vault content arrives via Syncthing"
-    log "  4. Verify local-codex/Plan.md resolves: ls -l $REPO_ROOT/local-codex/Plan.md"
+    log "  1. Verify local-codex/Plan.md resolves: ls -l $REPO_ROOT/local-codex/Plan.md"
   fi
+  log "  NOTE: the vault is machine-local since Syncthing was removed 2026-08-21 — there is no"
+  log "        replication between machines. Move anything another machine needs into git."
 }
 
 main "$@"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Tests README
 
-> **Scope:** this file covers the unit and integration test suite only (`pnpm run test`, Vitest). Tests verify code correctness against deterministic fixtures. For LLM tool-call permutation and stress testing, see the benchmark harness at `tools/remote-ollama-control/` and the `run-content-gen` command documented in `CLAUDE.md → Benchmark commands`.
+> **Scope:** this file covers the unit and integration test suite only (`pnpm run test`, Vitest). Tests verify code correctness against deterministic fixtures. LLM tool-call permutation and stress testing is **not** part of this suite and is **not run from a session**: benchmarking left the development process on 2026-08-13 and runs as a standalone nightly offline tool (`AGENTS.md → Benchmark strategy`).
 
 This file is the entry point for **low-complexity test work** delegated to a local model, typically Ollama launched through the Claude Code harness.
 

--- a/tools/remote-ollama-control/scripts/ufw-llm.sh
+++ b/tools/remote-ollama-control/scripts/ufw-llm.sh
@@ -19,9 +19,6 @@ SSH_PORT=2222
 LAN_CIDR="192.168.1.0/24"     # trusted home LAN (covers the Mac's WiFi + Ethernet IPs)
 VPN_SOURCE="86.38.64.24"      # your PRIVATE VPN exit IP (the source UFW sees after the port-forward)
 
-# Optional: allow fast direct Syncthing sync on the LAN (Mac <-> box). Leave empty to skip
-# (Syncthing still works via relay/outbound). Set to "$LAN_CIDR" to enable.
-SYNCTHING_LAN=""
 # -----------------------------------------------------------------------------------
 
 # --- safety guards -----------------------------------------------------------------
@@ -53,12 +50,6 @@ ufw allow from "$VPN_SOURCE" to any port "$SSH_PORT" proto tcp comment 'llm ssh 
 #   ufw allow from 192.168.1.152 to any port 2222 proto tcp comment 'llm ssh (mac wifi)'
 #   ufw allow from 192.168.1.164 to any port 2222 proto tcp comment 'llm ssh (mac eth)'
 # (Reserve both on the router and disable the Mac's private WiFi MAC first, or the IPs drift.)
-
-# Optional LAN Syncthing (off unless SYNCTHING_LAN is set above).
-if [ -n "$SYNCTHING_LAN" ]; then
-  ufw allow from "$SYNCTHING_LAN" to any port 22000 proto tcp comment 'syncthing (LAN)'
-  ufw allow from "$SYNCTHING_LAN" to any port 21027 proto udp comment 'syncthing discovery (LAN)'
-fi
 
 ufw --force enable
 echo


### PR DESCRIPTION
> ⚠️ **Needs a rebase before merge.** This branch was cut at `74a5837` and `main` has moved 22+ commits since; `git merge-tree` reports conflicts in `AGENTS.md` and `CLAUDE.md`, which gained ~17 lines on `main` in the meantime. Happy to rebase and fold those in — say the word.

## Why

The two guides had grown to **7,578 words with roughly 60% overlap**. The roster, docs tiering, file placement, architecture guardrails and the benchmark exclusion were each stated in both files — the last of those five times. One of them even instructed that *"the two files must agree"*, which is the tell: a rule copied into two places drifts, and then one copy is wrong while both look authoritative.

Now **5,171 words (−32%)**, with an explicit split stated at the top of each file:

- **`CLAUDE.md`** owns reporting, session start, code navigation, commands, the architecture summary, the enforcement checklist, escalation.
- **`AGENTS.md`** owns the roster and tiers, workflow, per-agent scope, review, test/benchmark strategy, placement, naming, the pre-handoff checklist.

Every load-bearing rule survives — effort levels, milestone size bands, the persona and artifact contracts, the typecheck-gate cost of widening, the perturbation obligation. What went is postmortem narrative that git already holds. Where a postmortem still carried a live constraint, the constraint stayed and the story went.

## Stale direction corrected, each checked against the repo

- `CLAUDE.md` asserted **"there is no tsc/typecheck script"** four lines above its own `pnpm run typecheck` entry.
- `AGENTS.md` sent UI work to **`Design.md`, which does not exist anywhere**, and to a Stitch MCP whose POC files were deleted. `.env.example` held nothing but `STITCH_API_KEY` and is removed.
- `AGENTS.md` said there is no second reviewer. True for humans — but `claude-code-review.yml` comments on every PR, and **there is no CI test job at all**, which is the more useful fact and is now stated plainly: the local gates are the only gates that run. Ruleset re-verified (still `deletion` + `non_fast_forward`, repository-role bypass).
- `tests/README.md` pointed at a CLAUDE.md section removed on 2026-08-13 and told readers to run `run-content-gen` — the one thing the benchmark policy forbids.

## Tooling that was in use but undocumented

The `agent-kernel-cli` MCP server (`ak_*`, including the `ak_test_*` harness) and the `structured-test-authoring` skill. Both now named, with the instruction to prefer `ak_*` over shelling out to `ak.mjs`.

## Syncthing removed (`08c83ca`)

It existed to keep benchmark material consistent across machines. That reason is gone: `find ~/vault -iname '*benchmark*'` returns nothing, and the catalog is Git-owned. What it actually replicated was 238 MB of MCP sample output — while producing **six sync-conflict copies of the handoff file it existed to carry**.

`setup-km.sh` loses phase 5 (the `.stignore` guard), phase 7 (daemon bootstrap), `--skip-syncthing`, and the prereq. Remaining phases **keep their original numbers** — renumbering would have churned 20 `6a`–`6j` labels inside a one-shot migration that has already run. `--phase=N` maps by name prefix, so `--phase=6` and `--phase=8` still mean what every existing note says, and the removed ones fail with `no phase 5 (available: 1 2 3 4 6 8)`.

The vault is now machine-local with no replica and no backup, documented as such rather than left implicit. Cross-machine handoff is not replaced — the maintainer confirmed it is not needed.

## Gates

`bash -n` clean on both scripts; `--phase=8` runs; `--phase=7` errors as designed; tests/tools 5 files / 44 passed at the time. Docs-only change plus two shell scripts; no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)