### PR TITLE
fix(cli): resource errors distinguish a missing field from an invalid value

### DIFF
--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -1214,13 +1214,28 @@ function parseResourceSpec(value, resourceIndex) {
     let vitals = [];
     let permanenceMode = "consumable";
     if (hasVitalPayload) {
+      // Which key put us in this branch. Without it the messages below are unanswerable: an author
+      // who set only permanenceMode on an affinity resource is told a vital is required and has no
+      // way to see why. Naming the trigger turns "what?" into "drop this key, or complete the set".
+      const trigger = ["permanenceMode", "vital", "delta", "regen"].filter((key) => fields.has(key));
+      const because = `read as a vital payload because ${trigger.join(", ")} ${trigger.length === 1 ? "is" : "are"} set`;
+
+      // MISSING and INVALID are different faults and were reported identically. A missing field was
+      // announced as "must be one of <enum>", which sends the reader hunting for a bad value that
+      // was never sent -- it misled a whole failure analysis before anyone read this function.
+      if (!fields.has("permanenceMode")) {
+        throw new Error(`resource[${resourceIndex}] permanenceMode is required for a vital payload (${because}); it governs how long the vital delta persists.`);
+      }
       permanenceMode = fields.get("permanenceMode");
       if (!RESOURCE_ALLOWED_PERMANENCE_MODES.has(permanenceMode)) {
-        throw new Error(`resource[${resourceIndex}] permanenceMode must be one of: ${[...RESOURCE_ALLOWED_PERMANENCE_MODES].join(", ")}.`);
+        throw new Error(`resource[${resourceIndex}] permanenceMode must be one of: ${[...RESOURCE_ALLOWED_PERMANENCE_MODES].join(", ")}; got "${permanenceMode}".`);
+      }
+      if (!fields.has("vital")) {
+        throw new Error(`resource[${resourceIndex}] vital is required for a vital payload (${because}). For an affinity-only resource, omit ${trigger.join(", ")}.`);
       }
       const vitalKey = fields.get("vital");
-      if (!vitalKey || !RESOURCE_ALLOWED_VITAL_KEYS.has(vitalKey)) {
-        throw new Error(`resource[${resourceIndex}] vital must be one of: ${[...RESOURCE_ALLOWED_VITAL_KEYS].join(", ")}.`);
+      if (!RESOURCE_ALLOWED_VITAL_KEYS.has(vitalKey)) {
+        throw new Error(`resource[${resourceIndex}] vital must be one of: ${[...RESOURCE_ALLOWED_VITAL_KEYS].join(", ")}; got "${vitalKey}".`);
       }
       // delta is optional once regen is present: a regen-only resource is legal.
       if (!fields.has("delta") && !fields.has("regen")) {

--- a/tests/integration/ak-create-hazard-resource.test.js
+++ b/tests/integration/ak-create-hazard-resource.test.js
@@ -464,3 +464,50 @@ test.skip("ak create --dry-run for V3 resource with invalid permanenceMode exits
 // - `--hazard` using the minimum valid hazard spec should emit one V3 hazard artifact.
 // - duplicate `--hazard` ids should either fail deterministically or produce documented artifact ordering.
 // - hazard V3 with omitted durability should retain the default one-time durability vital.
+
+// A missing field and an invalid value are different faults with different fixes, and the V3
+// resource parser reported them identically: an absent `vital` was announced as
+// "vital must be one of: health, mana, stamina", which sends the reader hunting for a bad value
+// that was never sent. That message misattributed 57 of 700 benchmark attempts to the models on
+// 2026-08-23, and misled the analysis of them until someone read the parser.
+function createResource(spec) {
+  const outDir = mkdtempSync(join(os.tmpdir(), "ak-resource-msg-"));
+  return runCli([
+    "create", "--resource", spec,
+    "--run-id", "run_resource_message",
+    "--created-at", "2026-08-24T00:00:00.000Z",
+    "--out-dir", outDir,
+  ]);
+}
+
+test("a missing vital-payload field is reported as missing, and names the key that demanded it", () => {
+  // permanenceMode alone puts the parser in the vital branch. The author asked for an affinity
+  // resource, so the actionable advice is to drop the key, not to invent a vital.
+  const result = createResource("affinity=fire;expression=emit;stacks=1;mana=25;permanenceMode=consumable");
+  assert.notEqual(result.status, 0);
+  const message = `${result.stdout}${result.stderr}`;
+  assert.match(message, /vital is required for a vital payload/);
+  assert.match(message, /because permanenceMode is set/);
+  assert.match(message, /omit permanenceMode/);
+  // The old wording claimed the value was out of range. It never was — there was no value.
+  assert.doesNotMatch(message, /vital must be one of/);
+});
+
+test("a vital payload missing permanenceMode says so, rather than blaming its enum", () => {
+  const result = createResource("vital=health;delta=15");
+  assert.notEqual(result.status, 0);
+  const message = `${result.stdout}${result.stderr}`;
+  assert.match(message, /permanenceMode is required for a vital payload/);
+  assert.match(message, /because vital, delta are set/);
+  assert.doesNotMatch(message, /permanenceMode must be one of/);
+});
+
+test("an out-of-enum value still reports the enum, and quotes what was actually sent", () => {
+  const result = createResource("permanenceMode=forever;vital=health;delta=1");
+  assert.notEqual(result.status, 0);
+  const message = `${result.stdout}${result.stderr}`;
+  assert.match(message, /permanenceMode must be one of: consumable, level, permanent/);
+  // Quoting the value is what separates this case from the two above at a glance.
+  assert.match(message, /got "forever"/);
+  assert.doesNotMatch(message, /is required/);
+});


### PR DESCRIPTION
Step 2 of the [benchmark failure analysis](https://claude.ai/code/artifact/dfaade37-c1b7-40e8-9da5-7b2a6a5619f2). No behaviour change — only what the parser says when it refuses.

## Why

The V3 resource parser reported both faults identically. An absent `vital` was announced as `vital must be one of: health, mana, stamina`, which sends the reader hunting for a bad value that was never sent. That message misattributed **57 of 700** benchmark attempts to the models on 2026-08-23, and misled the analysis of them through several wrong conclusions — the text named a cause the data could not support, and nobody read the parser until late.

## Before / after

| Input | Was | Now |
|---|---|---|
| `affinity=fire;expression=emit;stacks=1;mana=25;permanenceMode=consumable` | `vital must be one of: health, mana, stamina.` | `vital is required for a vital payload (read as a vital payload because permanenceMode is set). For an affinity-only resource, omit permanenceMode.` |
| `vital=health;delta=15` | `permanenceMode must be one of: consumable, level, permanent.` | `permanenceMode is required for a vital payload (read as a vital payload because vital, delta are set); it governs how long the vital delta persists.` |
| `permanenceMode=forever;…` | `permanenceMode must be one of: consumable, level, permanent.` | `… ; got "forever".` |

The middle column is the same string for a missing field and a bad value. That is the defect.

Naming **which key** put the parser in the vital branch is the part that matters most: an author who set only `permanenceMode` on an affinity resource was told a vital is required with no way to see why. Now it says which key to drop.

Nothing asserted on the old text, so no callers move.

## Tests

Pin the *distinction*, not the wording of any one message — missing must not say "must be one of", invalid must not say "is required", and the trigger key must be named. Restoring the old conflated messages fails all three.

Gates: 433 files / 3315 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)