### PR TITLE
perf(benchmark): primary serves 8192, the context it actually needs

### DIFF
--- a/tests/tools/remote-ollama-abstract-plan.test.js
+++ b/tests/tools/remote-ollama-abstract-plan.test.js
@@ -119,7 +119,11 @@ test("abstract-plan dry run reports the pilot without exposing its domain mappin
   const output = JSON.parse(result.stdout);
   assert.equal(output.command, "run-abstract-plan");
   assert.equal(output.scenarios.length, 1);
-  assert.deepEqual(output.settings, { contextTokens: 32768, outputTokens: 4096 });
+  assert.deepEqual(output.settings, { // primary's context dropped to 8192 on 2026-08-24. Verified safe for THIS suite too, not just
+    // content-gen: the abstract runner sends only scenario.problem (abstract-runner.js:84) — the
+    // reference and mapping fields are the grading key and never reach the model — and the largest
+    // problem is ~1,105 tokens, so worst case with the 4,096 output cap is ~5,201.
+    contextTokens: 8192, outputTokens: 4096 });
   assert.equal(Object.hasOwn(output.scenarios[0], "mapping"), false);
   assert.equal(Object.hasOwn(output.scenarios[0], "reference"), false);
 });

--- a/tests/tools/remote-ollama-benchmark.test.js
+++ b/tests/tools/remote-ollama-benchmark.test.js
@@ -61,9 +61,9 @@ test("content-gen matrix plans six primary-or-dual configurations in resource or
 
   assert.equal(plan.contractVersion, "content-gen-matrix-v1");
   // Pinned: the matrix hash is run identity, and a silent change makes two runs look
-  // comparable when they measured different things. It moved on 2026-08-24 when
-  // qwen3.5:27b left the primary profile.
-  assert.equal(plan.sha256, "58f201d394c7231b8e14f477aad6cce8d9419d3c3cce2561f7d6b07bf11796f1");
+  // comparable when they measured different things. It moved on 2026-08-24 twice -- when
+  // qwen3.5:27b left the primary profile, and when primary's context dropped to 8192.
+  assert.equal(plan.sha256, "3def36d7d6cd0fca73a357bf1080887c3e191505814167fc60fbe211b05efc4e");
   assert.equal(plan.configurationCount, 6);
   assert.deepEqual(plan.repeatPolicy, {
     minimumCompletePasses: 1,
@@ -72,9 +72,9 @@ test("content-gen matrix plans six primary-or-dual configurations in resource or
   });
   assert.deepEqual(plan.callBounds, { minimum: 600, maximum: 1800 });
   assert.deepEqual(plan.configurations.map((entry) => entry.configurationId), [
-    "cg-v1--qwen3.5_9b--primary--ctx32768--out4096",
-    "cg-v1--qwen3_14b--primary--ctx32768--out4096",
-    "cg-v1--qwen3.8_27b--primary--ctx32768--out4096",
+    "cg-v1--qwen3.5_9b--primary--ctx8192--out4096",
+    "cg-v1--qwen3_14b--primary--ctx8192--out4096",
+    "cg-v1--qwen3.8_27b--primary--ctx8192--out4096",
     "cg-v1--qwen3.5_27b--dual--ctx65536--out32768",
     "cg-v1--qwen3.8_27b--dual--ctx65536--out32768",
     "cg-v1--qwen3-coder_30b-a3b-q4_K_M--dual--ctx65536--out32768",

--- a/tools/remote-ollama-control/config/llm-profiles.json
+++ b/tools/remote-ollama-control/config/llm-profiles.json
@@ -12,7 +12,7 @@
       "hsaOverrideGfxVersion": "10.3.0",
       "port": 11434,
       "defaultModel": "qwen3.8:27b",
-      "defaultContext": 32768,
+      "defaultContext": 8192,
       "defaultNumPredict": 4096,
       "benchmarkModels": [
         "qwen3.8:27b"


### PR DESCRIPTION
`primary` served **32768** and needs **7,736** — a ~3,640-token prompt plus its 4,096 output cap. Over-provisioned 4×, and the KV cache that buys is costing real residency on a 12.87 GB card.

## Measured, from the run that just completed

| Model | Layers on GPU | KV @32768 | Spilled to CPU |
|---|---|---|---|
| 9b | 34/34 | 128 MiB | — |
| 14b | 33/41 | 2,048 MiB | 2,024 MiB |
| 27b | **32/66** | 5,120 MiB | **8,140 MiB** |

At 8192 the KV cache falls to roughly a quarter.

- **14b** is 9.3 GB against 12.87 and misses full residency by about the 1,536 MiB this frees — should become **fully resident**.
- **27b** is 17 GB and can never fit on one card at any context, but reclaiming ~3.75 GB should roughly **halve** what it spills.
- **dual** untouched — already 65/66 and 49/49. (This is why #117 was reverted: doubling its KV would have broken that.)

## Sized against measurement, not arithmetic

`llama-server` logs `n_tokens` — prompt plus generated, exactly what must fit. Across **18,401 real requests**:

| | p50 | p95 | p99 | max |
|---|---|---|---|---|
| primary | 2,696 | 3,734 | 4,389 | **6,289** |
| dual | 2,696 | 3,576 | 4,207 | 6,376 |

8192 leaves **~23% headroom** over the observed maximum. The only truncations in the logs are eleven from an earlier era at `prompt=37627` against `limit=32768` — six times anything current.

## The abstract-plan suite was checked, not assumed

It shares this profile. Its runner sends only `scenario.problem`; `reference` and `mapping` — which are far larger — are the grading key and never reach the model. Largest problem is ~1,105 tokens, so its worst case with the output cap is ~5,201. **Its pinned expectation moves for that reason, not to make a test pass.**

## Identity

Matrix hash **58f201d3 → 3def36d7**; the three primary `configurationId`s now read `ctx8192`. That hash is run identity — the runner's pinned `AK_BENCHMARK_MATRIX_HASH` must be regenerated in the same change, or change detection compares runs that measured different things.

Gates: 435 files / 3368 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)