### PR TITLE
feat(benchmark): drop qwen3.5:27b from the primary profile

### DIFF
--- a/tests/tools/benchmark-authoring-invocation.test.js
+++ b/tests/tools/benchmark-authoring-invocation.test.js
@@ -30,7 +30,7 @@ function seedAuthoringRun(retentionDir, name, { manifest = true } = {}) {
   return dir;
 }
 
-// The full nightly matrix is 7 configurations x 100 scenarios x up to 3 passes (700-2100 attempts).
+// The full nightly matrix is 6 configurations x 100 scenarios x up to 3 passes (600-1800 attempts).
 // At the 58s/attempt rate the last recorded run observed, the ceiling is well past a day, so a 24h
 // cap would SIGTERM the run it exists to protect.
 test('the authoring timeout leaves room for a full matrix rather than capping it below one day', () => {

--- a/tests/tools/remote-ollama-benchmark.test.js
+++ b/tests/tools/remote-ollama-benchmark.test.js
@@ -47,7 +47,7 @@ test("hardware benchmark reserves secondary and maps every model to its declared
   assert.deepEqual([...byModel.get("qwen3.8:27b")].sort(), ["dual", "primary"]);
   // qwen3.5:27b mirrors qwen3.8:27b exactly — same size, same profiles, same settings — so the
   // only thing that differs between them is the generation. That is the whole point of its row.
-  assert.deepEqual([...byModel.get("qwen3.5:27b")].sort(), ["dual", "primary"]);
+  assert.deepEqual([...byModel.get("qwen3.5:27b")].sort(), ["dual"]);
   assert.deepEqual([...byModel.get("qwen3:14b")].sort(), ["primary"]);
   assert.deepEqual([...byModel.get("qwen3.5:9b")].sort(), ["primary"]);
   assert.equal(byModel.has("qwen2.5-coder:14b"), false, "dropped: it scored below the 7b");
@@ -55,23 +55,25 @@ test("hardware benchmark reserves secondary and maps every model to its declared
   assert.equal(byModel.has("qwen3-coder:30b"), false, "dropped: same digest as :30b-a3b-q4_K_M");
 });
 
-test("content-gen matrix plans seven primary-or-dual configurations in resource order", () => {
+test("content-gen matrix plans six primary-or-dual configurations in resource order", () => {
   const config = loadConfig(ROOT);
   const plan = buildContentGenMatrix(config, { scenarioCount: 100 });
 
   assert.equal(plan.contractVersion, "content-gen-matrix-v1");
-  assert.equal(plan.sha256, "21d135595cf539764f9df8f94fb6334f027f6a51f93eb467e9512631aaa728c2");
-  assert.equal(plan.configurationCount, 7);
+  // Pinned: the matrix hash is run identity, and a silent change makes two runs look
+  // comparable when they measured different things. It moved on 2026-08-24 when
+  // qwen3.5:27b left the primary profile.
+  assert.equal(plan.sha256, "58f201d394c7231b8e14f477aad6cce8d9419d3c3cce2561f7d6b07bf11796f1");
+  assert.equal(plan.configurationCount, 6);
   assert.deepEqual(plan.repeatPolicy, {
     minimumCompletePasses: 1,
     maximumPasses: 3,
     earlyStop: "mathematically_lossless",
   });
-  assert.deepEqual(plan.callBounds, { minimum: 700, maximum: 2100 });
+  assert.deepEqual(plan.callBounds, { minimum: 600, maximum: 1800 });
   assert.deepEqual(plan.configurations.map((entry) => entry.configurationId), [
     "cg-v1--qwen3.5_9b--primary--ctx32768--out4096",
     "cg-v1--qwen3_14b--primary--ctx32768--out4096",
-    "cg-v1--qwen3.5_27b--primary--ctx32768--out4096",
     "cg-v1--qwen3.8_27b--primary--ctx32768--out4096",
     "cg-v1--qwen3.5_27b--dual--ctx65536--out32768",
     "cg-v1--qwen3.8_27b--dual--ctx65536--out32768",
@@ -86,7 +88,7 @@ test("content-gen matrix plans seven primary-or-dual configurations in resource 
   }
   assert.deepEqual(profilesByModel.get("qwen3-coder:30b-a3b-q4_K_M"), ["dual"]);
   assert.deepEqual(profilesByModel.get("qwen3.8:27b"), ["primary", "dual"]);
-  assert.deepEqual(profilesByModel.get("qwen3.5:27b"), ["primary", "dual"]);
+  assert.deepEqual(profilesByModel.get("qwen3.5:27b"), ["dual"]);
   assert.deepEqual(profilesByModel.get("qwen3:14b"), ["primary"]);
   assert.deepEqual(profilesByModel.get("qwen3.5:9b"), ["primary"]);
 
@@ -123,10 +125,10 @@ test("content-gen dry run exposes the complete offline matrix and exact repeat b
     complex: 25,
     constrained: 25,
   });
-  assert.equal(output.matrix.configurationCount, 7);
+  assert.equal(output.matrix.configurationCount, 6);
   assert.equal(output.runsPerScenario, 3);
-  assert.deepEqual(output.matrix.callBounds, { minimum: 700, maximum: 2100 });
-  assert.equal(output.matrix.configurations.length, 7);
+  assert.deepEqual(output.matrix.callBounds, { minimum: 600, maximum: 1800 });
+  assert.equal(output.matrix.configurations.length, 6);
 });
 
 // A state directory whose profile is unmistakably running: the pid is this very test process, so

--- a/tools/remote-ollama-control/README.md
+++ b/tools/remote-ollama-control/README.md
@@ -243,8 +243,8 @@ first `benchmark-results` branch publication.
 
 ### Heartbeat and interim progress
 
-A full matrix is 7 configurations × 100 scenarios × up to 3 passes — 700 attempts at the floor,
-2,100 at the ceiling — and runs for **days**. Two things follow, and both are wired in:
+A full matrix is 6 configurations × 100 scenarios × up to 3 passes — 600 attempts at the floor,
+1,800 at the ceiling — and runs for **days**. Two things follow, and both are wired in:
 
 **The agent's failure mode is silence, not error.** Two incidents exited zero the whole time: 147
 consecutive nightlies dying on a deleted branch ref, and a nine-day stretch returning `dry_run` on

--- a/tools/remote-ollama-control/config/models.json
+++ b/tools/remote-ollama-control/config/models.json
@@ -6,8 +6,8 @@
     "Single-GPU benchmarks run only on the primary profile; the secondary card is reserved for dual.",
     "qwen3-coder:30b was removed 2026-08-22: `ollama list` gives it and qwen3-coder:30b-a3b-q4_K_M the same digest (06c1097efce0, 18 GB). They were one model under two tags, so the matrix measured it twice. The 2.5-point spread between those two runs is the noise floor at one pass \u2014 treat any narrower difference as nothing.",
     "qwen3.5:27b mirrors qwen3.8:27b's profiles and settings on purpose. Same parameter count, same context and output, one variable: generation. Cross-profile rows are NOT comparable \u2014 primary is 32k/4k and dual is 64k/32k, so GPU count, context and output all change together.",
-    "The canary moved from qwen2.5-coder:7b to qwen3.5:9b on 2026-08-22. qwen2.5-coder:14b was dropped first (33.4 against a 75 bar, BELOW the 7b's 37.7 \u2014 formatting noise, not capability), and the 7b followed once a current small model was available: at 3 months old it was drifting away from the generation everything else in the matrix belongs to, which makes a uniform drop harder to read as 'harness' rather than 'the old model finally fell over'."
-  ],
+    "The canary moved from qwen2.5-coder:7b to qwen3.5:9b on 2026-08-22. qwen2.5-coder:14b was dropped first (33.4 against a 75 bar, BELOW the 7b's 37.7 \u2014 formatting noise, not capability), and the 7b followed once a current small model was available: at 3 months old it was drifting away from the generation everything else in the matrix belongs to, which makes a uniform drop harder to read as 'harness' rather than 'the old model finally fell over'.",
+    "qwen3.5:27b dropped from primary on 2026-08-24. Across 100 attempts each, primary and dual were indistinguishable on quality (26 vs 24 misses, z=0.33) but primary's median LLM call was 175.8s against dual's 62.2s -- 2.8x slower, ~4.9h of a 14.3h run. At 0.74 verdict it was also the config furthest from the 0.96 gate, so the time bought no answer. qwen3.8:27b KEEPS primary deliberately: it projects to exactly 0.96 and is the cheapest configuration that could qualify, and minimumSuccessfulConfiguration sorts on GPU count -- drop every primary and the benchmark can never report that one GPU suffices."],
   "benchmark": {
     "defaultScenarios": [
       "vitest-generation",
@@ -52,10 +52,7 @@
       "use": "preferred Qwen 3.8 tool-calling model; hybrid CPU/GPU on primary and high GPU residency on dual"
     },
     "qwen3.5:27b": {
-      "profiles": [
-        "primary",
-        "dual"
-      ],
+      "profiles": ["dual"],
       "parameterBillions": 27,
       "sizeGb": 17.0,
       "family": "qwen3.5",

--- a/tools/remote-ollama-control/scripts/lib/benchmark-pipeline.js
+++ b/tools/remote-ollama-control/scripts/lib/benchmark-pipeline.js
@@ -228,8 +228,8 @@ function boundedLog(filePath, stdout, stderr, maxBytes = 1024 * 1024) {
   fs.writeFileSync(filePath, value.subarray(0, maxBytes));
 }
 
-// The full matrix is 7 configurations x 100 scenarios x up to 3 passes: 700 attempts at the floor
-// and 2100 at the ceiling. The last recorded run averaged 58s per attempt while including the cheap
+// The full matrix is 6 configurations x 100 scenarios x up to 3 passes: 600 attempts at the floor
+// and 1800 at the ceiling. The last recorded run averaged 58s per attempt while including the cheap
 // 9B canary, and the real matrix is weighted toward 27-30B, so the ceiling sits well past a day.
 // This was 24h until 2026-08-23, which meant the guard rail would SIGTERM the run it protects --
 // and because spawnSync kills the child, the failure arrives as an opaque "content generation

--- a/tools/remote-ollama-control/scripts/lib/benchmark-progress.js
+++ b/tools/remote-ollama-control/scripts/lib/benchmark-progress.js
@@ -3,7 +3,7 @@
 /**
  * Interim progress for a content-gen run.
  *
- * A full matrix is 7 configurations x 100 scenarios x up to 3 passes and takes days. Until this
+ * A full matrix is 6 configurations x 100 scenarios x up to 3 passes and takes days. Until this
  * module existed the only observable states were "started" and "finished" -- so a run that had
  * already become worthless (a configuration mathematically unable to qualify, a rig sliding toward
  * the collapse floors) stayed indistinguishable from a healthy one until it ended.


### PR DESCRIPTION
## Why

Across 100 attempts each, primary and dual were **indistinguishable on quality** but very different on cost:

| Model | Profile | Misses | Verdict | Median LLM ms |
|---|---|---|---|---|
| qwen3.5:27b | primary | 26 | 0.74 | **175,812** |
| qwen3.5:27b | dual | 24 | 0.76 | 62,179 |
| qwen3.8:27b | primary | 14 | 0.86 | 91,405 |
| qwen3.8:27b | dual | 10 | 0.90 | 35,112 |

Two-proportion z on the miss rates: **0.33** and **0.87** — both well inside ±1.96. Dual doesn't author better; it's ~2.7× faster.

`qwen3.5:27b/primary` was the slowest configuration in the matrix (~4.9h of a 14.3h run) *and* the furthest from the 0.96 gate. The time bought no answer.

## What stays, and why

**`qwen3.8:27b` keeps primary.** It projects to exactly 0.96 and is the cheapest configuration with any chance of qualifying. The benchmark reports `minimumSuccessfulConfiguration`, which sorts on GPU count first — drop every primary and it can never report that one GPU suffices, and would systematically overstate the hardware needed.

## Identity

The matrix is now **6 configurations, 600–1800 attempts**, and its hash moves:

    21d135595cf53976…  →  58f201d394c7231b…

That hash is run identity. **The pinned value in the runner's environment must be regenerated in the same change**, or change detection silently compares runs that measured different things. Scenario and execution-suite hashes are untouched.

Everything that stated the old shape moves with it — the pinned test, the README, and three comments quoting "7 configurations / 700-2100 attempts" — because a comment contradicting the matrix is how the next reader learns the wrong number.

Rationale is recorded in `models.json` notes beside the canary history, so the next person finds the reasoning rather than an unexplained asymmetry between two 27B models.

Gates: 434 files / 3347 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)