### PR TITLE
fix(benchmark): a create call must author something

### DIFF
--- a/tests/tools/ak-tool-schema-cli-conformance.test.js
+++ b/tests/tools/ak-tool-schema-cli-conformance.test.js
@@ -148,3 +148,48 @@ for (const [entity, flag] of Object.entries(ENTITY_FLAGS)) {
     });
   }
 }
+
+// The other direction: a shape the CLI refuses must be one the schema refuses too. Conformance is
+// two-sided, and this side is what the whole `create requires at least one authored object` class
+// was — a call the schema called valid and the CLI always rejected.
+test("a call that authors nothing is rejected by the CLI and unrepresentable in the schema", () => {
+  const outDir = mkdtempSync(join(tmpdir(), "ak-conformance-empty-"));
+  const result = spawnSync(process.execPath, [
+    AK_CLI, "create",
+    "--text", "Create eight rooms, three hazards and a delver party",
+    "--run-id", "run_authors_nothing",
+    "--created-at", "2026-08-24T00:00:00.000Z",
+    "--out-dir", outDir,
+  ], { cwd: ROOT, encoding: "utf8" });
+
+  assert.notEqual(result.status, 0, "the CLI should refuse a create that authors nothing");
+  assert.match(`${result.stdout}${result.stderr}`, /at least one authored object/);
+
+  // ...and the schema must no longer offer it. Prose in `text` authors nothing, and the parameters
+  // now say so structurally rather than trusting the model to infer it.
+  const parameters = AK_CREATE_TOOL.function.parameters;
+  const entityBranches = (parameters.anyOf || []).flatMap((branch) => branch.required || []);
+  assert.deepEqual(
+    [...entityBranches].sort(),
+    ["delver", "floorTile", "hazard", "resource", "room", "warden"],
+    "the top-level anyOf must require at least one authored entity",
+  );
+
+  // Every branch names a property that actually exists, or the constraint is unsatisfiable.
+  for (const entity of entityBranches) {
+    assert.ok(
+      parameters.properties[entity],
+      `the anyOf requires "${entity}" but the schema has no such property`,
+    );
+  }
+});
+
+test("the text field does not present itself as a place to author entities", () => {
+  const text = AK_CREATE_TOOL.function.parameters.properties.text;
+  // It is the one required string, so a model under load reaches for it. It has to say outright
+  // that describing an entity here creates nothing.
+  assert.match(text.description, /not where the dungeon is authored/i);
+  for (const entity of ["room", "hazard", "resource", "delver", "warden"]) {
+    assert.match(text.description, new RegExp(entity, "i"));
+  }
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-tool-schema.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-tool-schema.js
@@ -100,10 +100,32 @@ const AK_CREATE_TOOL = {
     parameters: {
       type: 'object',
       required: ['text', 'runId', 'outDir'],
+      // `create` refuses a call that authors nothing, and until now the schema permitted exactly
+      // that: text/runId/outDir were the only required fields, so "describe it in prose and author
+      // no entities" was a fully valid call that always failed. It is not a hypothetical shape --
+      // it is what models produce under load. On 2026-08-23 it cost 16 of 700 attempts, every one
+      // of them omitting the entity keys entirely rather than sending empty arrays, and it appeared
+      // in six of the eight scenarios no configuration ever passed.
+      //
+      // The tell was in the text field: median length 447 characters in these failures against 325
+      // in passing calls. The model wrote MORE prose precisely when it authored LESS structure,
+      // because the schema marked the prose mandatory and the structure optional.
+      anyOf: [
+        { required: ['room'] },
+        { required: ['floorTile'] },
+        { required: ['hazard'] },
+        { required: ['resource'] },
+        { required: ['delver'] },
+        { required: ['warden'] }
+      ],
       properties: {
         text: {
           type: 'string',
-          description: 'Freeform authoring text describing what to create.'
+          description:
+            'Freeform authoring context for the request. This is NOT where the dungeon is authored '
+            + 'and describing entities here creates none of them — every element must be supplied '
+            + 'in the room, floorTile, hazard, resource, delver and warden arrays. At least one of '
+            + 'those is required.'
         },
         budgetTokens: {
           type: 'integer',


### PR DESCRIPTION
Step 4 of the [benchmark failure analysis](https://claude.ai/code/artifact/dfaade37-c1b7-40e8-9da5-7b2a6a5619f2) — the last schema item.

## The gap

`create` refuses a call that authors nothing, and the schema permitted exactly that. `text`/`runId`/`outDir` were the only required fields, so *"describe it in prose and author no entities"* was a fully valid call that always failed.

Not hypothetical — it's what models produce under load. **16 of 700 attempts**, and it appeared in **six of the eight scenarios no configuration ever passed**. All 16 omitted the entity keys entirely rather than sending empty arrays, so requiring one to be present covers every observed case.

## The tell

Median `text` length in these failures was **447 characters against 325 in passing calls**. The model wrote *more* prose precisely when it authored *less* structure — because the schema marked the prose mandatory and the structure optional. One ran to 2,870 characters describing eight rooms and a resource spread, with every entity array empty:

> "ROOMS: Create 8 rooms total - mix of small (2), medium (3), and large (3)… RESOURCES: Create diverse resource pickups including: - Healt…"

The model understood the task perfectly and filled in the wrong field.

## Changes

Both structural rather than hopeful:

- a top-level `anyOf` requiring at least one of `room`/`floorTile`/`hazard`/`resource`/`delver`/`warden`
- a `text` description that says outright that describing an entity there creates none of it

`delta`-unless-`regen`, the other item on this step, turned out to be **already covered** — the vital branch from #106 nests `anyOf:[{required:['delta']},{required:['regen']}]`.

## Tests

Cover the *other* direction of conformance — a shape the CLI refuses must be one the schema refuses too — and check each `anyOf` branch names a property that exists, since a branch requiring a missing property is unsatisfiable. Removing the `anyOf` fails one test; reverting the description fails the other.

**Residual, stated rather than papered over:** a call sending an entity key with an *empty array* still satisfies the constraint. No attempt in 700 did that, and `minItems` would wrongly reject a valid mixed call passing one empty array alongside a populated one.

Gates: 434 files / 3347 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)