### PR TITLE
fix(benchmark): serve the context the matrix declares

### DIFF
--- a/tests/tools/served-context-matches-the-matrix.test.js
+++ b/tests/tools/served-context-matches-the-matrix.test.js
@@ -1,0 +1,69 @@
+const assert = require("node:assert/strict");
+const { resolve } = require("node:path");
+
+const {
+  getProfile, loadConfig, serviceEnvironment,
+} = require("../../tools/remote-ollama-control/scripts/lib/config");
+const { buildContentGenMatrix } = require("../../tools/remote-ollama-control/scripts/lib/benchmark");
+
+const ROOT = resolve(__dirname, "../..", "tools/remote-ollama-control");
+
+// A configurationId says ctx65536 and matrixHash encodes it. If the server is not actually serving
+// that window, the identity asserts something that did not happen — and the result looks like a
+// model-quality finding rather than a plumbing one.
+//
+// That is not hypothetical. The benchmark asked per request with `options: { num_ctx }` while
+// posting to /v1/chat/completions, where Ollama's OpenAI-compatible shim discards `options`
+// silently. Every load fell back to the VRAM-based default of 32768. On `primary` that default
+// equals the configured value, so the bug was invisible on half the matrix; the three `dual`
+// configurations ran at half their declared context for months.
+
+test("every profile serves the context its own config declares", () => {
+  const config = loadConfig(ROOT);
+  for (const name of Object.keys(config.profiles)) {
+    const profile = getProfile(config, name);
+    const env = serviceEnvironment(profile);
+    assert.equal(
+      env.OLLAMA_CONTEXT_LENGTH, String(profile.defaultContext),
+      `${name} declares defaultContext ${profile.defaultContext} but does not serve it; `
+      + "Ollama would fall back to its VRAM-based default and nothing would say so",
+    );
+  }
+});
+
+// The matrix DERIVES contextTokens from profile.defaultContext
+// (benchmark.js: `options.contextTokens ?? profile.defaultContext`), so asserting the two agree
+// compares a value to its own source and can never fail. Two earlier drafts of this file did
+// exactly that and passed while the profile was deliberately broken.
+//
+// What is worth asserting crosses two independently built things: the `ctx<N>` label baked into
+// the configurationId — the string that appears in every published result — and the environment
+// the server is actually launched with. Change either construction and this fires.
+test("the ctx label in every configurationId is the context the server is launched with", () => {
+  const config = loadConfig(ROOT);
+  const matrix = buildContentGenMatrix(config, { scenarioCount: 100 });
+
+  for (const entry of matrix.configurations) {
+    const labelled = /--ctx(\d+)--/.exec(entry.configurationId);
+    assert.ok(labelled, `${entry.configurationId} carries no ctx label to check`);
+    const served = serviceEnvironment(getProfile(config, entry.profile.id)).OLLAMA_CONTEXT_LENGTH;
+    assert.equal(
+      labelled[1], served,
+      `${entry.configurationId} is published as ctx${labelled[1]}, but profile `
+      + `${entry.profile.id} is served with ${served}. Every result from it would name a window `
+      + "the run never had.",
+    );
+  }
+});
+
+// The per-request form is inert on this endpoint and must not come back looking functional.
+test("the runner does not set num_ctx per request, where it would be silently dropped", () => {
+  const source = require("node:fs").readFileSync(
+    resolve(ROOT, "scripts/lib/ak-runner.js"), "utf8",
+  );
+  assert.match(source, /v1\/chat\/completions/, "this test is anchored to the OpenAI-compatible endpoint");
+  assert.doesNotMatch(
+    source, /chatBody\.options\s*=/,
+    "`options` is an Ollama-native field; the OpenAI-compatible shim discards it without a word",
+  );
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-runner.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-runner.js
@@ -202,7 +202,10 @@ async function runScenario(endpoint, model, scenario, runOutDir, runId, timeoutM
     // Constrained scenarios are minimal specs; unconstrained ones can get large.
     max_tokens: settings.outputTokens || (constrained ? 4096 : 8192)
   };
-  if (settings.contextTokens) chatBody.options = { num_ctx: settings.contextTokens };
+  // No `options: { num_ctx }` here. This posts to /v1/chat/completions, and Ollama's
+  // OpenAI-compatible shim discards `options` without a word -- it looked like it was working for
+  // months. The context is set on the serving process instead, via OLLAMA_CONTEXT_LENGTH in
+  // serviceEnvironment(). Re-adding it here would not restore the behaviour, only the illusion.
 
   const llmStarted = Date.now();
   let chatResponse;

--- a/tools/remote-ollama-control/scripts/lib/config.js
+++ b/tools/remote-ollama-control/scripts/lib/config.js
@@ -289,6 +289,21 @@ function serviceEnvironment(profile) {
     OLLAMA_HOST: `${profile.bindHost}:${profile.port}`,
     OLLAMA_PROFILE: profile.name
   };
+  // The context the profile is meant to serve, set where the server can actually see it.
+  //
+  // The benchmark used to ask per request -- `options: { num_ctx }` -- while posting to
+  // /v1/chat/completions. `options` is an Ollama-native field and the OpenAI-compatible shim drops
+  // it silently, so every load fell back to Ollama's VRAM-based default of 32768. On `primary` that
+  // default happens to equal the configured value, so the bug was invisible on half the matrix;
+  // on `dual` it meant 32768 served against a configurationId reading ctx65536 and a matrixHash
+  // encoding it. Identity asserting something that did not happen.
+  //
+  // Serving it is coarser than asking per request -- every model on a profile gets the same window
+  // -- which is exactly right while the matrix holds context constant per profile, and a test
+  // fails if that ever stops being true.
+  if (Number.isInteger(profile.defaultContext) && profile.defaultContext > 0) {
+    env.OLLAMA_CONTEXT_LENGTH = String(profile.defaultContext);
+  }
   if (profile.hsaOverrideGfxVersion) {
     env.HSA_OVERRIDE_GFX_VERSION = profile.hsaOverrideGfxVersion;
   }


### PR DESCRIPTION
The runner asked for a context **per request** — `options: { num_ctx }` — while posting to `/v1/chat/completions`. `options` is an Ollama-native field and the OpenAI-compatible shim **discards it without a word**, so every load fell back to Ollama's VRAM-based default of 32768.

On `primary` that default *equals* the configured value, so the bug was invisible on half the matrix — the fallback coinciding with the real number is how it survived. The three `dual` configurations ran at **32768 while their `configurationId` read `ctx65536`** and `matrixHash` encoded it. Identity asserting something that did not happen — the same class #116 just closed for the prompt.

## Evidence from the box

    default_num_ctx=32768
    llama-server … -c 32768
    n_ctx_seq (32768) < n_ctx_train (262144)

Not a capacity clamp — the value simply never arrived. `65536` *does* appear in the log historically, from the native `/api/generate` path, which is the control showing the field works where it's parsed.

## The fix

`llm-profiles.json` already declared `defaultContext` per profile (65536 for `dual`); nothing passed it to the server. `serviceEnvironment` now sets `OLLAMA_CONTEXT_LENGTH` — confirmed present on 0.32.14, and documented there as defaulting to *"4k/32k/256k based on VRAM"*, the very fallback observed.

Serving per process is coarser than asking per request: every model on a profile gets the same window. Correct only while the matrix holds context constant within a profile, which it does because `contextTokens` derives from `profile.defaultContext`. If that stops being true, the fix is a per-request path, not a bigger env var.

The inert line is **removed** rather than left beside the working one. It looked functional for months.

## On the tests

Two of the four I first wrote were **tautological**. The matrix derives `contextTokens` from `profile.defaultContext`, so asserting they agree compares a value to its own source — both passed while the profile was deliberately broken.

They're replaced by one that crosses independently built things: the `ctx` label baked into the `configurationId` (what every published result carries) against the environment the server is launched with. Breaking either side alone now fails it.

Gates: 436 files / 3371 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)