### PR TITLE
feat(benchmark): tell the authoring model what things cost

### DIFF
--- a/tests/tools/price-brief.test.js
+++ b/tests/tools/price-brief.test.js
@@ -1,0 +1,71 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+
+const {
+  BASE_COSTS_PATH, buildPriceBrief, loadBaseCosts, priceBriefHash,
+} = require("../../tools/remote-ollama-control/scripts/lib/price-brief");
+
+// The brief tells the authoring model what things cost. A stale copy would teach it wrong prices
+// with total confidence, so nothing here may be restated by hand: the numbers are read back out of
+// the Allocator's own data, and the two formula rules out of the source that implements them.
+// This is the same discipline the resource-spec alignment test uses on the CLI allow-list.
+
+test("every number in the brief comes from base-costs.json", () => {
+  const costs = loadBaseCosts();
+  const brief = buildPriceBrief(costs);
+
+  for (const group of ["actor", "motivation", "vitals", "regen", "affinity", "hazard", "resource", "tile"]) {
+    for (const [id, cost] of Object.entries(costs[group] || {})) {
+      assert.match(
+        brief, new RegExp(`${id}=${cost}\\b`),
+        `the brief omits or misprices ${id}; the model would author against a number the Allocator does not charge`,
+      );
+    }
+  }
+});
+
+test("the brief states the quadratic rule, and names it for the ids the price list actually treats that way", () => {
+  // QUADRATIC_IDS is logic, not data — it lives in default-price-list.js. Read it from there so a
+  // change to the formula set fails here instead of silently making the brief wrong.
+  const source = readFileSync(
+    BASE_COSTS_PATH.replace("base-costs.json", "default-price-list.js"), "utf8",
+  );
+  const block = source.slice(source.indexOf("QUADRATIC_IDS = new Set(["));
+  const ids = [...block.slice(0, block.indexOf("]);")).matchAll(/"([a-z_]+)"/g)].map((m) => m[1]);
+  assert.ok(ids.length >= 4, "failed to read QUADRATIC_IDS out of the price list source");
+
+  const brief = buildPriceBrief();
+  assert.match(brief, /QUADRATIC/);
+  // Every quadratic id is a regen tick or an affinity stack; the brief must describe both families,
+  // or a model reading it would price the expensive ones linearly.
+  const families = new Set(ids.map((id) => (id.includes("regen") ? "regen" : "stack")));
+  for (const family of families) {
+    assert.match(brief, new RegExp(family, "i"), `the brief never mentions ${family} in the quadratic rule`);
+  }
+  assert.match(brief, /n\*n tokens, not n/);
+});
+
+test("the brief states the resource premium at the rate the price list applies", () => {
+  const costs = loadBaseCosts();
+  const brief = buildPriceBrief(costs);
+  assert.match(brief, new RegExp(`${costs.freeFloatingPremium}x`));
+  // Hazards are deliberately not premiumed; saying so stops the model over-pricing them.
+  assert.match(brief, /Hazards carry no such premium/);
+});
+
+test("a price change moves the brief and its hash", () => {
+  const costs = loadBaseCosts();
+  const before = buildPriceBrief(costs);
+  const bumped = JSON.parse(JSON.stringify(costs));
+  bumped.actor.actor_spawn = costs.actor.actor_spawn + 7;
+
+  const after = buildPriceBrief(bumped);
+  assert.notEqual(before, after, "editing a base cost must change what the model is told");
+  assert.notEqual(priceBriefHash(before), priceBriefHash(after));
+  assert.match(after, new RegExp(`actor_spawn=${costs.actor.actor_spawn + 7}\\b`));
+});
+
+test("the brief stays small enough to sit in every prompt", () => {
+  // It rides on all 100 scenarios per configuration; a brief that bloats is a context tax.
+  assert.ok(buildPriceBrief().length < 4000, "the price brief has grown past its budget");
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-runner.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-runner.js
@@ -5,6 +5,7 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 const { requestJson } = require('./ollama');
 const { AK_CREATE_TOOL } = require('./ak-tool-schema');
+const { buildPriceBrief } = require('./price-brief');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
 const AK_CLI = path.join(REPO_ROOT, 'packages', 'adapters-cli', 'src', 'cli', 'ak.mjs');
@@ -142,13 +143,18 @@ async function runScenario(endpoint, model, scenario, runOutDir, runId, timeoutM
   const budgetInstruction = constrained
     ? `Set budgetTokens to ${scenario.budget}. `
     : 'Omit budgetTokens — the budget is unconstrained. ';
+  // The model used to be handed a budget number and no prices, so authoring within it was a guess.
+  // Budget and spatial failures were 55% of what failed once the schema defects were fixed, and the
+  // constrained tier failed at 56% against simple's 18%. The brief is generated from the
+  // Allocator's own base-costs.json, never restated, so a price change reaches the model.
   const systemPrompt =
     'You are an agent-kernel dungeon designer. When given a dungeon creation request, ' +
     'call the ak_create tool with appropriate parameters. Use the exact prompt text as ' +
     `the text parameter. ${budgetInstruction}Always set emitIntermediates ` +
     'to true. Rooms are generic containers — affinity pressure belongs in hazards. ' +
     'Hazards are placed by proximityRadius, never by coordinates. ' +
-    'For delver goals use only: max_mana, mana_regen, or maximize_spend. Wardens have no goals.';
+    'For delver goals use only: max_mana, mana_regen, or maximize_spend. Wardens have no goals.\n\n' +
+    buildPriceBrief();
 
   const chatBody = {
     model,

--- a/tools/remote-ollama-control/scripts/lib/price-brief.js
+++ b/tools/remote-ollama-control/scripts/lib/price-brief.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * What things cost, rendered for the authoring model.
+ *
+ * The benchmark told the model `Set budgetTokens to 277` and nothing else. It was asked to author
+ * within a budget it had no way to compute against, and then measured on whether it guessed well:
+ * budget and spatial failures were 55% of everything that failed once the schema defects were
+ * fixed, and the constrained tier failed at 56% against 18% for simple.
+ *
+ * The numbers come from base-costs.json, the Allocator's own data, and are NEVER restated here --
+ * the price list is emphatic that costs must not get a second home, and a stale copy would teach
+ * the model wrong prices with total confidence. The two formula rules live in
+ * default-price-list.js as logic rather than data, so they are stated in prose and pinned by a
+ * test that reads them back out of that source.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const BASE_COSTS_PATH = path.resolve(
+  __dirname, '../../../../packages/runtime/src/personas/allocator/base-costs.json',
+);
+
+function loadBaseCosts(costsPath = BASE_COSTS_PATH) {
+  return JSON.parse(fs.readFileSync(costsPath, 'utf8'));
+}
+
+// Groups worth showing an authoring model, in the order it makes decisions: what an actor costs,
+// what it carries, then what fills the level. Internal bookkeeping groups are left out -- a longer
+// brief is not a better one, and every extra line is a chance to teach something irrelevant.
+const SECTIONS = [
+  ['actor', 'Actors'],
+  ['motivation', 'Motivations (per actor)'],
+  ['vitals', 'Vital points (per point of max)'],
+  ['regen', 'Vital regen (per tick of rate)'],
+  ['affinity', 'Affinity'],
+  ['hazard', 'Hazards'],
+  ['resource', 'Resources'],
+  ['tile', 'Tiles'],
+];
+
+function buildPriceBrief(baseCosts = loadBaseCosts()) {
+  const lines = ['Token prices (authoring budget):'];
+  for (const [key, label] of SECTIONS) {
+    const group = baseCosts[key];
+    if (!group || typeof group !== 'object') continue;
+    const entries = Object.entries(group).map(([id, cost]) => `${id}=${cost}`);
+    lines.push(`- ${label}: ${entries.join(', ')}`);
+  }
+  lines.push(
+    '- Regen rates and affinity stacks are QUADRATIC: n units cost n*n tokens, not n. '
+    + 'Everything else is linear: unit cost times quantity.',
+  );
+  const premium = baseCosts.freeFloatingPremium;
+  if (premium) {
+    lines.push(
+      `- Resource ids cost ${premium}x the equivalent base, rounded, because a resource is free-floating `
+      + 'and grants whichever actor picks it up. Hazards carry no such premium.',
+    );
+  }
+  lines.push('- Floor tiles are charged per tile, so a large room costs more than a small one.');
+  return lines.join('\n');
+}
+
+// Recorded with the run so two results are never silently compared across a change to what the
+// model was told. The prompt is not covered by any of the pinned identity hashes.
+function priceBriefHash(brief = buildPriceBrief()) {
+  return crypto.createHash('sha256').update(brief).digest('hex');
+}
+
+module.exports = { BASE_COSTS_PATH, buildPriceBrief, loadBaseCosts, priceBriefHash };


### PR DESCRIPTION
The prompt said `Set budgetTokens to 277` and stopped there — one mention of cost in the entire runner, and it was the `budgetTokens` field description. The model was asked to author within a budget it had **no way to compute against**, then measured on whether it guessed well.

That is the largest remaining failure class. With the schema defects fixed, budget and spatial failures are **55%** of everything that fails, and the `constrained` tier — which exists to test budget-aware authoring — fails at **56%** against `simple`'s 18%.

## Costing was verified clean first

A budget failure can as easily be a pricing regression, so before writing anything:

| Check | Result |
|---|---|
| `base-costs.json` last changed | 2026-08-12 |
| Constrained catalog recalibrated | 2026-08-22 — **after** pricing |
| `runtime` / `core-ts` changed between the two runs | **No** |
| Constrained scenarios unsatisfiable at budget | **0 of 25** — each passed by ≥1 config |

## The brief

**Generated from `base-costs.json`, never restated.** The price list is emphatic that costs must not get a second home, and a stale copy would teach the model wrong prices with total confidence.

The two formula rules are *logic*, not data, and live in `default-price-list.js` — so they're stated in prose and pinned by a test that reads `QUADRATIC_IDS` and the free-floating premium back out of that source. Same discipline the resource-spec alignment test uses on the CLI allow-list.

Both rules are included because omitting them would be **worse than silence**: regen rates and affinity stacks are quadratic, so a model pricing them linearly underestimates exactly the fields that blow a tight budget.

1,351 bytes, on every scenario.

Perturbation: editing a base cost moves the brief; hardcoding a price in the brief fails two tests.

## Known gap, stated rather than hidden

The authoring prompt is covered by **none** of the pinned identity hashes. This change makes results non-comparable with every prior run while `scenarioSetHash`, `matrixHash` and `executionSuiteHash` all stay put. `priceBriefHash()` exists for that purpose but is not yet recorded in the run record — recording it is the obvious follow-up.

Gates: 435 files / 3363 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)