### PR TITLE
feat(benchmark): results know which machine made them

### DIFF
--- a/tests/tools/runner-identity.test.js
+++ b/tests/tools/runner-identity.test.js
@@ -1,0 +1,61 @@
+const assert = require("node:assert/strict");
+
+const { runnerIdentity } = require("../../tools/remote-ollama-control/scripts/lib/runner-identity");
+const { computeRunKey } = require("../../tools/remote-ollama-control/scripts/lib/benchmark-trigger");
+
+const LINUX_BOX = { hostname: "darren-LLM", platform: "linux", arch: "x64", cpu: "AMD Ryzen 9" };
+const APPLE_MAC = { hostname: "darren-mac", platform: "darwin", arch: "arm64", cpu: "Apple M3 Pro" };
+
+// computeRunKey hashed the commit, the three identity hashes and the contract version — and nothing
+// about the host. Two machines running the same commit against the same matrix produced the SAME
+// key: the second overwrites the first's latest.json, conflates completedRunKeys, and leaves two
+// results from different hardware indistinguishable. Harmless with one runner; silently wrong the
+// moment there are two.
+
+test("two machines running the same commit and matrix do not collide", () => {
+  const shared = {
+    sourceCommit: "a".repeat(40),
+    scenarioSetHash: "b".repeat(64),
+    matrixHash: "c".repeat(64),
+    executionSuiteHash: "d".repeat(64),
+    runnerContractVersion: "benchmark-agent-v2",
+  };
+  const box = computeRunKey({ ...shared, runnerId: runnerIdentity({}, LINUX_BOX).id });
+  const mac = computeRunKey({ ...shared, runnerId: runnerIdentity({}, APPLE_MAC).id });
+  assert.notEqual(box, mac, "the same work on different hardware must not share a run key");
+
+  // ...and without the host it is exactly the collision this prevents.
+  assert.equal(computeRunKey(shared), computeRunKey(shared));
+});
+
+test("a machine's identity is stable across calls, so its own runs stay comparable", () => {
+  assert.equal(runnerIdentity({}, LINUX_BOX).id, runnerIdentity({}, LINUX_BOX).id);
+  // Stability must not come from ignoring the machine.
+  assert.notEqual(runnerIdentity({}, LINUX_BOX).id, runnerIdentity({}, APPLE_MAC).id);
+});
+
+test("identity is derived, not configured, so a second runner cannot collide by omission", () => {
+  // The failure being prevented is one of forgetting. An unset environment must still be distinct.
+  const withoutEnv = runnerIdentity({}, APPLE_MAC);
+  const withEnv = runnerIdentity({ AK_BENCHMARK_RUNNER_LABEL: "m3-pro" }, APPLE_MAC);
+  assert.equal(withoutEnv.id, withEnv.id, "a label must not change which machine this is");
+  assert.equal(withoutEnv.label, null);
+  assert.equal(withEnv.label, "m3-pro");
+});
+
+test("the published identity carries no hostname, address, port or route", () => {
+  // This lands on a branch of a PUBLIC repository, under the same rule as the heartbeat.
+  const serialized = JSON.stringify(runnerIdentity({ AK_BENCHMARK_RUNNER_LABEL: "box" }, LINUX_BOX));
+  for (const leak of ["darren-LLM", "darren-mac", "11434", "127.0.0.1", "192.168"]) {
+    assert.ok(!serialized.includes(leak), `runner identity leaked ${leak}: ${serialized}`);
+  }
+  // Exhaustive on purpose: a new field is the moment to ask whether it can carry topology.
+  assert.deepEqual(Object.keys(runnerIdentity({}, LINUX_BOX)).sort(), ["arch", "id", "label", "platform"]);
+});
+
+test("platform and arch survive, because they are what makes a number interpretable", () => {
+  // An M-series result and an ROCm result are not comparable, and a reader needs to see that.
+  const mac = runnerIdentity({}, APPLE_MAC);
+  assert.equal(mac.platform, "darwin");
+  assert.equal(mac.arch, "arm64");
+});

--- a/tools/remote-ollama-control/config/benchmark-trigger-policy.json
+++ b/tools/remote-ollama-control/config/benchmark-trigger-policy.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "agent-kernel-benchmark-trigger-policy/v1",
-  "runnerContractVersion": "benchmark-agent-v1",
+  "runnerContractVersion": "benchmark-agent-v2",
   "sourceRef": "main",
   "resultBranch": "benchmark-results",
   "pathClasses": {

--- a/tools/remote-ollama-control/scripts/benchmark-agent.js
+++ b/tools/remote-ollama-control/scripts/benchmark-agent.js
@@ -8,6 +8,7 @@ const { runBenchmarkPipeline } = require('./lib/benchmark-pipeline');
 const { prepareBenchmarkSource } = require('./lib/benchmark-source');
 const { acquireAgentLock, loadAgentState, saveAgentState } = require('./lib/benchmark-state');
 const { classifyTrigger, computeRunKey, loadTriggerPolicy } = require('./lib/benchmark-trigger');
+const { runnerIdentity } = require('./lib/runner-identity');
 
 function git(repo, args) {
   return execFileSync('git', ['-C', repo, ...args], {
@@ -53,7 +54,7 @@ function markEvaluated(state, sourceCommit, scenarioSetHash, matrixHash, executi
 function publicationRecord({
   outcome, sourceCommit, sourceTree, sourceRef, sourceRepository, key,
   startedAt, completedAt, policy, trigger, previousEvaluatedCommit,
-  scenarioSetHash, matrixHash, executionSuiteHash,
+  scenarioSetHash, matrixHash, executionSuiteHash, runner,
 }) {
   const status = outcome.status || 'infrastructure_error';
   const defaultFailures = status === 'infrastructure_error'
@@ -72,6 +73,9 @@ function publicationRecord({
       runnerContractVersion: policy.runnerContractVersion,
     },
     source: { repository: sourceRepository, ref: sourceRef, commit: sourceCommit, tree: sourceTree },
+    // Which machine produced this. Two runners on the same commit and matrix used to publish under
+    // the same key; a reader could not tell them apart, and the second silently replaced the first.
+    runner: runner || null,
     trigger: {
       previousEvaluatedCommit,
       reasons: trigger.reasons,
@@ -158,12 +162,15 @@ async function runBenchmarkAgent(options) {
       executionSuiteHashChanged: state.lastEvaluatedCommit !== null
         && state.executionSuiteHash !== executionSuiteHash,
     });
+    const runner = runnerIdentity();
     const key = computeRunKey({
       sourceCommit,
       scenarioSetHash,
       matrixHash,
       executionSuiteHash,
       runnerContractVersion: policy.runnerContractVersion,
+      // The host is part of what a run IS. Without it a second machine collides with the first.
+      runnerId: runner.id,
     });
 
     if (dryRun) {
@@ -231,6 +238,7 @@ async function runBenchmarkAgent(options) {
       scenarioSetHash,
       matrixHash,
       executionSuiteHash,
+      runner,
     });
     await publishResult({
       remote: resultsRemote,

--- a/tools/remote-ollama-control/scripts/lib/runner-identity.js
+++ b/tools/remote-ollama-control/scripts/lib/runner-identity.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * Which machine produced a result.
+ *
+ * computeRunKey hashed sourceCommit, the three identity hashes and the contract version -- and
+ * nothing about the host. Two machines running the same commit against the same matrix therefore
+ * produced the SAME run key: the second would overwrite the first's latest.json, conflate
+ * completedRunKeys, and leave two results from different hardware indistinguishable.
+ *
+ * That was harmless while exactly one runner existed. It stops being harmless the moment a second
+ * one does, and it fails silently rather than loudly -- the same shape as every other identity gap
+ * found on 2026-08-24.
+ *
+ * The record lands in a PUBLIC repository, so this deliberately publishes no hostname, address,
+ * port or route. `id` is an opaque digest that is stable for a machine and meaningless off it;
+ * `platform` and `arch` are the parts a reader genuinely needs to interpret a number (an M-series
+ * result and an ROCm result are not comparable); `label` is whatever the operator chooses to say.
+ */
+
+const crypto = require('crypto');
+const os = require('os');
+
+function machineFacts() {
+  const cpus = os.cpus();
+  return {
+    hostname: os.hostname(),
+    platform: process.platform,
+    arch: process.arch,
+    cpu: (cpus && cpus[0] && cpus[0].model) || 'unknown',
+  };
+}
+
+/**
+ * Stable across restarts and reinstalls, distinct between machines, and not reversible into
+ * anything useful. Derived rather than configured so a second runner cannot collide by forgetting
+ * to set something -- the failure this exists to prevent is precisely one of omission.
+ */
+function runnerIdentity(env = process.env, facts = machineFacts()) {
+  const digest = crypto.createHash('sha256')
+    .update([facts.hostname, facts.platform, facts.arch, facts.cpu].join('\n'))
+    .digest('hex')
+    .slice(0, 16);
+  const label = (env.AK_BENCHMARK_RUNNER_LABEL || '').trim();
+  return {
+    id: digest,
+    platform: facts.platform,
+    arch: facts.arch,
+    // Optional and operator-chosen. Null rather than absent: a reader must be able to tell
+    // "nobody named this runner" from "this field did not exist yet".
+    label: label === '' ? null : label,
+  };
+}
+
+module.exports = { machineFacts, runnerIdentity };


### PR DESCRIPTION
Stage 1 of running the benchmark on a second machine — and the blocking prerequisite for all of it.

## The defect

```js
computeRunKey({ sourceCommit, scenarioSetHash, matrixHash, executionSuiteHash, runnerContractVersion })
```

Nothing about the host. Two machines running the same commit against the same matrix produce the **same run key** — the second overwrites the first's `latest.json`, conflates `completedRunKeys`, and leaves two results from different hardware indistinguishable.

Harmless with one runner. Silently wrong the moment there are two, which is the same shape as every other identity gap found today.

## What lands

`runnerId` now participates in the key, and the published record carries a `runner` object. The contract version moves to **`benchmark-agent-v2`** — which is what that field is for: the key composition changed, so the next run legitimately gets a new key rather than appearing to continue the old series.

**Derived, not configured.** The failure being prevented is one of *omission* — a second runner colliding because nobody set a variable — so an unset environment must still be distinct. An operator label is optional and cannot change which machine a runner is.

## Public-repo discipline

The record lands on a branch of a public repository, under the same rule as the heartbeat. It publishes **no hostname, address, port or route**: `id` is an opaque digest, stable for a machine and meaningless off it.

`platform` and `arch` *do* survive, because they're what makes a number interpretable — an M-series result and an ROCm result are not comparable, and a reader has to see that. A test pins the field set exhaustively, so adding one is the moment to ask whether it can carry topology.

## Perturbation

| Change | Result |
|---|---|
| drop `runnerId` from the key | collision returns |
| make the digest ignore the machine | 2 cases fail |

Gates: 436 files / 3373 passed / typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)