### PR TITLE
fix(benchmark): the agent lock must not outlive the process holding it

### DIFF
--- a/tests/tools/benchmark-agent.test.js
+++ b/tests/tools/benchmark-agent.test.js
@@ -276,3 +276,71 @@ test("execution-suite identity triggers execution modes, persists, publishes, an
 // - corrupt local poll state fails closed without rewriting it
 // - a deleted result branch is recreated only from an explicit empty publication state
 // - two queued source commits coalesce to the newest reachable source ref
+
+// The lock was a bare `wx` create with no liveness check, so it outlived its owner. Any SIGTERM,
+// crash, OOM, reboot mid-run, or kill at the 72h authoring ceiling left it held forever, and the
+// agent then reported `locked` and exited ZERO on every poll while the heartbeat kept beating
+// "idle" -- exits clean, looks healthy, does nothing. Observed live on 2026-08-24 after a run was
+// stopped by hand; the agent refused to start again until the file was removed by hand.
+const { acquireAgentLock: acquireLock } = require("../../tools/remote-ollama-control/scripts/lib/benchmark-state");
+const { mkdtempSync: mkTemp, writeFileSync: writeFile, existsSync: exists, rmSync: rmFile } = require("node:fs");
+const { tmpdir: tmp } = require("node:os");
+
+function lockDir() {
+  return mkTemp(join(tmp(), "ak-agent-lock-"));
+}
+function lockFile(dir) {
+  return join(dir, "agent.lock");
+}
+
+test("a lock stranded by a dead owner is reclaimed, and the reclaim is reported", () => {
+  const dir = lockDir();
+  // A pid that cannot be running: the previous holder, killed without releasing.
+  writeFile(lockFile(dir), "876367\n");
+
+  const lock = acquireLock(dir);
+  assert.equal(lock.acquired, true, "a lock whose owner is gone must not block the agent forever");
+  // Reported, not swallowed — silently taking it would hide the crash that stranded it.
+  assert.equal(lock.reclaimedFrom, 876367);
+  lock.release();
+  assert.equal(exists(lockFile(dir)), false, "release must remove the lock file");
+});
+
+test("a lock held by a live owner is refused, and says so", () => {
+  const dir = lockDir();
+  // This test process is unambiguously alive.
+  writeFile(lockFile(dir), `${process.pid}\n`);
+
+  const lock = acquireLock(dir);
+  assert.equal(lock.acquired, false, "mutual exclusion is the point — a live holder still wins");
+  assert.equal(lock.heldBy, process.pid);
+  assert.match(lock.reason, /live agent/);
+  // Refusing must not delete someone else's lock.
+  assert.equal(exists(lockFile(dir)), true);
+});
+
+test("a lock with an unreadable owner is refused rather than reclaimed", () => {
+  const dir = lockDir();
+  writeFile(lockFile(dir), "not-a-pid\n");
+
+  const lock = acquireLock(dir);
+  // Conservative on purpose: a corrupt lock cannot be shown to be free, and quietly seizing it
+  // would trade a rare stuck state for a real double-run.
+  assert.equal(lock.acquired, false);
+  assert.equal(lock.heldBy, null);
+  assert.match(lock.reason, /unreadable owner/);
+  assert.match(lock.reason, /agent\.lock/);
+});
+
+test("an uncontended lock reports no reclaim", () => {
+  const dir = lockDir();
+  const lock = acquireLock(dir);
+  assert.equal(lock.acquired, true);
+  assert.equal(lock.reclaimedFrom, null, "a clean acquisition must not look like a recovered crash");
+
+  // A second acquisition while the first is held is refused by the live-owner path.
+  const second = acquireLock(dir);
+  assert.equal(second.acquired, false);
+  lock.release();
+  rmFile(lockFile(dir), { force: true });
+});

--- a/tools/remote-ollama-control/scripts/benchmark-agent.js
+++ b/tools/remote-ollama-control/scripts/benchmark-agent.js
@@ -130,7 +130,18 @@ async function runBenchmarkAgent(options) {
   }
 
   const lock = acquireAgentLock(stateDir);
-  if (!lock.acquired) return { status: 'locked' };
+  if (!lock.acquired) {
+    // Why it is locked is the whole diagnostic. "locked" alone read identically whether another
+    // agent was working or a dead one had stranded the file, and the second state is permanent.
+    return { status: 'locked', heldBy: lock.heldBy ?? null, reason: lock.reason ?? 'unknown' };
+  }
+  if (lock.reclaimedFrom !== null && lock.reclaimedFrom !== undefined) {
+    // A stranded lock means the previous run died without releasing it. Say so: it is evidence of
+    // a crash or a kill that nothing else records.
+    process.stderr.write(
+      `reclaimed a stale agent lock from pid ${lock.reclaimedFrom}; the previous run did not exit cleanly\n`,
+    );
+  }
 
   try {
     const state = loadAgentState(stateDir);

--- a/tools/remote-ollama-control/scripts/lib/benchmark-state.js
+++ b/tools/remote-ollama-control/scripts/lib/benchmark-state.js
@@ -33,26 +33,87 @@ function saveAgentState(stateDir, state) {
   fs.renameSync(temporary, statePath);
 }
 
+// EPERM means the process exists and belongs to someone else -- alive. Only ESRCH proves it is
+// gone. Conflating them would reclaim a lock a live agent still holds.
+function ownerAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code !== 'ESRCH';
+  }
+}
+
+function readLockOwner(lockPath) {
+  try {
+    const raw = fs.readFileSync(lockPath, 'utf8').trim();
+    return /^[0-9]+$/.test(raw) ? Number(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The lock was a bare `wx` create with no liveness check, so it outlived its owner. Any SIGTERM,
+ * crash, OOM, reboot mid-run, or kill at the 72h authoring ceiling left it held forever, and the
+ * agent then reported `locked` and exited ZERO on every poll while the heartbeat kept beating
+ * "idle". That is the failure shape this whole mechanism exists to catch -- exits clean, looks
+ * healthy, does nothing -- and it is what the 147 consecutive failed nightlies and the nine-day
+ * dry_run stall both were. Observed live on 2026-08-24 after a run was stopped by hand.
+ *
+ * So a lock whose owner is provably dead is reclaimed, and the reclaim is REPORTED rather than
+ * swallowed: silently taking the lock would hide the crash that stranded it.
+ *
+ * A lock whose owner cannot be parsed is NOT reclaimed. Mutual exclusion is the point, and a
+ * corrupt lock cannot be shown to be free -- the refusal names the file so an operator can act,
+ * which is a far rarer situation than the kill this fixes.
+ */
 function acquireAgentLock(stateDir, owner = `${process.pid}`) {
   ensureDir(stateDir);
   const lockPath = path.join(stateDir, 'agent.lock');
-  let descriptor;
-  try {
-    descriptor = fs.openSync(lockPath, 'wx');
-    fs.writeFileSync(descriptor, `${owner}\n`);
-  } catch (error) {
-    if (error.code === 'EEXIST') return { acquired: false, release() {} };
-    throw error;
-  }
-  return {
-    acquired: true,
-    release() {
-      if (descriptor === undefined) return;
-      fs.closeSync(descriptor);
-      descriptor = undefined;
-      fs.unlinkSync(lockPath);
+  let reclaimedFrom = null;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let descriptor;
+    try {
+      descriptor = fs.openSync(lockPath, 'wx');
+      fs.writeFileSync(descriptor, `${owner}\n`);
+      return {
+        acquired: true,
+        reclaimedFrom,
+        release() {
+          if (descriptor === undefined) return;
+          fs.closeSync(descriptor);
+          descriptor = undefined;
+          fs.rmSync(lockPath, { force: true });
+        }
+      };
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
     }
-  };
+
+    // Lost the create. On the second pass another agent won the race legitimately, so stop.
+    if (attempt === 1) {
+      return { acquired: false, heldBy: readLockOwner(lockPath), reason: 'raced', release() {} };
+    }
+
+    const holder = readLockOwner(lockPath);
+    if (holder === null) {
+      return {
+        acquired: false,
+        heldBy: null,
+        reason: `unreadable owner in ${lockPath}; remove it by hand once no agent is running`,
+        release() {}
+      };
+    }
+    if (ownerAlive(holder)) {
+      return { acquired: false, heldBy: holder, reason: 'held by a live agent', release() {} };
+    }
+    reclaimedFrom = holder;
+    fs.rmSync(lockPath, { force: true });
+  }
+
+  return { acquired: false, heldBy: readLockOwner(lockPath), reason: 'raced', release() {} };
 }
 
 module.exports = { acquireAgentLock, loadAgentState, saveAgentState };


### PR DESCRIPTION
## The defect

The lock was a bare `wx` create with **no liveness check**:

```js
descriptor = fs.openSync(lockPath, 'wx');   // create-if-absent, and that is the whole check
```

So it survived its owner. Any SIGTERM, crash, OOM, reboot mid-run, or kill at the 72h authoring ceiling stranded it — and the agent then reported `locked` and **exited 0** on every subsequent poll while the heartbeat kept beating `idle`.

That is the exact failure shape this mechanism exists to catch: **exits clean, looks healthy, does nothing, indefinitely.** Neither alarm channel fires, because the agent *is* reporting — it simply never runs again. Same shape as the 147 consecutive failed nightlies and the nine-day `dry_run` stall.

**Observed live on 2026-08-24:** a run stopped by hand left pid 876367 in the file, and the next start exited instantly with `{"status":"locked"}`. It would have done so forever.

## The fix

A lock whose owner is provably dead is reclaimed, and the reclaim is **reported on stderr** rather than swallowed — a stranded lock is evidence of a crash that nothing else records.

Two deliberate refusals to be clever:

- **`ESRCH` proves the owner is gone; `EPERM` means it exists and belongs to another user — which is *alive*.** Conflating them would reclaim a lock a live agent still holds.
- **A lock whose owner cannot be parsed is NOT reclaimed.** Mutual exclusion is the point and a corrupt lock cannot be shown to be free, so the refusal names the file for an operator. Far rarer than the kill this fixes, and trading it for a real double-run would be a bad bargain.

`locked` also carries `heldBy` and a `reason` now. On its own it read identically whether another agent was working or a dead one had stranded the file — and only the second state is permanent.

| Lock state | Result |
|---|---|
| owner dead | acquired, `reclaimedFrom` reported |
| owner alive | refused, `held by a live agent` |
| owner unparseable | refused, names the file |
| uncontended | acquired, no reclaim reported |

Perturbation: restoring the old acquire fails all four cases.

Gates: 434 files / 3358 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)