### PR TITLE
fix(benchmark): the resource schema now states the contract the CLI enforces

### DIFF
--- a/tests/tools/remote-ollama-resource-spec-alignment.test.js
+++ b/tests/tools/remote-ollama-resource-spec-alignment.test.js
@@ -80,3 +80,109 @@ test("normalization never adds a resource field the CLI would reject", () => {
     );
   }
 });
+
+// ---------------------------------------------------------------------------
+// Combination-level conformance.
+//
+// The tests above check that every field NAME the schema offers is one the CLI accepts. That is
+// necessary and was not sufficient: on 2026-08-23 the schema offered only legal names in two
+// COMBINATIONS the parser rejects, and 57 of 700 benchmark attempts died on them. Worse, both were
+// reported as bad enum VALUES for fields that were simply absent, so they read as model error --
+// 71% of the best configuration's failures were this, not capability.
+//
+// So these drive the real CLI with objects the schema calls valid. A schema branch that cannot be
+// executed is a promise to the model that the parser will break.
+
+const { mkdtempSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { spawnSync } = require("node:child_process");
+
+const AK_CLI = join(REPO_ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+
+// The benchmark hands the model an object and ships `key=value;key=value` to the CLI. Go through
+// the same shape, so the test exercises the path the run actually takes.
+function toSegments(resource) {
+  return Object.entries(resource).map(([k, v]) => `${k}=${v}`).join(";");
+}
+
+function createWithResource(resource) {
+  const outDir = mkdtempSync(join(tmpdir(), "ak-resource-conformance-"));
+  return spawnSync(process.execPath, [
+    AK_CLI, "create",
+    "--resource", toSegments(resource),
+    "--run-id", "run_resource_conformance",
+    "--created-at", "2026-08-24T00:00:00.000Z",
+    "--out-dir", outDir,
+  ], { cwd: REPO_ROOT, encoding: "utf8" });
+}
+
+// Derived from the schema, not hand-written to match it. A hand-written mirror passes even after
+// someone adds a branch the parser cannot execute -- which is precisely the failure being guarded.
+// Synthesising the minimal object for each branch means a NEW branch is exercised automatically.
+function sampleValue(name, propertySchema) {
+  const spec = propertySchema || {};
+  if (Array.isArray(spec.enum)) return spec.enum[0];
+  if (spec.type === "integer" || spec.type === "number") {
+    return Number.isFinite(spec.minimum) ? Math.max(spec.minimum, 1) : 1;
+  }
+  return `sample_${name}`;
+}
+
+// A branch may nest its own anyOf (the vital payload needs delta OR regen), so each nested
+// alternative becomes its own executable case rather than being collapsed to one.
+function branchCases(branch, path = []) {
+  const base = branch.required || [];
+  if (!Array.isArray(branch.anyOf) || branch.anyOf.length === 0) {
+    return [{ fields: base, label: path.join(" + ") || base.join(" + ") }];
+  }
+  return branch.anyOf.flatMap((nested, i) => branchCases(
+    { ...nested, anyOf: nested.anyOf },
+    [...path, `${base.join(" + ")} + ${(nested.required || []).join(" + ") || `alt${i}`}`],
+  ).map((c) => ({ fields: [...base, ...c.fields], label: c.label })));
+}
+
+const RESOURCE_ITEMS = AK_CREATE_TOOL.function.parameters.properties.resource.items;
+const DERIVED_CASES = (RESOURCE_ITEMS.anyOf || []).flatMap((b) => branchCases(b));
+
+assert.ok(DERIVED_CASES.length >= 2, "failed to derive executable cases from the resource schema");
+
+for (const { fields, label } of DERIVED_CASES) {
+  test(`every schema branch is executable by the CLI: ${label}`, () => {
+    const resource = {};
+    for (const field of fields) {
+      resource[field] = sampleValue(field, RESOURCE_ITEMS.properties[field]);
+    }
+    const result = createWithResource(resource);
+    assert.equal(
+      result.status, 0,
+      `the tool schema advertises this branch but the CLI rejects it:\n`
+      + `  ${toSegments(resource)}\n  ${(result.stderr || result.stdout || "").trim()}`,
+    );
+  });
+}
+
+// The two shapes that actually cost the run. Both are now unrepresentable in the schema, and both
+// must stay rejected by the CLI -- if either starts passing, the schema branches above are the
+// thing to re-derive, not these expectations.
+test("the two shapes that cost 57 attempts are rejected by the CLI and unrepresentable in the schema", () => {
+  const affinityWithPermanence = { affinity: "fire", expression: "emit", stacks: 1, mana: 25, permanenceMode: "consumable" };
+  const vitalWithoutPermanence = { vital: "health", delta: 15, expression: "emit", stacks: 3 };
+
+  assert.notEqual(createWithResource(affinityWithPermanence).status, 0,
+    "an affinity payload carrying permanenceMode should still be rejected");
+  assert.notEqual(createWithResource(vitalWithoutPermanence).status, 0,
+    "a vital payload without permanenceMode should still be rejected");
+
+  // ...and the schema must no longer advertise them.
+  const items = AK_CREATE_TOOL.function.parameters.properties.resource.items;
+  const branches = items.anyOf || [];
+  const vitalBranch = branches.find((b) => (b.required || []).includes("vital"));
+  const affinityBranch = branches.find((b) => (b.required || []).includes("affinity"));
+
+  assert.ok(vitalBranch.required.includes("permanenceMode"),
+    "the vital branch must require permanenceMode — the parser validates it as an enum and absent fails");
+  assert.ok(affinityBranch.not,
+    "the affinity-only branch must exclude the vital-payload keys the parser reads as a vital declaration");
+  const excluded = (affinityBranch.not.anyOf || []).flatMap((b) => b.required || []);
+  assert.deepEqual([...excluded].sort(), ["delta", "permanenceMode", "regen", "vital"]);
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-tool-schema.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-tool-schema.js
@@ -177,25 +177,65 @@ const AK_CREATE_TOOL = {
         },
         resource: {
           type: 'array',
-          description: 'Resource pickups carrying a vital payload, an affinity payload, or both.',
+          description:
+            'Resource pickups carrying a vital payload, an affinity payload, or both. A vital '
+            + 'payload is permanenceMode + vital + (delta or regen). An affinity payload is '
+            + 'affinity + expression + stacks + mana. permanenceMode belongs to the vital payload '
+            + 'and must not appear on an affinity-only resource.',
           items: {
             type: 'object',
             properties: {
               id: { type: 'string' },
-              permanenceMode: { type: 'string', enum: ['consumable', 'level', 'permanent'] },
+              permanenceMode: {
+                type: 'string',
+                enum: ['consumable', 'level', 'permanent'],
+                description:
+                  'Part of the VITAL payload — it governs how long the vital delta persists. '
+                  + 'Required whenever vital is set, and must be omitted on an affinity-only resource.'
+              },
               vital: { type: 'string', enum: ['health', 'mana', 'stamina'] },
               regen: { type: 'integer', minimum: 0 },
               affinity: { type: 'string', enum: AFFINITY_ENUM },
               expression: { type: 'string', enum: EXPRESSION_ENUM },
               stacks: { type: 'integer', minimum: 1 },
-              mana: { type: 'integer', minimum: 0 },
+              mana: { type: 'integer', minimum: 0, description: 'Affinity-payload mana pool. An integer here, unlike hazard.mana.' },
               manaRegen: { type: 'integer', minimum: 0 },
-              delta: { type: 'number', description: 'Amount to apply' }
+              delta: { type: 'number', description: 'Amount of the vital to apply' }
             },
+            // These branches restate the contract parseResourceSpec actually enforces. The previous
+            // pair -- {required:['vital']} and {required:[affinity,expression,stacks,mana]} --
+            // advertised two shapes the CLI rejects, and the run of 2026-08-23 lost 57 of 700
+            // attempts to them: a vital payload without permanenceMode, and an affinity payload
+            // carrying one. Both were reported as bad enum VALUES for fields that were simply
+            // absent, which is why it read as model error for months.
             anyOf: [
-              { required: ['vital'] },
-              { required: ['affinity', 'expression', 'stacks', 'mana'] }
-            ]
+              {
+                // A vital payload, optionally alongside an affinity payload. permanenceMode is
+                // required here because the parser reads it as the declaration of a vital payload
+                // and then validates it as an enum -- absent, it fails as "must be one of".
+                required: ['permanenceMode', 'vital'],
+                anyOf: [{ required: ['delta'] }, { required: ['regen'] }]
+              },
+              {
+                // An affinity payload alone. The parser treats ANY of permanenceMode/vital/delta/
+                // regen as "a vital payload follows" and then demands the whole set, so none of
+                // them may appear on an affinity-only resource.
+                required: ['affinity', 'expression', 'stacks', 'mana'],
+                not: {
+                  anyOf: [
+                    { required: ['permanenceMode'] },
+                    { required: ['vital'] },
+                    { required: ['delta'] },
+                    { required: ['regen'] }
+                  ]
+                }
+              }
+            ],
+            // Descriptive for clients that honour it; the anyOf above is the enforcing half.
+            dependentRequired: {
+              affinity: ['expression', 'stacks', 'mana'],
+              manaRegen: ['mana']
+            }
           }
         },
         delver: {


### PR DESCRIPTION
Step 1 of the [benchmark failure analysis](https://claude.ai/code/artifact/dfaade37-c1b7-40e8-9da5-7b2a6a5619f2) — the highest-leverage item, 57 of 700 failed attempts.

## The defect

The tool schema advertised two resource shapes `parseResourceSpec` rejects:

| Shape | Rejected because |
|---|---|
| `{affinity, expression, stacks, mana, permanenceMode}` | no `vital` |
| `{vital, delta, …}` | no `permanenceMode` |

The parser reads **any** of `permanenceMode`/`vital`/`delta`/`regen` as the declaration of a vital payload and then requires the whole set. `permanenceMode` governs the vital delta — the implementation says so twice — so it belongs to the vital payload and is meaningless beside an affinity payload. The old `anyOf`, `{required:['vital']}` and `{required:[affinity,expression,stacks,mana]}`, said neither thing.

**The CLI is not the defect.** It enforces its documented contract; the schema misdescribed it. So this changes the schema and leaves validation that artifacts depend on alone.

## Why it read as model error

Both were reported as bad enum *values* for fields that were simply absent — `vital must be one of: health, mana, stamina` when no `vital` was sent. They are not evenly spread:

| Model | Share of attempts | Share of **failures** |
|---|---|---|
| qwen3.5:9b | 15% | 39% |
| qwen3:14b | 17% | 55% |
| qwen3.5:27b | 17% | 68% |
| **qwen3.8:27b** | **8%** | **71%** |

For the best configuration in the matrix, 71% of everything it got wrong was this. Correcting it moves `qwen3.8:27b/dual` from 0.90 → **0.97** verdict and `qwen3.8:27b/primary` from 0.86 → **0.96**, both clearing the gate. Both still land short of the 75 score bar (74.2 and 73.6) — a question for a clean re-run, not this diff.

## The test that was missing

The existing alignment test checks every field *name* the schema offers is one the CLI accepts. Necessary, and not sufficient: these were legal names in illegal combinations.

It's now joined by combination-level conformance that **derives** a minimal object from each schema branch and drives the real CLI with it. A branch the parser cannot execute fails immediately, and a newly added branch is exercised without anyone remembering to add a case.

Hand-written sample objects were the first attempt and were rejected — they passed against the *defective* schema too, making them a mirror of it rather than a guard on it. Perturbing the schema back to its old form now fails two tests.

Gates: 433 files / 3312 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)