### PR TITLE
feat(benchmark): lower the scenario-verdict gate from 0.99 to 0.96

### DIFF
--- a/tests/tools/benchmark-progress.test.js
+++ b/tests/tools/benchmark-progress.test.js
@@ -169,3 +169,35 @@ test('the summary is serializable, since it crosses a process and a git branch',
 // - scenarioCount of 0
 // - mixed tiers, asserting the tier breakdown
 // - a configuration where every attempt is an infrastructure failure
+
+// The gate that actually binds. Over a 100-scenario set 0.99 permits exactly one miss, and
+// canStillQualify is optimistic — it credits every remaining attempt as perfect — so a
+// configuration used to be eliminated by its second miss. 0.96 permits four. Pinned because the
+// value is a maintainer calibration decision, not an implementation detail to drift.
+test('the verdict gate permits four misses in a hundred, and the tool-call gate still permits one', () => {
+  const { DEFAULT_THRESHOLDS, canStillQualify } = require('../../tools/remote-ollama-control/scripts/lib/ak-compare');
+
+  assert.equal(DEFAULT_THRESHOLDS.scenarioVerdictRate, 0.96);
+  assert.equal(DEFAULT_THRESHOLDS.toolCallRate, 0.99);
+  assert.equal(DEFAULT_THRESHOLDS.averageScore, 75);
+
+  const attempt = (passed) => ({
+    recordKind: 'content_gen_attempt',
+    toolCallProduced: true,
+    scenarioVerdict: { passed },
+    score: 100,
+  });
+
+  // Four misses with the rest of the set still to run: survivable at 0.96, and was not at 0.99.
+  const fourMisses = [...Array(4)].map(() => attempt(false)).concat([...Array(6)].map(() => attempt(true)));
+  assert.equal(canStillQualify(fourMisses, { remainingAttempts: 90 }), true);
+
+  // Five is not, whatever happens next — the ceiling is already 0.95.
+  const fiveMisses = [...Array(5)].map(() => attempt(false)).concat([...Array(5)].map(() => attempt(true)));
+  assert.equal(canStillQualify(fiveMisses, { remainingAttempts: 90 }), false);
+
+  // The live shape that prompted the change: qwen3:14b sat at 12 misses in 46 attempts, so its
+  // ceiling was 0.88 and it fails the new gate too. Lowering the bar did not lower it to nothing.
+  const observed = [...Array(12)].map(() => attempt(false)).concat([...Array(34)].map(() => attempt(true)));
+  assert.equal(canStillQualify(observed, { remainingAttempts: 54 }), false);
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-compare.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-compare.js
@@ -4,9 +4,22 @@ const fs = require('fs');
 const path = require('path');
 const { table } = require('./markdown');
 
+// scenarioVerdictRate was 0.99 until 2026-08-23. Over a 100-scenario set that permits exactly one
+// miss, and canStillQualify is optimistic -- it credits every remaining attempt as perfect -- so a
+// configuration was eliminated by its SECOND miss, often within the first quarter of its run.
+// Lowered to 0.96 (four misses) on the maintainer's call, to leave a gate that a strong model can
+// actually clear while still demanding near-perfection.
+//
+// toolCallRate stays 0.99 deliberately: producing a tool call at all is a harness-level
+// expectation, not a quality judgment, and it currently runs at 1.0. Only the verdict gate moved.
+//
+// Thresholds are NOT part of the content-gen matrix hash (that covers contractVersion, repeatPolicy
+// and configurations), so this does not invalidate AK_BENCHMARK_MATRIX_HASH and needs no identity
+// regeneration on the runner. Each published result records the thresholds it was judged against,
+// so results either side of this change remain readable rather than silently incomparable.
 const DEFAULT_THRESHOLDS = Object.freeze({
   toolCallRate: 0.99,
-  scenarioVerdictRate: 0.99,
+  scenarioVerdictRate: 0.96,
   averageScore: 75
 });
 


### PR DESCRIPTION
Over a 100-scenario set `0.99` permits exactly **one** miss, and `canStillQualify` is optimistic — it credits every remaining attempt as perfect — so a configuration was eliminated by its **second** miss, often in the first quarter of its run. Measured live: `qwen3:14b` was ruled out at attempt 21 with 4 misses, because even 79 perfect attempts capped it at 0.96.

`0.96` permits four misses. Maintainer's call.

`toolCallRate` stays `0.99` deliberately: producing a tool call at all is a harness-level expectation rather than a quality judgment, and it currently runs at 1.0. Only the verdict gate moved.

## Two things this does NOT do — verified, not assumed

**It does not disturb run identity.** Thresholds are not part of the content-gen matrix hash (that covers `contractVersion`, `repeatPolicy`, `configurations`). The pinned `AK_BENCHMARK_MATRIX_HASH` still computes to `21d13559…`, so the runner needs no identity regeneration and change-detection is unaffected. Each published result records the thresholds it was judged against, so results either side of this stay readable rather than silently incomparable.

**It does not rescue anything measured so far:**

| Config | Misses | Ceiling | Passes 0.96? |
|---|---|---|---|
| qwen3.5:9b | 38 / 100 | 0.62 | no |
| qwen3:14b | 12 / 46 | 0.88 | no |

Whether the gate is now *reachable* rests entirely on the five 27b/30b configurations that have not started. A test pins that shape explicitly, so "we lowered the bar to nothing" stays falsifiable.

The in-flight run is judged by the installed agent copy and keeps the old gate; this takes effect at the next reinstall.

Gates: 433 files / 3308 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)