### PR TITLE
fix(remote-ollama): a profile dry run must read no live process state

### DIFF
--- a/tests/tools/remote-ollama-benchmark.test.js
+++ b/tests/tools/remote-ollama-benchmark.test.js
@@ -1,9 +1,15 @@
 const assert = require("node:assert/strict");
 const { spawn, spawnSync } = require("node:child_process");
+const { mkdtempSync, writeFileSync } = require("node:fs");
 const http = require("node:http");
-const { resolve } = require("node:path");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
 
-const { loadConfig } = require("../../tools/remote-ollama-control/scripts/lib/config");
+const { getProfile, loadConfig } = require("../../tools/remote-ollama-control/scripts/lib/config");
+const {
+  assertPortAvailable,
+  dryRunProcessProbe,
+} = require("../../tools/remote-ollama-control/scripts/remote-ollama-profile");
 const {
   buildContentGenMatrix,
   buildHardwareBenchmarkSpecs,
@@ -122,6 +128,17 @@ test("content-gen dry run exposes the complete offline matrix and exact repeat b
   assert.equal(output.matrix.configurations.length, 7);
 });
 
+// A state directory whose profile is unmistakably running: the pid is this very test process, so
+// `process.kill(pid, 0)` succeeds on any host. That is the machine state the dry run must ignore.
+function runningProfileStateDir(profileName = "primary") {
+  const dir = mkdtempSync(join(tmpdir(), "remote-ollama-state-"));
+  writeFileSync(
+    join(dir, `${profileName}.json`),
+    `${JSON.stringify({ mode: "pid", pid: process.pid, profile: profileName, model: "" })}\n`,
+  );
+  return dir;
+}
+
 test("profile dry run honors an explicit Ollama binary for unattended starts", () => {
   const result = spawnSync(process.execPath, [
     PROFILE_SCRIPT,
@@ -137,6 +154,85 @@ test("profile dry run honors an explicit Ollama binary for unattended starts", (
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /'\/opt\/ollama-current\/bin\/ollama' serve/);
+});
+
+// The perturbation that makes the test above hermetic. It used to pass only where no profile
+// happened to be running — that is, everywhere except the benchmark box, whose whole job is to run
+// Ollama. A dry run there exited 1, the source preflight failed, and the benchmark never started.
+test("profile dry run plans the start even while that profile is running", () => {
+  const result = spawnSync(process.execPath, [
+    PROFILE_SCRIPT,
+    "start",
+    "--profile",
+    "primary",
+    "--dry-run",
+  ], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      OLLAMA_BIN: "/opt/ollama-current/bin/ollama",
+      LLM_PROFILE_MANAGER: "pid",
+      LLM_PROFILE_STATE_DIR: runningProfileStateDir(),
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /'\/opt\/ollama-current\/bin\/ollama' serve/);
+  // The plan still states the guard it did not evaluate, so an inert check never reads as no check.
+  assert.match(result.stdout, /preflight \(not evaluated\).*already running/);
+});
+
+// The refusal half. Skipping the check for a plan must not skip it for a start — prove the guard
+// still has teeth by handing it a probe that reports exactly what the box reports.
+test("a real start refuses when the process probe reports the profile running", () => {
+  const profile = getProfile(loadConfig(ROOT), "primary");
+
+  assert.throws(
+    () => assertPortAvailable(profile, {
+      runningInfo: () => ({ running: true, mode: "systemd-user" }),
+      portLines: () => [],
+    }),
+    /Profile 'primary' is already running \(systemd-user\)/,
+  );
+
+  assert.throws(
+    () => assertPortAvailable(profile, {
+      runningInfo: () => ({ running: false, mode: "" }),
+      portLines: () => ["LISTEN 0 4096 127.0.0.1:11434 users:((\"ollama\",pid=1,fd=3))"],
+    }),
+    /is already in use; refusing to kill unrelated processes/,
+  );
+
+  // ...and the dry-run probe is inert by construction, not by luck of the host it runs on.
+  assert.equal(dryRunProcessProbe.runningInfo(profile).running, false);
+  assert.deepEqual(dryRunProcessProbe.portLines(profile.port), []);
+  assert.doesNotThrow(() => assertPortAvailable(profile, dryRunProcessProbe));
+});
+
+// End to end, on the same fixture the dry run above ignores: a start that is not a dry run still
+// reads live state and still refuses. OLLAMA_BIN points nowhere so a regression here cannot launch
+// a real Ollama on the benchmark box.
+test("the start guard is wired to the live probe when the start is real", () => {
+  const stateDir = runningProfileStateDir();
+  const result = spawnSync(process.execPath, [
+    PROFILE_SCRIPT,
+    "start",
+    "--profile",
+    "primary",
+  ], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      OLLAMA_BIN: join(stateDir, "never-ollama"),
+      LLM_PROFILE_MANAGER: "pid",
+      LLM_PROFILE_STATE_DIR: stateDir,
+    },
+  });
+
+  assert.equal(result.status, 1, result.stdout);
+  assert.match(result.stderr, /Profile 'primary' is already running \(pid\)/);
 });
 
 test("hardware benchmark recommendations prefer score before speed", () => {

--- a/tools/remote-ollama-control/README.md
+++ b/tools/remote-ollama-control/README.md
@@ -157,6 +157,12 @@ systemctl --user daemon-reload
 
 Without the systemd unit, `remote-ollama-profile` uses managed pid files under `~/.local/state/remote-ollama`.
 
+`start --dry-run` is plan-only and reads no live process state: it prints the command it would run
+and names the preflight it did **not** evaluate. That is deliberate — a plan must be the same plan on
+every host, and the benchmark box always has Ollama running, so a dry run that consulted live state
+exited 1 there and failed the source preflight that gates every benchmark run. A real `start` still
+reads live state and still refuses when the profile is already running or the port is occupied.
+
 ## Unattended Benchmark Agent (M4b)
 
 Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`)

--- a/tools/remote-ollama-control/scripts/remote-ollama-profile.js
+++ b/tools/remote-ollama-control/scripts/remote-ollama-profile.js
@@ -214,14 +214,40 @@ function portLines(port) {
   return result.stdout.split(/\r?\n/).filter((line) => new RegExp(`:${port}\\b`).test(line));
 }
 
-function assertPortAvailable(profile) {
-  const info = runningInfo(profile);
-  if (info.running) {
-    fail(`Profile '${profile.name}' is already running (${info.mode}). Stop or restart it first.`);
+// Whether a profile is already running, and who owns its port, are facts about the live machine.
+// A start must read them — that is the whole guard. A dry run must not: it prints a plan, and a
+// plan is the same plan on every host. The host that matters most is the benchmark box, where
+// `ollama serve` is always up because that is the box's entire job; reading live state there made
+// `start --dry-run` a guaranteed exit 1, which failed the source preflight that runs this suite
+// before any GPU work and so blocked every benchmark run. Hence the probe: live for a real start,
+// inert for a plan-only one, stubbable from a test.
+const liveProcessProbe = {
+  runningInfo,
+  portLines
+};
+
+const dryRunProcessProbe = {
+  runningInfo: () => ({ running: false, mode: '', model: '', state: null }),
+  portLines: () => []
+};
+
+function probeFor(options) {
+  if (options.probe) {
+    return options.probe;
   }
-  const occupied = portLines(profile.port);
+  return options.dryRun ? dryRunProcessProbe : liveProcessProbe;
+}
+
+function assertPortAvailable(profile, probe = liveProcessProbe) {
+  const info = probe.runningInfo(profile);
+  if (info.running) {
+    // Thrown rather than failed in place: main() routes every start/stop error through fail(), so
+    // the CLI still exits 1 with this exact message, and the guard stays callable from a test.
+    throw new Error(`Profile '${profile.name}' is already running (${info.mode}). Stop or restart it first.`);
+  }
+  const occupied = probe.portLines(profile.port);
   if (occupied.length > 0) {
-    fail(`Port ${profile.port} is already in use; refusing to kill unrelated processes.\n${occupied.join('\n')}`);
+    throw new Error(`Port ${profile.port} is already in use; refusing to kill unrelated processes.\n${occupied.join('\n')}`);
   }
 }
 
@@ -305,12 +331,14 @@ async function startPid(profile, model, options) {
 }
 
 async function startSystemd(profile, model, manager, options) {
-  writeSystemdEnv(profile);
   const unit = serviceName(profile);
   if (options.dryRun) {
+    // Written after this point, never before: a dry run plans, it does not put files on the host.
+    printDryRun(`write ${systemdEnvFile(profile)}`);
     printDryRun(`systemctl ${manager.scope === 'user' ? '--user ' : ''}start ${unit}`);
     return;
   }
+  writeSystemdEnv(profile);
   const daemonReload = systemctl(manager.scope, ['daemon-reload']);
   if (daemonReload.status !== 0) {
     fail(daemonReload.stderr || daemonReload.stdout || `systemctl daemon-reload failed for ${manager.scope}`);
@@ -342,9 +370,15 @@ async function startSystemd(profile, model, manager, options) {
 }
 
 async function startProfile(profile, options) {
-  ensureDirs();
   const model = options.model || profile.defaultModel || '';
-  assertPortAvailable(profile);
+  if (options.dryRun) {
+    // Announced, not evaluated: the plan still states the guard a real start would apply, so a
+    // dry run does not read as though the guard had gone away.
+    printDryRun(`preflight (not evaluated): refuse to start if '${profile.name}' is already running or port ${profile.port} is occupied`);
+  } else {
+    ensureDirs();
+  }
+  assertPortAvailable(profile, probeFor(options));
   const manager = chooseManager();
   if (manager.type === 'systemd') {
     await startSystemd(profile, model, manager, options);
@@ -544,4 +578,14 @@ async function main() {
   }
 }
 
-main();
+// stopProfile's dry run deliberately keeps reading live state: it reports what it would stop and
+// never exits non-zero, so it cannot fail a preflight the way the start guard did.
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  assertPortAvailable,
+  dryRunProcessProbe,
+  liveProcessProbe
+};


### PR DESCRIPTION
## Why

`remote-ollama-profile start --dry-run` consulted the live machine before printing its plan: `assertPortAvailable` read the pid state file, sent signal 0, asked systemd, and ran `ss`. On any host with that profile up it refused with exit 1 — and the one host where that is guaranteed is the benchmark box, whose entire job is to keep `ollama serve` running.

The cost was not one red test. The unattended benchmark agent runs a **source preflight** over the full suite before any GPU work; this test failed there, so the agent published `status: "infrastructure_error"` with `reasons: ["preflight tests failed"]` and never ran a benchmark. **The box could not benchmark precisely because it was doing its job.**

## What changed

The check now comes from an **injected probe** — live for a real start, inert for a plan-only one, stubbable from a test.

- A dry run announces the preflight it did *not* evaluate, so an inert check never reads as no check.
- A dry run no longer `mkdir`s the state root or writes the systemd env file: a plan does not put files on the host.
- A real start is unchanged. The guard `throw`s instead of exiting in place, which `main()` already routes through `fail()`, so the CLI still exits 1 with the same message.
- `stopProfile`'s dry run deliberately keeps reading live state: it *reports* what it would stop and never exits non-zero, so it cannot fail a preflight.

## Tests

The existing dry-run case is now hermetic, plus:

- a **perturbation** that plants a running-profile state file whose pid is the test process itself (alive on any host) and still expects exit 0 — it fails on the old code;
- the **refusal** half proven twice: at the guard, with a stub probe reporting running/occupied, and end to end, where a non-dry start on that same fixture still exits 1.

## Gates

| Gate | Mac | LLM box (Ollama running) |
|---|---|---|
| Suite | 433 files / 3301 passed | **433 passed (was 432 passed, 1 failed)** |
| Typecheck | 0 | — |

Verified on the box by cloning this branch and running the full suite under the same live-Ollama conditions that produced the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)