### PR TITLE
feat(benchmark): this Mac can run the models, deliberately

### DIFF
--- a/tests/tools/mac-profile.test.js
+++ b/tests/tools/mac-profile.test.js
@@ -1,0 +1,101 @@
+const assert = require("node:assert/strict");
+const { resolve } = require("node:path");
+
+const {
+  loadConfig, getProfile, serviceEnvironment,
+} = require("../../tools/remote-ollama-control/scripts/lib/config");
+const { buildContentGenMatrix } = require("../../tools/remote-ollama-control/scripts/lib/benchmark");
+
+const ROOT = resolve(__dirname, "../../tools/remote-ollama-control");
+
+// A second machine can run the matrix, but only on purpose.
+//
+// The `mac` profile describes this MacBook so a run can be pointed at it without inventing the
+// hardware facts at the call site. What it deliberately does NOT do is join the benchmark matrix:
+// `buildContentGenMatrix` derives configurations from models.json's per-model `profiles` list, so a
+// profile nothing references is inert, and matrixHash -- the identity every published result is
+// compared through -- does not move. That inertness is the whole safety property here, and the
+// tests below hold it in place rather than trusting a comment to.
+
+function configWithoutMac() {
+  const config = loadConfig(ROOT);
+  const profiles = { ...config.profiles };
+  delete profiles.mac;
+  return { ...config, profiles };
+}
+
+function matrixHash(config) {
+  return buildContentGenMatrix(config, { scenarioCount: 100, maximumPasses: 3 }).sha256;
+}
+
+test("the mac profile is complete enough that activating it cannot fail at matrix-build time", () => {
+  const profile = getProfile(loadConfig(ROOT), "mac");
+  for (const field of ["gpuCount", "capacityRank", "defaultContext", "defaultNumPredict", "port"]) {
+    assert.ok(
+      Number.isInteger(profile[field]) && profile[field] > 0,
+      `mac.${field} must be a positive integer — buildContentGenMatrix throws on anything else`,
+    );
+  }
+  assert.equal(typeof profile.hardwareClass, "string");
+  assert.ok(profile.hardwareClass.length > 0, "mac.hardwareClass must be non-empty");
+  assert.ok(profile.defaultModel, "mac.defaultModel must name a model this machine can serve");
+});
+
+// Copying an existing profile is the obvious way to add one, and every existing profile is AMD.
+// Carrying those fields over would be silently wrong rather than loudly wrong: they are meaningless
+// on Metal, and an empty one is actively harmful (see the serviceEnvironment test below).
+test("the mac profile declares no AMD device visibility", () => {
+  const raw = require("../../tools/remote-ollama-control/config/llm-profiles.json").profiles.mac;
+  for (const field of ["rocrVisibleDevices", "hipVisibleDevices", "hsaOverrideGfxVersion", "gpuDevices"]) {
+    assert.equal(
+      raw[field], undefined,
+      `mac.${field} is an AMD/ROCm concept and must be absent, not empty — `
+      + "loadConfig normalises absent to '', and '' is not the same as unset downstream",
+    );
+  }
+});
+
+// The reason absent must not become empty. ROCR_VISIBLE_DEVICES='' does not read as "unset" to the
+// ROCm runtime, it reads as "no devices", which drops the server to CPU without erroring.
+test("serviceEnvironment omits device visibility rather than exporting it empty", () => {
+  const config = loadConfig(ROOT);
+  const mac = serviceEnvironment(getProfile(config, "mac"));
+  assert.ok(!("ROCR_VISIBLE_DEVICES" in mac), "mac must not export ROCR_VISIBLE_DEVICES at all");
+  assert.ok(!("HIP_VISIBLE_DEVICES" in mac), "mac must not export HIP_VISIBLE_DEVICES at all");
+  assert.equal(mac.OLLAMA_PROFILE, "mac");
+
+  // ...and the guard must not have disarmed the profiles that genuinely need these set.
+  const dual = serviceEnvironment(getProfile(config, "dual"));
+  assert.equal(dual.ROCR_VISIBLE_DEVICES, "0,1");
+  assert.equal(dual.HIP_VISIBLE_DEVICES, "0,1");
+  assert.equal(dual.HSA_OVERRIDE_GFX_VERSION, "10.3.0");
+});
+
+// The load-bearing one. Every published result is comparable only to results carrying the same
+// matrixHash, and the box has that hash pinned in its agent env. If merely DEFINING a profile moved
+// it, this change would silently orphan every prior result and the pin would compare incomparable
+// runs without erroring.
+test("defining the mac profile does not move matrixHash", () => {
+  assert.equal(
+    matrixHash(loadConfig(ROOT)), matrixHash(configWithoutMac()),
+    "the mac profile changed the content-gen matrix identity — it must stay inert until a model opts in",
+  );
+});
+
+// What makes the profile inert is that no model references it. Activating the Mac means editing
+// models.json, and that is a decision with a cost this test states rather than hides: resourceOrder
+// ranks configurations by gpuCount then capacityRank to report "the cheapest configuration that
+// qualifies", and that ordering assumes one machine. One GPU on an M3 Pro and one GPU on the
+// benchmark box are not the same cost, so mixing them into one matrix makes that answer incoherent.
+// Settle the ordering question first; then delete this test in the same diff that opts a model in.
+test("no model opts into the mac profile yet", () => {
+  const models = require("../../tools/remote-ollama-control/config/models.json").models;
+  const opted = Object.entries(models)
+    .filter(([, model]) => (model.profiles || []).includes("mac"))
+    .map(([id]) => id);
+  assert.deepEqual(
+    opted, [],
+    `${opted.join(", ")} opted into the mac profile. That changes matrixHash and mixes two machines `
+    + "into one resourceOrder ranking — decide how cross-machine cost is ordered before landing it",
+  );
+});

--- a/tests/tools/price-brief.test.js
+++ b/tests/tools/price-brief.test.js
@@ -83,10 +83,14 @@ const { assertResumable } = require("../../tools/remote-ollama-control/scripts/l
 
 // assertResumable checks catalog, matrix, policy, scenario ids and configuration ids in that
 // order, so a fixture must satisfy all of them for the policy case to be the one under test.
+// The runner is part of that list as of the day a second machine could run the matrix: a manifest
+// that cannot say which machine produced it is refused outright, so the fixture has to name one for
+// the policy case to be reachable at all.
 const IDENT = {
   scenarioSet: { sha256: "s".repeat(64) },
   matrix: { sha256: "m".repeat(64), configurationIds: ["cfg-a"] },
   scenarioIds: [1, 2],
+  runner: { id: "a1b2c3d4e5f60718", platform: process.platform, arch: process.arch, label: null },
 };
 
 test("the authoring policy hashes the instructions and the prices together", () => {

--- a/tests/tools/remote-ollama-content-gen-resume.test.js
+++ b/tests/tools/remote-ollama-content-gen-resume.test.js
@@ -239,3 +239,70 @@ test("a diagnostic run says so in its manifest, so it cannot be quoted as qualif
   writeRunManifest(dir, { route: "internal", ...IDENTITY });
   assert.equal(readRunManifest(dir).diagnostic, false, "a normal run must record diagnostic:false, not undefined");
 });
+
+// A run is identified by what was asked AND by what answered. The three identity fields above pin
+// the questions, the configurations and the instructions; until a second machine existed, nothing
+// pinned the machine, and the omission was invisible precisely because there was only one. A resume
+// that crosses machines would append one machine's attempts to another's runs.jsonl and aggregate
+// them into a single score for a configuration neither machine ran on its own.
+
+test("a manifest records which machine produced it without being asked to", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cg-runner-"));
+  const manifest = writeRunManifest(dir, { route: "internal", ...IDENTITY });
+  assert.ok(manifest.runner, "the manifest must carry a runner");
+  assert.match(manifest.runner.id, /^[0-9a-f]{16}$/, "runner.id must be the derived digest");
+  assert.equal(manifest.runner.platform, process.platform);
+  assert.equal(manifest.runner.arch, process.arch);
+  // Round-trips through disk: an in-memory return value proves nothing about resume, which reads.
+  assert.deepEqual(readRunManifest(dir).runner, manifest.runner);
+});
+
+test("resume refuses a run started on a different machine", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cg-runner-other-"));
+  writeRunManifest(dir, { route: "internal", ...IDENTITY });
+  const manifest = readRunManifest(dir);
+
+  assert.doesNotThrow(
+    () => assertResumable(manifest, IDENTITY),
+    "the machine that started the run must still be able to finish it",
+  );
+
+  const elsewhere = {
+    ...manifest,
+    runner: { id: "0123456789abcdef", platform: "linux", arch: "x64", label: "benchmark-box" },
+  };
+  assert.throws(
+    () => assertResumable(elsewhere, IDENTITY),
+    /two machines cannot share one result/i,
+    "attempts from two machines must not merge into one run",
+  );
+  // The message has to name both ends, or the operator cannot tell which machine to go back to.
+  assert.throws(() => assertResumable(elsewhere, IDENTITY), /benchmark-box/);
+  assert.throws(() => assertResumable(elsewhere, IDENTITY), new RegExp(process.platform));
+});
+
+// The guard derives the current machine rather than taking it as an argument. A caller that forgot
+// to pass one would otherwise disarm the check silently -- which is the same shape of omission the
+// check exists to catch.
+test("the runner check fires even when the caller supplies no runner", () => {
+  const foreign = {
+    ...IDENTITY,
+    runner: { id: "fedcba9876543210", platform: "linux", arch: "x64", label: null },
+  };
+  const current = { ...IDENTITY };
+  assert.equal(current.runner, undefined, "this case only means anything if the caller is silent");
+  assert.throws(
+    () => assertResumable(foreign, current),
+    /two machines cannot share one result/i,
+    "an absent runner on the caller side must not disarm the guard",
+  );
+});
+
+test("a run predating the runner record cannot be resumed", () => {
+  const { runner, ...predates } = { ...IDENTITY, runner: undefined };
+  assert.throws(
+    () => assertResumable(predates, IDENTITY),
+    /predates the runner record/i,
+    "an unattributable run must be restarted, not silently adopted",
+  );
+});

--- a/tools/remote-ollama-control/config/llm-profiles.json
+++ b/tools/remote-ollama-control/config/llm-profiles.json
@@ -51,6 +51,18 @@
       "benchmarkModels": [
         "qwen3.8:27b"
       ]
+    },
+    "mac": {
+      "description": "This MacBook's own Ollama. Apple unified memory: one GPU, no per-device visibility to set.",
+      "hardwareClass": "apple-unified",
+      "gpuCount": 1,
+      "capacityRank": 4,
+      "intendedGpu": "Apple M3 Pro, 18-core GPU / ~27GB of 36GB unified memory addressable",
+      "port": 11434,
+      "defaultModel": "qwen3.8:27b",
+      "defaultContext": 8192,
+      "defaultNumPredict": 4096,
+      "benchmarkModels": []
     }
   }
 }

--- a/tools/remote-ollama-control/scripts/lib/config.js
+++ b/tools/remote-ollama-control/scripts/lib/config.js
@@ -284,11 +284,20 @@ function localEndpointForProfile(profile) {
 
 function serviceEnvironment(profile) {
   const env = {
-    ROCR_VISIBLE_DEVICES: profile.rocrVisibleDevices,
-    HIP_VISIBLE_DEVICES: profile.hipVisibleDevices,
     OLLAMA_HOST: `${profile.bindHost}:${profile.port}`,
     OLLAMA_PROFILE: profile.name
   };
+  // Omitted, never emptied. loadConfig normalises an absent gpuDevices to '', and exporting
+  // HIP_VISIBLE_DEVICES='' to a ROCm runtime does not mean "no preference" -- it means "no GPUs",
+  // which silently drops the server to CPU. A profile on hardware with no per-device visibility
+  // (Apple unified memory) has nothing to say here, and saying nothing is the only safe way to
+  // say it.
+  if (profile.rocrVisibleDevices) {
+    env.ROCR_VISIBLE_DEVICES = profile.rocrVisibleDevices;
+  }
+  if (profile.hipVisibleDevices) {
+    env.HIP_VISIBLE_DEVICES = profile.hipVisibleDevices;
+  }
   if (profile.hsaOverrideGfxVersion) {
     env.HSA_OVERRIDE_GFX_VERSION = profile.hsaOverrideGfxVersion;
   }

--- a/tools/remote-ollama-control/scripts/lib/content-gen-checkpoint.js
+++ b/tools/remote-ollama-control/scripts/lib/content-gen-checkpoint.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { runnerIdentity } = require('./runner-identity');
 
 const MANIFEST_SCHEMA = 'agent-kernel-content-gen-run-manifest/v1';
 const MANIFEST_NAME = 'run-manifest.json';
@@ -22,7 +23,7 @@ function manifestPath(resultDir) {
   return path.join(resultDir, MANIFEST_NAME);
 }
 
-function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, startedAt, diagnostic, authoringPolicy }) {
+function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, startedAt, diagnostic, authoringPolicy, runner }) {
   fs.mkdirSync(resultDir, { recursive: true });
   const manifest = {
     schemaVersion: MANIFEST_SCHEMA,
@@ -38,6 +39,11 @@ function writeRunManifest(resultDir, { route, scenarioSet, matrix, scenarioIds, 
     // instructions sat outside all three, so adding the price brief on 2026-08-24 changed what was
     // measured while every pinned hash held still.
     authoringPolicy: authoringPolicy || null,
+    // WHICH MACHINE answered. The three fields above pin what the model was asked; this pins what
+    // did the asking, and it is identity-bearing for the same reason: an Apple unified-memory GPU
+    // and a dual-AMD box are not one measurement. It was unrecorded while only one machine existed,
+    // which is exactly when the omission is invisible.
+    runner: runner || runnerIdentity(),
     scenarioIds: [...scenarioIds].sort((left, right) => left - right)
   };
   fs.writeFileSync(manifestPath(resultDir), `${JSON.stringify(manifest, null, 2)}\n`);
@@ -96,6 +102,28 @@ function assertResumable(manifest, current) {
         + 'Attempts told different things cannot share one result.'
       );
     }
+  }
+
+  // Resume on a different machine than started the run. Reachable from the day a second runner
+  // exists, and silent until then: attempts from two machines would land in one runs.jsonl and be
+  // aggregated into a single score for a configuration neither machine actually ran.
+  const priorRunner = manifest.runner;
+  // Derived here rather than required from the caller. Every other field on `current` describes
+  // what was ASKED and only the caller knows it; the machine is ambient, and a guard that fires
+  // only when someone remembers to pass an argument is the failure of omission it exists to catch.
+  const currentRunner = current.runner || runnerIdentity();
+  if (!priorRunner) {
+    throw new Error(
+      'cannot resume: this run predates the runner record, so there is no way to tell which '
+      + 'machine produced its attempts. Start a fresh run.'
+    );
+  }
+  if (priorRunner.id !== currentRunner.id) {
+    const describe = (runner) => `${runner.label || runner.id.slice(0, 12)} (${runner.platform}/${runner.arch})`;
+    throw new Error(
+      `cannot resume: this run was started on ${describe(priorRunner)} and this is `
+      + `${describe(currentRunner)}. Attempts from two machines cannot share one result.`
+    );
   }
 
   const known = new Set(manifest.scenarioIds);


### PR DESCRIPTION
Stages 2 and 3 of making a second machine able to run the matrix. Stage 1 (runner identity, #120) is the prerequisite; Stage 4 (the ~62 GB of model pulls) is data, not code, and is done.

## What this does

**Stage 2 — a `mac` profile that is inert until someone opts in.** The profile describes this MacBook (Apple M3 Pro, unified memory, one GPU, port 11434) so a run can be pointed at it without inventing hardware facts at the call site.

The safety property is that defining it changes nothing. `buildContentGenMatrix` derives configurations from `models.json`'s per-model `profiles` list, not from `llm-profiles.json`, so a profile nothing references contributes nothing to `matrixHash` — and every published result stays comparable to the baseline the box has pinned. `defining the mac profile does not move matrixHash` builds the matrix with and without the profile and compares the two hashes.

**What stops activation from being a one-line edit** is `resourceOrder`. It ranks configurations by `gpuCount` then `capacityRank` so a run can report the cheapest configuration that qualifies, and that ranking assumes one machine. One GPU on an M3 Pro and one GPU on the benchmark box are not the same cost. `no model opts into the mac profile yet` states that question and fails the moment someone answers it implicitly.

**A latent bug the profile surfaced.** `serviceEnvironment` exported `ROCR_VISIBLE_DEVICES` and `HIP_VISIBLE_DEVICES` unconditionally, and `loadConfig` normalises an absent `gpuDevices` to `''`. To the ROCm runtime `''` means "no devices", not "no preference" — it drops the server to CPU without erroring. Absent fields are now omitted rather than emptied; `primary` and `dual` still get theirs.

**Stage 3 — a run records which machine answered.** The run manifest pinned what was *asked* (catalog, matrix, instructions) on the stated principle that merging attempts from two different inputs produces a number nobody can interpret. It never pinned what *answered*, because there was one machine and the omission had no way to show itself.

This work is what makes it reachable. A resume crossing machines appends one machine's attempts to another's `runs.jsonl` and aggregates them into a single score for a configuration neither machine ran — silently, since every other identity field still matches.

`assertResumable` **derives** the current machine rather than accepting it as an argument, and the caller passes nothing. Every other field on `current` describes what was asked and only the caller knows it; the machine is ambient. A guard armed only when someone remembers to pass an argument is the failure of omission it exists to catch — the same call made in #120.

## Perturbation

| Break | Expected failure | Result |
|---|---|---|
| Opt `qwen3:14b` into `mac` | matrixHash moves, opt-in guard trips | 2 failed |
| Restore the unconditional `ROCR`/`HIP` export | serviceEnvironment test | 1 failed |
| Empty-string `hipVisibleDevices` on `mac` | AMD-field + serviceEnvironment | 2 failed |
| Stamp `runner: null` in the manifest | record + cross-machine tests | 3 failed |
| Make the runner guard conditional on the caller | all four runner tests, plus an existing one | 4 failed |
| *Control:* same machine resumes | must still return true | true |

## Gates

suite 437 files / 3382 passed / 207 skipped · typecheck 0

## Not in scope

Activating the Mac in `models.json`, and the macOS service/launchd path. The first needs the `resourceOrder` decision above; the second is not what an idle day needs — `run-content-gen --local` already drives this machine's own Ollama through the real pipeline, and its results are marked `local-unversioned` so they cannot be mistaken for a qualifying baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)