### PR TITLE
chore(ci): move the heartbeat alarm to actions/github-script v9

### DIFF
--- a/.github/workflows/benchmark-heartbeat-alarm.yml
+++ b/.github/workflows/benchmark-heartbeat-alarm.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate heartbeat freshness
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           STALE_AFTER_MINUTES: '60'
           STALE_RESULT_DAYS: '7'


### PR DESCRIPTION
`v7` targets Node 20, which GitHub is deprecating — runners already force it onto Node 24 and annotate every run.

**v9, not v8** — v8 is already superseded, so bumping to it would only need doing again.

The script uses `github.rest.repos.getContent`, `github.rest.issues.{listForRepo,create,update,createComment}`, and `core.summary`/`core.notice`. None changed signature across these majors; this is a runtime bump, not an API one. Verified by dispatching the workflow and confirming a clean run with no deprecation annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)