### PR TITLE
fix(benchmark): drop PrivateTmp, which silently breaks every ssh call in these units

### DIFF
--- a/tests/tools/benchmark-systemd-units.test.js
+++ b/tests/tools/benchmark-systemd-units.test.js
@@ -1,0 +1,73 @@
+const assert = require('node:assert/strict');
+const { readFileSync, readdirSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+
+const SYSTEMD_DIR = resolve(__dirname, '../../tools/remote-ollama-control/systemd');
+
+// Both of these reach GitHub over SSH: the benchmark service to publish results, the heartbeat to
+// publish its beacon.
+const PUBLISHING_UNITS = ['agent-kernel-benchmark.service', 'agent-kernel-heartbeat.service'];
+
+function unit(name) {
+  return readFileSync(join(SYSTEMD_DIR, name), 'utf8');
+}
+
+function directives(text) {
+  return text.split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#') && line.includes('='));
+}
+
+/**
+ * PrivateTmp=true silently destroys SSH in these units. Inside its mount namespace OpenSSH's
+ * safe_path check on /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf fails with "Bad owner or
+ * permissions" and every ssh invocation exits 255 -- while the same command run by hand, or under
+ * systemd-run without this one setting, succeeds. That asymmetry is what makes it expensive: it
+ * cannot be reproduced outside a unit, so it only ever appears in production.
+ */
+test('units that publish over SSH do not enable PrivateTmp', () => {
+  for (const name of PUBLISHING_UNITS) {
+    const active = directives(unit(name));
+    const offending = active.filter((line) => /^PrivateTmp\s*=\s*(true|yes|on|1)$/i.test(line));
+    assert.deepEqual(
+      offending, [],
+      `${name} sets PrivateTmp, which makes every ssh call in it fail with `
+      + '"Bad owner or permissions on /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf"',
+    );
+  }
+});
+
+// The explanation is the only thing standing between the next reader and re-adding it as an obvious
+// hardening win. A bare absence looks like an oversight.
+test('the omission is documented in each unit, not merely absent', () => {
+  for (const name of PUBLISHING_UNITS) {
+    assert.match(unit(name), /PrivateTmp is deliberately NOT set/,
+      `${name} must say why PrivateTmp is missing`);
+  }
+});
+
+test('every shipped unit is syntactically a systemd unit', () => {
+  const units = readdirSync(SYSTEMD_DIR).filter((name) => /\.(service|timer)$/.test(name));
+  assert.ok(units.length >= 4, `expected the benchmark and heartbeat units, found ${units.join(', ')}`);
+  for (const name of units) {
+    const text = unit(name);
+    assert.match(text, /^\[Unit\]/m, `${name} has no [Unit] section`);
+    for (const line of directives(text)) {
+      assert.match(line, /^[A-Za-z][A-Za-z0-9]*\s*=/, `${name} has a malformed directive: ${line}`);
+    }
+  }
+});
+
+// The heartbeat exists to keep reporting while a benchmark run occupies the agent for days. Sharing
+// the benchmark timer's OnUnitInactiveSec would make it wait for that run to finish first, which is
+// precisely the window it is meant to cover.
+test('the heartbeat timer fires on a fixed cadence rather than after the previous run', () => {
+  const timer = unit('agent-kernel-heartbeat.timer');
+  assert.match(timer, /^OnUnitActiveSec=/m);
+  assert.doesNotMatch(timer, /^OnUnitInactiveSec=/m);
+});
+
+// ## TODO: Test Permutations
+// - a unit adding ProtectSystem or ProtectHome, which can fail the same safe_path check
+// - PrivateTmp written with whitespace or alternate truthy spellings
+// - a newly added *.service that publishes but is missing from PUBLISHING_UNITS

--- a/tools/remote-ollama-control/systemd/agent-kernel-benchmark.service
+++ b/tools/remote-ollama-control/systemd/agent-kernel-benchmark.service
@@ -9,7 +9,12 @@ EnvironmentFile=-%h/.config/agent-kernel-benchmark/benchmark-agent.env
 ExecStart=%h/bin/agent-kernel-benchmark --service
 WorkingDirectory=%h/remote-ollama-control
 NoNewPrivileges=true
-PrivateTmp=true
+# PrivateTmp is deliberately NOT set. Under its mount namespace, OpenSSH's safe_path check on
+# /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf fails with "Bad owner or permissions" and every
+# ssh invocation dies -- verified by toggling only this setting via systemd-run. The file itself is
+# a correct 644 root:root symlink; nothing is wrong outside the namespace, which is exactly why this
+# only ever appears once the unit runs under systemd. This service pushes over SSH, so a private
+# /tmp is not worth trading a working transport for.
 
 [Install]
 WantedBy=default.target

--- a/tools/remote-ollama-control/systemd/agent-kernel-heartbeat.service
+++ b/tools/remote-ollama-control/systemd/agent-kernel-heartbeat.service
@@ -9,7 +9,12 @@ EnvironmentFile=-%h/.config/agent-kernel-benchmark/benchmark-agent.env
 ExecStart=%h/bin/agent-kernel-heartbeat
 WorkingDirectory=%h/remote-ollama-control
 NoNewPrivileges=true
-PrivateTmp=true
+# PrivateTmp is deliberately NOT set. Under its mount namespace, OpenSSH's safe_path check on
+# /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf fails with "Bad owner or permissions" and every
+# ssh invocation dies -- verified by toggling only this setting via systemd-run. The file itself is
+# a correct 644 root:root symlink; nothing is wrong outside the namespace, which is exactly why this
+# only ever appears once the unit runs under systemd. This service pushes over SSH, so a private
+# /tmp is not worth trading a working transport for.
 # A beat that cannot finish promptly is a beat worth skipping: the next one is minutes away, and a
 # pile of stuck publishers would be a second fault on top of whatever caused the first.
 TimeoutStartSec=120


### PR DESCRIPTION
The first heartbeat beat failed at the push:

```
Bad owner or permissions on /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf
fatal: Could not read from remote repository.
```

The file is a correct `644 root:root` symlink, and the identical ssh command succeeds when run by hand, under a stripped environment (`env -i`), and under `systemd-run` — but fails under `systemd-run -p PrivateTmp=true`. Toggling only that one setting reproduces it in both directions. Inside the `PrivateTmp` mount namespace, OpenSSH's `safe_path` check on that config fails and every ssh invocation exits 255.

## Scope

Removed from **both** units that reach GitHub over SSH. `agent-kernel-benchmark.service` carried it too, so publishing results would have failed identically the moment live mode was enabled — **after a run of one to three days, at the very last step.**

## Why this one is expensive

It cannot be reproduced outside a systemd unit, so it only ever appears in production. The error names a file permission rather than the sandbox that caused it, pointing the reader at `/etc/ssh` — where nothing is actually wrong.

Both units now record *why* the setting is absent. A bare omission reads as an oversight and invites re-adding it as obvious hardening.

## Testing

`tests/tools/benchmark-systemd-units.test.js` guards the absence, requires the rationale comment to be present, and checks the heartbeat timer uses `OnUnitActiveSec` rather than `OnUnitInactiveSec` (sharing the benchmark timer's setting would make the beacon wait for a multi-day run to finish — precisely the window it exists to cover). Perturbed to confirm it fails when `PrivateTmp` returns.

Suite 432 files passed, with one unrelated `serve-ui` port-collision flake that passes in isolation; typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)