### PR TITLE
fix(cli): a hazard vital accepts a plain amount

### DIFF
--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -953,6 +953,17 @@ function parseHazardVitalSpec(value, field, hazardIndex) {
     return { kind: "one-time", amount: 0 };
   }
   const parts = value.split(":").map((s) => s.trim());
+  // A bare amount means one-time:<amount>. Models write `mana=10` overwhelmingly and always have:
+  // the field is called `mana` on hazard and on resource, and on resource it IS an integer. The
+  // prefixed grammar exists for the regen case, not the common one, so requiring it everywhere
+  // taxes the ordinary spelling. Accepting the shorthand removes the mismatch instead of
+  // documenting it -- 14 of 21 failures in a 43-attempt sample were exactly this.
+  if (parts.length === 1 && /^[0-9]+$/.test(parts[0])) {
+    return {
+      kind: "one-time",
+      amount: parseNonNegativeIntStrict(parts[0], `hazard[${hazardIndex}] ${field} amount`),
+    };
+  }
   if (parts[0] === "one-time" && parts.length === 2) {
     const amount = parseNonNegativeIntStrict(parts[1], `hazard[${hazardIndex}] ${field} amount`);
     return { kind: "one-time", amount };
@@ -966,7 +977,7 @@ function parseHazardVitalSpec(value, field, hazardIndex) {
     }
     return { kind: "regen", current, max, regen };
   }
-  throw new Error(`hazard[${hazardIndex}] ${field} must be one-time:<amount> or regen:<current>:<max>:<regen>.`);
+  throw new Error(`hazard[${hazardIndex}] ${field} must be a plain amount, one-time:<amount>, or regen:<current>:<max>:<regen>; got "${value}".`);
 }
 
 function placementVitalToHazardVital(vital) {

--- a/tests/integration/ak-create-hazard-resource.test.js
+++ b/tests/integration/ak-create-hazard-resource.test.js
@@ -511,3 +511,66 @@ test("an out-of-enum value still reports the enum, and quotes what was actually 
   assert.match(message, /got "forever"/);
   assert.doesNotMatch(message, /is required/);
 });
+
+// A plain amount is the ordinary spelling of a hazard vital, and requiring the prefixed grammar
+// everywhere taxed it. Models write `mana=10`: the field is named `mana` on hazard and on resource,
+// and on resource it IS an integer. In a 43-attempt sample after the field was made more prominent,
+// 14 of 21 failures were this one mismatch.
+for (const [label, value] of [
+  ["a plain amount", "10"],
+  ["a plain zero", "0"],
+  ["the explicit one-time form", "one-time:5"],
+  ["the regen form", "regen:4:4:1"],
+]) {
+  test(`a hazard vital accepts ${label}`, () => {
+    const outDir = mkdtempSync(join(os.tmpdir(), "ak-hazard-vital-"));
+    const result = runCli([
+      "create",
+      "--hazard", `affinity=fire;expression=emit;proximityRadius=2;mana=${value};durability=${value}`,
+      "--run-id", "run_hazard_vital",
+      "--created-at", "2026-08-24T00:00:00.000Z",
+      "--out-dir", outDir,
+    ]);
+    assert.equal(result.status, 0, `mana=${value} should be accepted: ${(result.stderr || result.stdout || "").trim()}`);
+  });
+}
+
+test("a plain amount is the one-time form, not a separate kind", () => {
+  const outDir = mkdtempSync(join(os.tmpdir(), "ak-hazard-vital-eq-"));
+  runCliOk([
+    "create",
+    "--hazard", "affinity=fire;expression=emit;proximityRadius=2;mana=10",
+    "--run-id", "run_hazard_plain",
+    "--created-at", "2026-08-24T00:00:00.000Z",
+    "--out-dir", outDir,
+  ]);
+  const plain = readJson(join(outDir, "spec.json")).configurator?.inputs?.levelGen?.hazards?.[0];
+
+  const outDirExplicit = mkdtempSync(join(os.tmpdir(), "ak-hazard-vital-eq2-"));
+  runCliOk([
+    "create",
+    "--hazard", "affinity=fire;expression=emit;proximityRadius=2;mana=one-time:10",
+    "--run-id", "run_hazard_plain",
+    "--created-at", "2026-08-24T00:00:00.000Z",
+    "--out-dir", outDirExplicit,
+  ]);
+  const explicit = readJson(join(outDirExplicit, "spec.json")).configurator?.inputs?.levelGen?.hazards?.[0];
+
+  // Shorthand, not a new behaviour: the two spellings must produce identical artifacts.
+  assert.deepEqual(plain, explicit);
+});
+
+test("a hazard vital still rejects a value in no recognised form", () => {
+  const outDir = mkdtempSync(join(os.tmpdir(), "ak-hazard-vital-bad-"));
+  const result = runCli([
+    "create",
+    "--hazard", "affinity=fire;expression=emit;proximityRadius=2;mana=nonsense",
+    "--run-id", "run_hazard_bad",
+    "--created-at", "2026-08-24T00:00:00.000Z",
+    "--out-dir", outDir,
+  ]);
+  assert.notEqual(result.status, 0);
+  const message = `${result.stdout}${result.stderr}`;
+  assert.match(message, /plain amount, one-time:<amount>, or regen:/);
+  assert.match(message, /got "nonsense"/);
+});

--- a/tests/tools/ak-tool-schema-cli-conformance.test.js
+++ b/tests/tools/ak-tool-schema-cli-conformance.test.js
@@ -193,3 +193,20 @@ test("the text field does not present itself as a place to author entities", () 
     assert.match(text.description, new RegExp(entity, "i"));
   }
 });
+
+// The schema description for a hazard vital must not name the other type. An earlier revision read
+// "this is a STRING here; resource.mana is an integer", and naming the contrast beside the field
+// tripled its use and flipped its spelling: 25% of hazards carried mana and 100% of those were
+// well-formed before, against 77% carrying it and most malformed after. The lesson is narrow and
+// worth pinning -- a description is a prompt, and mentioning a wrong form teaches it.
+test("hazard vital descriptions do not name the type they are not", () => {
+  const hazard = AK_CREATE_TOOL.function.parameters.properties.hazard.items.properties;
+  for (const field of ["mana", "durability"]) {
+    assert.doesNotMatch(
+      hazard[field].description, /resource\.mana|is an integer|STRING here/i,
+      `${field} contrasts itself with another field's type — that priming tripled malformed values`,
+    );
+  }
+  // Both spellings the CLI accepts must be offered, with the common one first.
+  assert.equal(hazard.mana.examples[0], 10, "lead with the plain amount, which is what models write");
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-tool-schema.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-tool-schema.js
@@ -185,21 +185,29 @@ const AK_CREATE_TOOL = {
               proximityRadius: { type: 'integer', minimum: 1, description: 'Tiles around the hazard its affinity pressure reaches' },
               stacks: { type: 'integer', minimum: 1, default: 1 },
               blocking: { type: 'boolean', description: 'Whether the hazard blocks movement through its tile' },
-              // The format was carried in prose only, so nothing could check a value before the CLI
-              // rejected it and no derived test could generate a valid one. `pattern` states the
-              // grammar parseHazardVitalSpec accepts; `examples` gives any generator a known-good
-              // value. (current <= max is semantic and stays with the parser.)
+              // A plain amount is the ordinary spelling and is what models write; the prefixed
+              // forms exist for the regen case. `pattern` states the grammar parseHazardVitalSpec
+              // accepts, `examples` leads with the common form so a generator and a model both
+              // reach for it first. (current <= max is semantic and stays with the parser.)
+              //
+              // The description deliberately does NOT contrast this field with resource.mana. An
+              // earlier revision said "this is a STRING here; resource.mana is an integer", and
+              // naming the other type beside the field tripled its use and flipped its spelling to
+              // integers: 25% of hazards carried mana and 100% of those were well-formed before,
+              // against 77% carrying it and most malformed after. Do not reintroduce the contrast.
               mana: {
-                type: 'string',
-                pattern: '^(one-time:[0-9]+|regen:[0-9]+:[0-9]+:[0-9]+)$',
-                examples: ['one-time:5', 'regen:4:4:1'],
-                description: 'Optional mana vital as "one-time:<amount>" or "regen:<current>:<max>:<regen>", e.g. "regen:4:4:1". Note this is a STRING here; resource.mana is an integer.'
+                type: ['integer', 'string'],
+                minimum: 0,
+                pattern: '^([0-9]+|one-time:[0-9]+|regen:[0-9]+:[0-9]+:[0-9]+)$',
+                examples: [10, 'regen:4:4:1'],
+                description: 'Optional mana vital. A plain amount grants it once, e.g. 10. Use "regen:<current>:<max>:<regen>" for a refilling pool, e.g. "regen:4:4:1".'
               },
               durability: {
-                type: 'string',
-                pattern: '^(one-time:[0-9]+|regen:[0-9]+:[0-9]+:[0-9]+)$',
-                examples: ['one-time:6', 'regen:6:6:0'],
-                description: 'Optional durability vital, same format as mana'
+                type: ['integer', 'string'],
+                minimum: 0,
+                pattern: '^([0-9]+|one-time:[0-9]+|regen:[0-9]+:[0-9]+:[0-9]+)$',
+                examples: [6, 'regen:6:6:0'],
+                description: 'Optional durability vital, same forms as mana'
               }
             },
             required: ['affinity', 'expression', 'proximityRadius']


### PR DESCRIPTION
Fixes a regression I introduced in #109, which turned out worse than the bug it fixed.

## What happened

Making `hazard.mana` machine-samplable added `examples` and a description contrasting it with `resource.mana` — *"this is a STRING here; resource.mana is an integer"*. Naming the other type beside the field changed model behaviour sharply:

| | hazards carrying `mana` | well-formed |
|---|---|---|
| before | 180 / 710 — 25% | **100%** |
| after the contrast | 41 / 53 — 77% | minority |

That class went from **5 failures in 700 attempts to 14 in 43** — two thirds of the sample. The re-run was stopped rather than spending a day measuring it.

## The fix, both halves

`mana=10` is the ordinary spelling and models write it overwhelmingly: the field is named `mana` on hazard and on resource, and on resource it *is* an integer. The prefixed grammar exists for the regen case, so requiring it everywhere taxed the common one.

- **CLI**: `parseHazardVitalSpec` accepts a bare non-negative amount as `one-time:<amount>`. Shorthand, not new behaviour — a test pins that both spellings produce **identical artifacts**.
- **Schema**: drops the contrast entirely, declares `type: ['integer','string']` since both are now valid, and leads its examples with the plain amount.

Malformed values are still rejected, and the message now quotes what was sent.

## The guard

A test forbids reintroducing the contrast, because the lesson is narrow and easy to undo: **a description is a prompt, and naming a wrong form teaches it.**

Perturbation: reinstating the clause fails the schema guard; reverting the shorthand fails three CLI cases including artifact-equivalence.

Gates: 434 files / 3354 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)