### PR TITLE
feat(benchmark): record what the model was told, as identity

### DIFF
--- a/tests/tools/price-brief.test.js
+++ b/tests/tools/price-brief.test.js
@@ -69,3 +69,56 @@ test("the brief stays small enough to sit in every prompt", () => {
   // It rides on all 100 scenarios per configuration; a brief that bloats is a context tax.
   assert.ok(buildPriceBrief().length < 4000, "the price brief has grown past its budget");
 });
+
+// ---------------------------------------------------------------------------
+// What the model was TOLD, as identity.
+//
+// scenarioSetHash covers the questions, matrixHash the configurations, executionSuiteHash the
+// evaluation. Nothing covered the instructions — so adding the price brief on 2026-08-24 changed
+// what was being measured while all three pinned hashes sat still, and two runs would have looked
+// comparable. That is the silent-drift failure this repository cares most about.
+
+const { authoringPolicy } = require("../../tools/remote-ollama-control/scripts/lib/ak-runner");
+const { assertResumable } = require("../../tools/remote-ollama-control/scripts/lib/content-gen-checkpoint");
+
+// assertResumable checks catalog, matrix, policy, scenario ids and configuration ids in that
+// order, so a fixture must satisfy all of them for the policy case to be the one under test.
+const IDENT = {
+  scenarioSet: { sha256: "s".repeat(64) },
+  matrix: { sha256: "m".repeat(64), configurationIds: ["cfg-a"] },
+  scenarioIds: [1, 2],
+};
+
+test("the authoring policy hashes the instructions and the prices together", () => {
+  const policy = authoringPolicy();
+  assert.match(policy.sha256, /^[0-9a-f]{64}$/);
+  assert.match(policy.priceBriefSha256, /^[0-9a-f]{64}$/);
+  // Two hashes, because "the prices moved" and "the wording moved" call for different responses.
+  assert.notEqual(policy.sha256, policy.priceBriefSha256);
+});
+
+test("a run refuses to resume once the prices it was told have changed", () => {
+  const prior = { ...IDENT, authoringPolicy: { sha256: "a".repeat(64), priceBriefSha256: "b".repeat(64) } };
+  const current = { ...IDENT, authoringPolicy: { sha256: "c".repeat(64), priceBriefSha256: "d".repeat(64) } };
+  assert.throws(() => assertResumable(prior, current), /price brief changed/);
+});
+
+test("a wording change is named as such, not as a price change", () => {
+  const brief = "e".repeat(64);
+  const prior = { ...IDENT, authoringPolicy: { sha256: "a".repeat(64), priceBriefSha256: brief } };
+  const current = { ...IDENT, authoringPolicy: { sha256: "c".repeat(64), priceBriefSha256: brief } };
+  // Same prices, different policy hash — the instructions moved.
+  assert.throws(() => assertResumable(prior, current), /authoring instructions changed/);
+});
+
+test("an unchanged policy resumes", () => {
+  const policy = { sha256: "a".repeat(64), priceBriefSha256: "b".repeat(64) };
+  assert.doesNotThrow(() => assertResumable({ ...IDENT, authoringPolicy: policy }, { ...IDENT, authoringPolicy: policy }));
+});
+
+test("a run predating the record refuses rather than silently merging", () => {
+  // No way to tell what those attempts were told, so they cannot be pooled with new ones.
+  const prior = { ...IDENT };
+  const current = { ...IDENT, authoringPolicy: { sha256: "c".repeat(64), priceBriefSha256: "d".repeat(64) } };
+  assert.throws(() => assertResumable(prior, current), /predates the authoring-policy record/);
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-runner.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-runner.js
@@ -4,8 +4,9 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { requestJson } = require('./ollama');
+const crypto = require('crypto');
 const { AK_CREATE_TOOL } = require('./ak-tool-schema');
-const { buildPriceBrief } = require('./price-brief');
+const { buildPriceBrief, priceBriefHash } = require('./price-brief');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
 const AK_CLI = path.join(REPO_ROOT, 'packages', 'adapters-cli', 'src', 'cli', 'ak.mjs');
@@ -136,6 +137,43 @@ function classifyExecutionOutcome(runResult) {
   return 'execution_failed';
 }
 
+// The constant half of the system prompt, split only so it can be hashed. The assembled text is
+// byte-identical to what it was before the split: changing wording here would confound the very
+// comparison the hash exists to enable.
+const AUTHORING_INSTRUCTIONS_HEAD =
+  'You are an agent-kernel dungeon designer. When given a dungeon creation request, '
+  + 'call the ak_create tool with appropriate parameters. Use the exact prompt text as '
+  + 'the text parameter. ';
+const AUTHORING_INSTRUCTIONS_TAIL =
+  'Always set emitIntermediates '
+  + 'to true. Rooms are generic containers — affinity pressure belongs in hazards. '
+  + 'Hazards are placed by proximityRadius, never by coordinates. '
+  + 'For delver goals use only: max_mana, mana_regen, or maximize_spend. Wardens have no goals.';
+
+/**
+ * What the model was told, as identity.
+ *
+ * scenarioSetHash covers the questions, matrixHash the configurations, executionSuiteHash the
+ * evaluation. Nothing covered the INSTRUCTIONS -- so changing the prompt, or the prices inside it,
+ * moved what was being measured while all three pinned hashes sat still and two runs looked
+ * comparable. Adding the price brief on 2026-08-24 is exactly such a change.
+ *
+ * The scenario-specific half is deliberately excluded: the budget number and the prompt text are
+ * scenario data, already covered by scenarioSetHash. Only the harness's own contribution is here.
+ */
+function authoringPolicy() {
+  const brief = buildPriceBrief();
+  const canonical = JSON.stringify({
+    head: AUTHORING_INSTRUCTIONS_HEAD,
+    tail: AUTHORING_INSTRUCTIONS_TAIL,
+    priceBrief: brief
+  });
+  return {
+    sha256: crypto.createHash('sha256').update(canonical).digest('hex'),
+    priceBriefSha256: priceBriefHash(brief)
+  };
+}
+
 async function runScenario(endpoint, model, scenario, runOutDir, runId, timeoutMs = 600000, settings = {}) {
   const { buildArgv, authoringSpec } = await getMcpBuildTools();
 
@@ -147,14 +185,7 @@ async function runScenario(endpoint, model, scenario, runOutDir, runId, timeoutM
   // Budget and spatial failures were 55% of what failed once the schema defects were fixed, and the
   // constrained tier failed at 56% against simple's 18%. The brief is generated from the
   // Allocator's own base-costs.json, never restated, so a price change reaches the model.
-  const systemPrompt =
-    'You are an agent-kernel dungeon designer. When given a dungeon creation request, ' +
-    'call the ak_create tool with appropriate parameters. Use the exact prompt text as ' +
-    `the text parameter. ${budgetInstruction}Always set emitIntermediates ` +
-    'to true. Rooms are generic containers — affinity pressure belongs in hazards. ' +
-    'Hazards are placed by proximityRadius, never by coordinates. ' +
-    'For delver goals use only: max_mana, mana_regen, or maximize_spend. Wardens have no goals.\n\n' +
-    buildPriceBrief();
+  const systemPrompt = `${AUTHORING_INSTRUCTIONS_HEAD}${budgetInstruction}${AUTHORING_INSTRUCTIONS_TAIL}\n\n${buildPriceBrief()}`;
 
   const chatBody = {
     model,
@@ -255,4 +286,5 @@ async function runScenario(endpoint, model, scenario, runOutDir, runId, timeoutM
   };
 }
 
-module.exports = { classifyExecutionOutcome, normalizeToolArgs, runScenario, AK_CLI, REPO_ROOT };
+module.exports = {
+  authoringPolicy, classifyExecutionOutcome, normalizeToolArgs, runScenario, AK_CLI, REPO_ROOT };

--- a/tools/remote-ollama-control/scripts/lib/content-gen-checkpoint.js
+++ b/tools/remote-ollama-control/scripts/lib/content-gen-checkpoint.js
@@ -22,7 +22,7 @@ function manifestPath(resultDir) {
   return path.join(resultDir, MANIFEST_NAME);
 }
 
-function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, startedAt, diagnostic }) {
+function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, startedAt, diagnostic, authoringPolicy }) {
   fs.mkdirSync(resultDir, { recursive: true });
   const manifest = {
     schemaVersion: MANIFEST_SCHEMA,
@@ -33,6 +33,11 @@ function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, 
     diagnostic: diagnostic === true,
     scenarioSet,
     matrix,
+    // What the model was TOLD, which no pinned identity hash covered. scenarioSetHash covers the
+    // questions, matrixHash the configurations, executionSuiteHash the evaluation -- and the
+    // instructions sat outside all three, so adding the price brief on 2026-08-24 changed what was
+    // measured while every pinned hash held still.
+    authoringPolicy: authoringPolicy || null,
     scenarioIds: [...scenarioIds].sort((left, right) => left - right)
   };
   fs.writeFileSync(manifestPath(resultDir), `${JSON.stringify(manifest, null, 2)}\n`);
@@ -70,6 +75,29 @@ function assertResumable(manifest, current) {
       + `(${manifest.matrix.sha256.slice(0, 12)}… → ${current.matrix.sha256.slice(0, 12)}…).`
     );
   }
+  // A run whose attempts were told different things is not one run. This refuses for the same
+  // reason as the two above, and names the field for the same reason.
+  const priorPolicy = manifest.authoringPolicy;
+  const currentPolicy = current.authoringPolicy;
+  if (currentPolicy) {
+    if (!priorPolicy) {
+      throw new Error(
+        'cannot resume: this run predates the authoring-policy record, so there is no way to tell '
+        + 'whether its attempts were given the same instructions and prices as new ones would be. '
+        + 'Start a fresh run.'
+      );
+    }
+    if (priorPolicy.sha256 !== currentPolicy.sha256) {
+      const what = priorPolicy.priceBriefSha256 !== currentPolicy.priceBriefSha256
+        ? 'the price brief changed' : 'the authoring instructions changed';
+      throw new Error(
+        `cannot resume: ${what} since this run started `
+        + `(${priorPolicy.sha256.slice(0, 12)}… → ${currentPolicy.sha256.slice(0, 12)}…). `
+        + 'Attempts told different things cannot share one result.'
+      );
+    }
+  }
+
   const known = new Set(manifest.scenarioIds);
   const added = current.scenarioIds.filter((index) => !known.has(index));
   if (added.length > 0) {

--- a/tools/remote-ollama-control/scripts/remote-ollama-mac.js
+++ b/tools/remote-ollama-control/scripts/remote-ollama-mac.js
@@ -1245,7 +1245,7 @@ function runRemoteExec(options) {
 
 async function runContentGen(options) {
   const { loadScenarioCatalog } = require('./lib/ak-scenarios');
-  const { classifyExecutionOutcome, runScenario } = require('./lib/ak-runner');
+  const { classifyExecutionOutcome, runScenario , authoringPolicy } = require('./lib/ak-runner');
   const { aggregateContentGenResults, scoreRun, writeContentResult, writeContentSummary } = require('./lib/ak-compare');
   const { executeContentGenMatrix } = require('./lib/ak-matrix');
   const { CollapseError, resolveBreaker } = require('./lib/collapse-breaker');
@@ -1381,6 +1381,7 @@ async function runContentGen(options) {
     );
   } else {
     runManifest = writeRunManifest(resultDir, {
+      authoringPolicy: authoringPolicy(),
       route: options.route, diagnostic: !options.earlyStop, ...runIdentity
     });
   }


### PR DESCRIPTION
`scenarioSetHash` covers the questions, `matrixHash` the configurations, `executionSuiteHash` the evaluation. **Nothing covered the instructions.**

So adding the price brief in #115 changed what was being measured while all three pinned hashes sat still, and two runs either side of it would have looked comparable. That is the silent-drift failure this repository cares most about, and the price brief walked straight into it.

## What lands

`run-manifest.json` now records an `authoringPolicy`: a hash over the constant half of the system prompt together with the price brief, plus the brief's own hash separately. **Two hashes, because "the prices moved" and "the wording moved" call for different responses** — and the resume error names which one it was.

`assertResumable` refuses a changed policy for the same reason it already refuses a changed catalog or matrix: attempts told different things are not one run. A manifest predating the record also refuses — there's no way to tell what those attempts were given, and pooling them would manufacture exactly the false comparison this prevents.

The scenario-specific half is deliberately excluded: the budget number and prompt text are scenario data, already covered by `scenarioSetHash`. Only the harness's own contribution belongs here.

## The prompt text does not change

The constant half was split into two named strings purely so it could be hashed. The assembled string is **byte-identical in both budget modes** — verified against the previous expression rather than assumed, because altering wording here would confound the very comparison the hash exists to enable.

Perturbation: removing the policy check fails three cases.

Gates: 435 files / 3368 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)