### PR TITLE
fix(ci): assign the benchmark alarm so it actually notifies someone

### DIFF
--- a/.github/workflows/benchmark-heartbeat-alarm.yml
+++ b/.github/workflows/benchmark-heartbeat-alarm.yml
@@ -236,9 +236,23 @@ jobs:
             }
 
             if (!existing) {
-              await github.rest.issues.create({
+              const { data: created } = await github.rest.issues.create({
                 owner: context.repo.owner, repo: context.repo.repo, title, body, labels: [label],
               });
+              // Creation is the notification, but only for someone already watching the repository.
+              // An unassigned bot-authored issue is easy to never see, and the whole mechanism is
+              // built for the case where nobody is looking. Assignment notifies regardless of watch
+              // settings. Separate call and non-fatal on purpose: an owner who cannot be assigned
+              // (an org without the repo-owner as a member, a renamed account) must degrade to the
+              // issue existing unassigned, never to the alarm failing to raise at all.
+              try {
+                await github.rest.issues.addAssignees({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: created.number, assignees: [context.repo.owner],
+                });
+              } catch (error) {
+                core.warning(`Raised #${created.number} but could not assign ${context.repo.owner}: ${error.message}`);
+              }
               return;
             }
 


### PR DESCRIPTION
The alarm raises a bot-authored issue with a label and **no assignee**. That notifies only someone already watching the repository — and the whole mechanism exists for the case where nobody is looking. Issue #94 sat open and unassigned through six consecutive `infrastructure_error` results today.

Assignment notifies regardless of watch settings.

Separate call and non-fatal on purpose: an owner who cannot be assigned (an org that does not have the repo-owner as a member, a renamed account) must degrade to the issue existing unassigned, never to the alarm failing to raise at all. A failure logs a warning naming the issue it did raise.

`permissions: issues: write` already covers this; no scope change.

Gates: 433 files / 3307 passed. Embedded script syntax-checked as JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)