### PR TITLE
feat(benchmark): alarm when a merged fix never reaches the runner

### DIFF
--- a/.github/workflows/benchmark-heartbeat-alarm.yml
+++ b/.github/workflows/benchmark-heartbeat-alarm.yml
@@ -134,6 +134,46 @@ jobs:
               );
             }
 
+            // DEPLOYMENT DRIFT. The box runs an installed FILE COPY of the agent, not a checkout, so
+            // merging to main updates the source it checks out per run and never the agent itself.
+            // Both states are then true at once and look contradictory: the preflight passes with
+            // your new test while the code that spawned it is weeks old. Observed 2026-08-23 —
+            // PR #97 merged, preflight green at 433/433, and the identical infrastructure_error
+            // kept publishing until the package was reinstalled by hand.
+            //
+            // Comparing the installed commit to main's HEAD directly would fire on every unrelated
+            // merge, so it asks the only question that matters: has anything under the tool's own
+            // directory changed since the copy was taken? Silent when main races ahead elsewhere.
+            const installedCommit = heartbeat.agent?.installedCommit ?? null;
+            let agentDrift = null;
+            if (installedCommit) {
+              try {
+                const { data: diff } = await github.rest.repos.compareCommitsWithBasehead({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  basehead: `${installedCommit}...${context.payload.repository.default_branch}`,
+                });
+                const changed = (diff.files ?? [])
+                  .filter((file) => file.filename.startsWith('tools/remote-ollama-control/'))
+                  .map((file) => file.filename);
+                if (changed.length > 0) {
+                  agentDrift = changed;
+                  problems.push(
+                    `The runner is executing agent code from \`${installedCommit.slice(0, 12)}\`, and ` +
+                    `${changed.length} file(s) under \`tools/remote-ollama-control/\` have changed on ` +
+                    'the default branch since. A merge does NOT update the installed copy — reinstall ' +
+                    'it, or the agent keeps running the old logic while its preflight tests the new.',
+                  );
+                }
+              } catch (error) {
+                // An unknown commit (force-pushed away, or a box installed from a fork) must not
+                // fail the alarm: losing liveness detection to report a staleness question is a bad
+                // trade. Say it and move on.
+                problems.push(`Could not compare the installed agent commit \`${installedCommit}\`: ${error.message}`);
+              }
+            } else if (heartbeat.agent === null) {
+              core.notice('Heartbeat carries no agent provenance; the runner predates install-manifest reporting.');
+            }
+
             const progress = heartbeat.progress;
             const lines = [
               `- **Status**: \`${heartbeat.status}\`${heartbeat.dryRun ? ' (dry-run: no benchmark will execute)' : ''}`,
@@ -141,6 +181,9 @@ jobs:
               `- **Source commit**: \`${heartbeat.source?.commit?.slice(0, 12) ?? 'unknown'}\``,
               `- **Last attempt**: ${latest?.run?.id ?? 'none'} — \`${latest?.run?.status ?? 'n/a'}\`${attemptAgeDays === null ? '' : ` (${attemptAgeDays} day(s) ago)`}`,
               `- **Last qualifying result**: ${latestSuccess?.run?.id ?? 'none ever'}${resultAgeDays === null ? '' : ` (${resultAgeDays} day(s) ago)`}`,
+              `- **Installed agent**: ${installedCommit ? `\`${installedCommit.slice(0, 12)}\`` : 'unreported'}` +
+                `${heartbeat.agent?.installedAt ? ` (installed ${heartbeat.agent.installedAt})` : ''}` +
+                `${agentDrift ? ` — **stale: ${agentDrift.length} tool file(s) changed since**` : ''}`,
             ];
             if (progress) {
               const attempts = progress.attempts ?? {};

--- a/tests/tools/benchmark-heartbeat.test.js
+++ b/tests/tools/benchmark-heartbeat.test.js
@@ -1,14 +1,16 @@
 const assert = require('node:assert/strict');
 const { execFileSync } = require('node:child_process');
-const { mkdtempSync } = require('node:fs');
+const { mkdtempSync, writeFileSync } = require('node:fs');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 
 const {
   DEFAULT_BRANCH,
   HEARTBEAT_NAME,
+  INSTALL_MANIFEST_NAME,
   composeHeartbeat,
   publishHeartbeat,
+  readInstallManifest,
 } = require('../../tools/remote-ollama-control/scripts/lib/benchmark-heartbeat');
 
 const AT = '2026-08-23T12:00:00.000Z';
@@ -58,8 +60,10 @@ test('host and route detail cannot ride along into the published document', () =
   for (const leak of ['192.0.2.10', 'example.invalid', '2222', 'external']) {
     assert.ok(!serialized.includes(leak), `heartbeat leaked ${leak}: ${serialized}`);
   }
+  // Exhaustive on purpose: a new field must be added here deliberately, which is the moment to ask
+  // whether it can carry topology. `agent` was added 2026-08-23 and carries a commit hash only.
   assert.deepEqual(Object.keys(beat).sort(), [
-    'dryRun', 'error', 'identity', 'lastPublishedRunId', 'progress',
+    'agent', 'dryRun', 'error', 'identity', 'lastPublishedRunId', 'progress',
     'publishedAt', 'runKey', 'schemaVersion', 'source', 'status', 'triggerReasons',
   ]);
 });
@@ -108,3 +112,71 @@ test('the heartbeat branch is separate from the results branch', () => {
 // - a heartbeat carrying an error string from a failed poll
 // - identity hashes partially absent
 // - workDir that exists but is not a git repository
+
+// The box runs an installed file copy, so a merge updates the source it checks out per run and
+// never the agent itself. Nothing on the box can notice that, so the beacon carries the installed
+// commit off-box for the alarm to compare against the default branch.
+test('the beacon reports which agent code is running, not just which commit it polls', () => {
+  const beat = composeHeartbeat({
+    publishedAt: AT,
+    status: 'running',
+    dryRun: false,
+    sourceCommit: 'ffffffffffffffffffffffffffffffffffffffff',
+    agent: { installedCommit: '1111111111111111111111111111111111111111', installedAt: AT },
+  });
+
+  // The two are deliberately different values in this fixture: conflating them is the whole defect.
+  assert.equal(beat.agent.installedCommit, '1111111111111111111111111111111111111111');
+  assert.equal(beat.source.commit, 'ffffffffffffffffffffffffffffffffffffffff');
+  assert.equal(beat.agent.installedAt, AT);
+});
+
+test('a runner with no install manifest reports null provenance rather than failing to beat', () => {
+  const beat = composeHeartbeat({ publishedAt: AT, status: 'idle', dryRun: false });
+  // Null, not absent: the checker distinguishes "predates this reporting" from "field missing".
+  assert.equal(beat.agent, null);
+  assert.equal('agent' in beat, true);
+
+  const empty = mkdtempSync(join(tmpdir(), 'ak-no-manifest-'));
+  assert.equal(readInstallManifest(empty), null);
+
+  const corrupt = mkdtempSync(join(tmpdir(), 'ak-bad-manifest-'));
+  writeFileSync(join(corrupt, INSTALL_MANIFEST_NAME), 'not json at all');
+  // An unreadable manifest must not silence the beacon: losing liveness to report staleness is a
+  // strictly worse trade than reporting unknown provenance.
+  assert.equal(readInstallManifest(corrupt), null);
+});
+
+test('install provenance is read from the manifest the installer writes', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ak-manifest-'));
+  writeFileSync(join(dir, INSTALL_MANIFEST_NAME), JSON.stringify({
+    schemaVersion: 'agent-kernel-install-manifest/v1',
+    installedAt: AT,
+    sourceCommit: 'abc123abc123abc123abc123abc123abc123abcd',
+    sourceRef: 'main',
+  }));
+
+  assert.deepEqual(readInstallManifest(dir), {
+    installedCommit: 'abc123abc123abc123abc123abc123abc123abcd',
+    installedAt: AT,
+  });
+});
+
+test('provenance carries no address, port or route into the public document', () => {
+  const beat = composeHeartbeat({
+    publishedAt: AT,
+    status: 'idle',
+    dryRun: false,
+    agent: {
+      installedCommit: 'abc123abc123abc123abc123abc123abc123abcd',
+      installedAt: AT,
+      internalHost: '192.168.1.170',
+      sshPort: 2222,
+    },
+  });
+
+  const serialized = JSON.stringify(beat);
+  assert.equal(serialized.includes('192.168.1.170'), false);
+  assert.equal(serialized.includes('2222'), false);
+  assert.deepEqual(Object.keys(beat.agent).sort(), ['installedAt', 'installedCommit']);
+});

--- a/tools/remote-ollama-control/scripts/benchmark-heartbeat.js
+++ b/tools/remote-ollama-control/scripts/benchmark-heartbeat.js
@@ -20,7 +20,7 @@ const path = require('path');
 const { loadAgentState } = require('./lib/benchmark-state');
 const { latestResultDir } = require('./lib/content-gen-checkpoint');
 const { readProgress } = require('./lib/benchmark-progress');
-const { composeHeartbeat, publishHeartbeat, DEFAULT_BRANCH } = require('./lib/benchmark-heartbeat');
+const { composeHeartbeat, publishHeartbeat, readInstallManifest, DEFAULT_BRANCH } = require('./lib/benchmark-heartbeat');
 
 function requiredEnv(name) {
   const value = process.env[name];
@@ -78,6 +78,9 @@ function main() {
       matrixHash: process.env.AK_BENCHMARK_MATRIX_HASH || null,
       executionSuiteHash: process.env.AK_BENCHMARK_EXECUTION_SUITE_HASH || null,
     },
+    // Resolved from this file's own location, so it describes the copy that is actually executing
+    // rather than whatever a configured path might point at.
+    agent: readInstallManifest(path.resolve(__dirname, '..')),
     progress,
     lastPublishedRunId: lastPublishedRunId(state),
     error,

--- a/tools/remote-ollama-control/scripts/install-local-ubuntu.sh
+++ b/tools/remote-ollama-control/scripts/install-local-ubuntu.sh
@@ -52,6 +52,34 @@ else
     | tar -C "$REMOTE_PACKAGE_DIR" -xzf -
 fi
 
+# Written AFTER the copy, never before: rsync --delete would remove it. This is the only record of
+# which commit the installed copy came from -- the package dir is a file copy, not a checkout, so
+# `git log` there fails and a merge to main leaves it untouched and silent. The heartbeat publishes
+# this so the off-box alarm can say "a merge has not been deployed" instead of nobody noticing for
+# an hour, which is exactly what happened on 2026-08-23.
+INSTALL_SOURCE_COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || true)"
+INSTALL_SOURCE_REF="$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+# A source tree that is not a checkout yields null, not the string "null" and not a broken document:
+# the reader treats absent provenance as unknown, and an unparseable one would silence the beacon.
+if [ -n "$INSTALL_SOURCE_COMMIT" ]; then
+  INSTALL_COMMIT_JSON="\"$INSTALL_SOURCE_COMMIT\""
+else
+  INSTALL_COMMIT_JSON=null
+fi
+if [ -n "$INSTALL_SOURCE_REF" ]; then
+  INSTALL_REF_JSON="\"$INSTALL_SOURCE_REF\""
+else
+  INSTALL_REF_JSON=null
+fi
+cat > "$REMOTE_PACKAGE_DIR/.install-manifest.json" <<MANIFEST
+{
+  "schemaVersion": "agent-kernel-install-manifest/v1",
+  "installedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "sourceCommit": $INSTALL_COMMIT_JSON,
+  "sourceRef": $INSTALL_REF_JSON
+}
+MANIFEST
+
 chmod +x "$REMOTE_PACKAGE_DIR/bin/remote-ollama-profile" \
          "$REMOTE_PACKAGE_DIR/bin/remote-ollama-diagnostics" \
          "$REMOTE_PACKAGE_DIR/bin/remote-project-safety-check" \

--- a/tools/remote-ollama-control/scripts/lib/benchmark-heartbeat.js
+++ b/tools/remote-ollama-control/scripts/lib/benchmark-heartbeat.js
@@ -49,6 +49,7 @@ function composeHeartbeat({
   runKey = null,
   triggerReasons = [],
   identity = {},
+  agent = null,
   progress = null,
   lastPublishedRunId = null,
   error = null,
@@ -69,6 +70,16 @@ function composeHeartbeat({
       executionSuiteHash: identity.executionSuiteHash ?? null,
     },
     lastPublishedRunId,
+    // Which agent code is actually RUNNING, as opposed to which commit it polls. Those are
+    // different questions with different answers: the box runs an installed file copy, so merging
+    // to main updates what the agent checks out per run but never the agent itself. On 2026-08-23 a
+    // fix merged, the preflight went green with it, and the identical failure kept publishing for
+    // an hour because the code that spawns the preflight was still the previous copy. Nothing on
+    // the box could report that, so the beacon carries it off-box for the checker to compare.
+    // A commit hash, never a path: this document is public.
+    agent: agent
+      ? { installedCommit: agent.installedCommit ?? null, installedAt: agent.installedAt ?? null }
+      : null,
     // Present only while a run is in flight. Null is a real answer -- "the agent is alive and no
     // benchmark is running" -- and is not the same as the field being absent.
     progress,
@@ -98,8 +109,26 @@ function publishHeartbeat({ remote, branch = DEFAULT_BRANCH, workDir, heartbeat 
   return { branch, commit: git(workDir, ['rev-parse', 'HEAD']) };
 }
 
+const INSTALL_MANIFEST_NAME = '.install-manifest.json';
+
+/**
+ * Provenance of the installed copy, written by the installer. Absent is a legitimate answer that
+ * must not throw: a box installed before this existed has no manifest, and a beacon that died on
+ * that would remove the liveness signal to report a staleness one.
+ */
+function readInstallManifest(packageDir) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(packageDir, INSTALL_MANIFEST_NAME), 'utf8'));
+    return { installedCommit: raw.sourceCommit ?? null, installedAt: raw.installedAt ?? null };
+  } catch {
+    return null;
+  }
+}
+
 module.exports = {
   DEFAULT_BRANCH,
+  INSTALL_MANIFEST_NAME,
+  readInstallManifest,
   HEARTBEAT_NAME,
   SCHEMA_VERSION,
   composeHeartbeat,


### PR DESCRIPTION
## The gap

The box runs an installed **file copy** of the agent, not a checkout. Merging to `main` updates the source tree the agent checks out per run, and **never the agent itself**. Both states are then true at once and read as contradictory: the preflight passes with your new test while the code that *spawned* the preflight is weeks old.

Not hypothetical — this happened today:

| | |
|---|---|
| PR #97 merged | ✅ |
| Preflight on the box | ✅ green, 433/433 |
| Actual behaviour | ❌ identical `infrastructure_error`, for another hour |

Because `lib/benchmark-pipeline.js` on the box was still the previous copy. Nothing surfaced it: the agent exited zero, the heartbeat was fresh to the minute, and the alarm had no way to ask *which code is running*. It was found by hand, by grepping the installed file for a symbol.

## The fix

Nothing on the box can report this, so the beacon carries it off-box.

- **Installer** records provenance in `.install-manifest.json` (source commit, ref, timestamp), written **after** the rsync because `--delete` would remove it. A non-checkout source yields `null`, not a broken document.
- **Heartbeat** publishes it as `agent`, resolved from its own file location so it describes the copy actually executing. Absent or unreadable provenance reports `null` rather than killing the beat — losing liveness detection to report a staleness question is a strictly worse trade.
- **Alarm** compares the installed commit against the default branch and raises only when files under `tools/remote-ollama-control/` changed since. Comparing HEADs directly would fire on every unrelated merge; this asks the one question that matters and stays silent otherwise.

## Notes

- The document is **public**, so provenance is a commit hash and nothing else. The existing exhaustive key-shape guard failed on the new field — that guard working as designed — and a new test pins that no host, port, or route survives into `agent`.
- `schemaVersion` stays `v1`: additive field, every reader uses optional chaining.
- A box installed before this reports `agent: null`, so the check is **inert until the next reinstall** rather than firing spuriously.

## Gates

433 files / 3307 passed · typecheck 0. Installer verified end to end in both the git and non-git source cases; the embedded workflow script syntax-checked as JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)