### PR TITLE
fix(benchmark): give content generation the host addressing it needs

### DIFF
--- a/tests/tools/remote-ollama-benchmark.test.js
+++ b/tests/tools/remote-ollama-benchmark.test.js
@@ -1,6 +1,6 @@
 const assert = require("node:assert/strict");
 const { spawn, spawnSync } = require("node:child_process");
-const { mkdtempSync, writeFileSync } = require("node:fs");
+const { mkdirSync, mkdtempSync, writeFileSync } = require("node:fs");
 const http = require("node:http");
 const { tmpdir } = require("node:os");
 const { join, resolve } = require("node:path");
@@ -10,6 +10,7 @@ const {
   assertPortAvailable,
   dryRunProcessProbe,
 } = require("../../tools/remote-ollama-control/scripts/remote-ollama-profile");
+const { hostEnvironmentForChild } = require("../../tools/remote-ollama-control/scripts/lib/benchmark-pipeline");
 const {
   buildContentGenMatrix,
   buildHardwareBenchmarkSpecs,
@@ -634,3 +635,48 @@ test("local run-local verifies endpoint and model against a live local Ollama-co
 // - content-gen matrix rejects duplicate sanitized configuration ids
 // - explicit model/profile filters with no eligible intersection fail closed
 // - explicit context, output, repeat, and scenario overrides produce exact call bounds
+
+// The content-gen child runs in the isolated source worktree, where config/llm-host.env is absent
+// by design. Before this, it inherited nothing, defaulted sshPort to 22, and reported a route-probe
+// failure — a network story for a missing-file fault, published as infrastructure_error.
+test("content generation inherits host addressing from the installed package, not the worktree", () => {
+  const installed = mkdtempSync(join(tmpdir(), "remote-ollama-installed-"));
+  mkdirSync(join(installed, "config"), { recursive: true });
+  writeFileSync(
+    join(installed, "config", "llm-host.env"),
+    "LLM_INTERNAL_HOST=10.0.0.5\nLLM_SSH_PORT=2222\nLLM_DEFAULT_ROUTE=internal\nUNRELATED=nope\n",
+  );
+
+  const hostEnv = hostEnvironmentForChild(installed);
+  assert.equal(hostEnv.LLM_INTERNAL_HOST, "10.0.0.5");
+  // The port is the whole point: without it the child probes 22 and blames the network.
+  assert.equal(hostEnv.LLM_SSH_PORT, "2222");
+  assert.equal(hostEnv.LLM_DEFAULT_ROUTE, "internal");
+  // Only LLM_* crosses over — the file is not a general-purpose environment injection point.
+  assert.equal("UNRELATED" in hostEnv, false);
+});
+
+// The refusal half: an installation with no host file must say so, naming the file, rather than
+// letting the child emit a plausible-looking route-probe failure.
+test("content generation refuses to start when the runner has no host addressing", () => {
+  const empty = mkdtempSync(join(tmpdir(), "remote-ollama-nohost-"));
+  mkdirSync(join(empty, "config"), { recursive: true });
+
+  const saved = {
+    internal: process.env.LLM_INTERNAL_HOST,
+    external: process.env.LLM_EXTERNAL_HOST,
+  };
+  delete process.env.LLM_INTERNAL_HOST;
+  delete process.env.LLM_EXTERNAL_HOST;
+  try {
+    assert.throws(
+      () => hostEnvironmentForChild(empty),
+      /content generation has no host configuration: .*llm-host\.env/,
+    );
+  } finally {
+    if (saved.internal === undefined) delete process.env.LLM_INTERNAL_HOST;
+    else process.env.LLM_INTERNAL_HOST = saved.internal;
+    if (saved.external === undefined) delete process.env.LLM_EXTERNAL_HOST;
+    else process.env.LLM_EXTERNAL_HOST = saved.external;
+  }
+});

--- a/tools/remote-ollama-control/scripts/lib/benchmark-pipeline.js
+++ b/tools/remote-ollama-control/scripts/lib/benchmark-pipeline.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
+const { ROOT_DIR, parseEnvFile } = require('./config');
 const { validateContentResult } = require('./ak-compare');
 const { loadScenarioCatalog } = require('./ak-scenarios');
 const { MANIFEST_NAME, latestResultDir } = require('./content-gen-checkpoint');
@@ -243,6 +244,36 @@ function resumableAuthoringDir(resultsDir) {
   return candidate;
 }
 
+// The content-gen child runs inside the isolated SOURCE WORKTREE, where config/llm-host.env does
+// not exist: site addresses are operator data and are deliberately never committed. So the child
+// loaded no host config at all and every value fell back to its default — no internal host, no
+// external host, and sshPort 22 while this box's sshd is on 2222. That surfaced as
+// "Route auto-detection failed ... answered on port 22", a message about the network for a fault
+// that is a missing file, and the run published infrastructure_error before any GPU work.
+//
+// Site addressing is INSTALLATION data, not revision data, so it comes from the installed package
+// this agent is itself running from — not from the worktree, whose source isolation stays intact.
+// process.env still wins over the file, matching loadConfig's own precedence.
+function hostEnvironmentForChild(rootDir = ROOT_DIR) {
+  const file = path.join(rootDir, 'config', 'llm-host.env');
+  const hostEnv = {};
+  for (const [key, value] of Object.entries(parseEnvFile(file))) {
+    if (key.startsWith('LLM_')) hostEnv[key] = value;
+  }
+  const haveHost = hostEnv.LLM_INTERNAL_HOST || hostEnv.LLM_EXTERNAL_HOST
+    || process.env.LLM_INTERNAL_HOST || process.env.LLM_EXTERNAL_HOST;
+  if (!haveHost) {
+    // Fail here, naming the file. The alternative is the child's route probe reporting a plausible
+    // network failure, which sends the reader to check the LAN instead of the configuration.
+    throw new Error(
+      `content generation has no host configuration: ${file} defines neither LLM_INTERNAL_HOST nor `
+      + 'LLM_EXTERNAL_HOST, and neither is set in the environment. Populate that file on the runner '
+      + '(it is gitignored by design) rather than expecting it from the source checkout.'
+    );
+  }
+  return hostEnv;
+}
+
 // Split out from the spawn so the composed command is assertable without running a benchmark.
 function authoringInvocation({ sourceWorktree, retentionDir, timeoutMs }) {
   const resultsDir = path.join(retentionDir, 'authoring');
@@ -266,7 +297,7 @@ async function runContentGenerationProcess({ sourceWorktree, retentionDir, timeo
   const { resultsDir } = invocation;
   const child = spawnSync(process.execPath, invocation.args, {
     cwd: sourceWorktree,
-    env: { ...process.env, LLM_RESULTS_DIR: resultsDir },
+    env: { ...hostEnvironmentForChild(), ...process.env, LLM_RESULTS_DIR: resultsDir },
     encoding: 'utf8', timeout: invocation.timeoutMs, maxBuffer: 32 * 1024 * 1024,
   });
   boundedLog(path.join(retentionDir, 'authoring-command.log'), child.stdout, child.stderr);
@@ -422,6 +453,7 @@ async function runBenchmarkPipeline({
 }
 
 module.exports = {
+  hostEnvironmentForChild,
   AUTHORING_TIMEOUT_MS,
   authoringInvocation,
   createCommittedBuildResolver,


### PR DESCRIPTION
## Why

The content-gen child runs inside the agent's **isolated source worktree**, where `config/llm-host.env` does not exist — site addresses are operator data and are deliberately never committed. So the child loaded no host config at all and every value fell back to its default: no internal host, no external host, and `sshPort` **22** while the runner's sshd is on **2222**.

That surfaced as:

    ERROR: Route auto-detection failed: neither the internal host (600ms) nor the external host (1500ms) answered on port 22.

— a message about the network for a fault that is a missing file — and the run published `infrastructure_error` with no GPU work. It was invisible until now because the source preflight always failed first (fixed in #96).

## What changed

Site addressing is **installation** data, not revision data, so it now comes from the installed package the agent is itself running from. The worktree's source isolation is untouched.

- `process.env` still wins over the file, matching `loadConfig`'s own precedence.
- Only `LLM_*` keys cross over, so the file does not become a general-purpose environment injection point.
- When neither host is configured anywhere, content generation fails **naming the file**, instead of letting the child emit a plausible route-probe failure that sends the reader to check the LAN.

Rejected alternative: `--local`. It sets the matrix `sha256` to the literal `local-unversioned`, which fails the pinned `AK_BENCHMARK_MATRIX_HASH` identity check, and collapses the 7-configuration matrix to one model on one endpoint. It swaps the benchmark for a different, unversioned one.

## Gates

433 files / 3303 passed · typecheck 0.

## Operator config (done on the runner, not in this diff)

The runner's `LLM_INTERNAL_HOST` was stale (`192.168.1.143`; the box is `192.168.1.170`, and `.143` is dead — silent to ping, incomplete ARP). Rather than chase a DHCP address that will churn again, the runner now self-addresses over loopback (`127.0.0.1:2222`) with a dedicated self-authorized key. Loopback cannot go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)