### PR TITLE
revert(benchmark): the price brief did not help, so stop sending it

### DIFF
--- a/tests/tools/price-brief.test.js
+++ b/tests/tools/price-brief.test.js
@@ -1,5 +1,7 @@
 const assert = require("node:assert/strict");
 const { readFileSync } = require("node:fs");
+const { createHash } = require("node:crypto");
+const { resolve } = require("node:path");
 
 const {
   BASE_COSTS_PATH, buildPriceBrief, loadBaseCosts, priceBriefHash,
@@ -125,4 +127,45 @@ test("a run predating the record refuses rather than silently merging", () => {
   const prior = { ...IDENT };
   const current = { ...IDENT, authoringPolicy: { sha256: "c".repeat(64), priceBriefSha256: "d".repeat(64) } };
   assert.throws(() => assertResumable(prior, current), /predates the authoring-policy record/);
+});
+
+// The brief is generated, tested and DISCONNECTED. Five arms over the whole constrained tier had it
+// losing to sending nothing on every measure, so `AUTHORING_PRICE_BRIEF` is empty and these guard
+// that it stays that way until an experiment says otherwise.
+
+test("no price list reaches the model", () => {
+  const policy = authoringPolicy();
+  const emptyHash = createHash("sha256").update("").digest("hex");
+  assert.equal(
+    policy.priceBriefSha256, emptyHash,
+    "the run record must state that no prices were sent — a non-empty hash here means the brief is back",
+  );
+});
+
+// The prompt and the identity used to call buildPriceBrief() SEPARATELY, so the record could claim
+// a brief the model never saw, or miss one it did. One value feeds both now, and this holds it:
+// a second call in the prompt path would let them disagree again.
+test("the prompt and the run record cannot disagree about what was sent", () => {
+  const source = readFileSync(
+    resolve(__dirname, "../../tools/remote-ollama-control/scripts/lib/ak-runner.js"), "utf8",
+  );
+  // Comments are stripped first: the constant's own docblock names buildPriceBrief() as the way to
+  // re-enable the brief, and that instruction is worth keeping readable.
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+  const calls = code.match(/buildPriceBrief\(\)/g) || [];
+  assert.deepEqual(
+    calls, [],
+    "ak-runner must read AUTHORING_PRICE_BRIEF rather than calling buildPriceBrief() — two calls is "
+    + "how the prompt and the identity came to be separate values",
+  );
+  assert.match(source, /const AUTHORING_PRICE_BRIEF = /);
+});
+
+// ...and the generator itself still works, so the derivation experiment can use it.
+test("the generator survives, still built from base-costs.json", () => {
+  const brief = buildPriceBrief();
+  assert.ok(brief.length > 0, "buildPriceBrief must remain usable for the derived-prices experiment");
+  assert.match(brief, /hazard_basic=5/, "still generated from the Allocator's own costs, not restated");
 });

--- a/tools/remote-ollama-control/scripts/lib/ak-runner.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-runner.js
@@ -161,8 +161,40 @@ const AUTHORING_INSTRUCTIONS_TAIL =
  * The scenario-specific half is deliberately excluded: the budget number and the prompt text are
  * scenario data, already covered by scenarioSetHash. Only the harness's own contribution is here.
  */
+/**
+ * The price brief is NOT sent, and this is the single value that says so.
+ *
+ * It was built twice -- once into the system prompt and once into the hash below -- so the identity
+ * could disagree with what the model was actually told. One value now feeds both: whatever is here
+ * is what is sent AND what is recorded, and the two cannot drift.
+ *
+ * Measured on 2026-08-25, qwen3.5:9b over all 25 constrained scenarios, paired by scenario, five
+ * arms differing only in this text:
+ *
+ *   none (this)          mean 47.7   13/25 pass   <-- best on every measure
+ *   exact prices         mean 40.9   10/25
+ *   assembled costs      mean 37.8   12/25
+ *   rules, no numbers    mean 40.2    9/25
+ *   exact + examples     mean 38.0   12/25
+ *
+ * No single arm reaches significance against the control (sign test p = 0.125 to 0.688; 17-19 of 25
+ * scenarios are untouched in each pairing). The signal is the consistency: four unrelated contents,
+ * all below the control, none above. When four different contents give the same answer, content is
+ * not the lever.
+ *
+ * The mechanism, from constrained scenario 92: given prices the model authored a room, a floor
+ * tile, four empty arrays and all four vitals, and overran a 58-token budget by 2. Given nothing it
+ * authored the warden alone and scored 100. A price list reads as a MENU, and the model orders from
+ * it -- which is why the numberless rules arm failed too.
+ *
+ * buildPriceBrief() is kept, tested and generated from base-costs.json rather than deleted: the open
+ * question is whether prices help when the model DERIVES a total rather than being handed one, and
+ * that experiment needs this generator. Set this constant back to buildPriceBrief() to re-run it.
+ */
+const AUTHORING_PRICE_BRIEF = '';
+
 function authoringPolicy() {
-  const brief = buildPriceBrief();
+  const brief = AUTHORING_PRICE_BRIEF;
   const canonical = JSON.stringify({
     head: AUTHORING_INSTRUCTIONS_HEAD,
     tail: AUTHORING_INSTRUCTIONS_TAIL,
@@ -181,11 +213,11 @@ async function runScenario(endpoint, model, scenario, runOutDir, runId, timeoutM
   const budgetInstruction = constrained
     ? `Set budgetTokens to ${scenario.budget}. `
     : 'Omit budgetTokens — the budget is unconstrained. ';
-  // The model used to be handed a budget number and no prices, so authoring within it was a guess.
-  // Budget and spatial failures were 55% of what failed once the schema defects were fixed, and the
-  // constrained tier failed at 56% against simple's 18%. The brief is generated from the
-  // Allocator's own base-costs.json, never restated, so a price change reaches the model.
-  const systemPrompt = `${AUTHORING_INSTRUCTIONS_HEAD}${budgetInstruction}${AUTHORING_INSTRUCTIONS_TAIL}\n\n${buildPriceBrief()}`;
+  // Prices are deliberately NOT appended -- see AUTHORING_PRICE_BRIEF above for the measurement.
+  // The trailing separator is conditional so an empty brief leaves no dangling blank lines, and so
+  // restoring the brief needs no change here.
+  const systemPrompt = `${AUTHORING_INSTRUCTIONS_HEAD}${budgetInstruction}${AUTHORING_INSTRUCTIONS_TAIL}`
+    + (AUTHORING_PRICE_BRIEF ? `\n\n${AUTHORING_PRICE_BRIEF}` : '');
 
   const chatBody = {
     model,


### PR DESCRIPTION
#115 gave the authoring model a generated price list, on the reasoning that budget failures were 55% of what failed once the schema defects were fixed and the model had no way to compute against the budget it was handed. Measured over the whole constrained tier, it does not help.

## The measurement

`qwen3.5:9b`, all 25 constrained scenarios, paired by scenario, one machine, the brief as the only variable. Each arm's run manifest carries its own `priceBriefSha256`, so they cannot be confused for one another.

| arm | brief | mean | verdict pass | exec ok |
|---|---|---|---|---|
| A | exact prices — **what #115 ships** (1351 ch) | 40.9 | 10/25 | 8/25 |
| **B** | **nothing (0 ch)** | **47.7** | **13/25** | **10/25** |
| C | assembled costs, no unit prices (876 ch) | 37.8 | 12/25 | 7/25 |
| D | rules only, no numbers (707 ch) | 40.2 | 9/25 | 7/25 |
| E | exact prices + worked examples (1548 ch) | 38.0 | 12/25 | 7/25 |

**No arm reaches significance on its own** — paired sign test against B gives p = 0.125 (A), 0.289 (C), 0.688 (D), 0.125 (E), with 17–19 of 25 scenarios untouched in each pairing. That is stated rather than buried, and it is why this is a revert to the control rather than a claim that prices are harmful.

The signal is the **consistency**: four unrelated contents, all below the control, none above. When four different contents give the same answer, content is not the lever.

## The mechanism

Constrained scenario 92, a 58-token budget for one defending dark warden. With prices:

```json
{"budgetTokens":58, "room":[{"size":"small"}], "floorTile":[{"count":1}],
 "hazard":[], "resource":[], "delver":[],
 "warden":[{"affinity":"dark","count":1,"motivation":"defending",
   "vitals":{"durability":{"max":1},"health":{"max":1},"mana":{"max":1},"stamina":{"max":1}}}]}
```
→ `Budget receipt denied; remaining=-2`, scored 20.

Without:

```json
{"budgetTokens":58,
 "warden":[{"affinity":"dark","count":1,"motivation":"defending","vitals":{"health":{"max":1}}}]}
```
→ scored 100.

It missed by two tokens, and not through bad arithmetic — it succeeded at arithmetic on a larger shopping list it only assembled because the list existed. **A price list reads as a menu and the model orders from it**, which is why even the numberless rules arm lost.

## Why this is not `git revert 6d60fe1`

#116 landed afterwards and hashes the brief as run identity, so undoing the commit would take that with it.

The brief was also being built **twice** — once into the system prompt, once into `authoringPolicy()` — which let the run record claim a brief the model never saw, or miss one it did. Both now read a single `AUTHORING_PRICE_BRIEF` constant, so the prompt and the identity cannot drift apart. With it empty, the published identity records the empty-string hash, honestly stating that no prices were sent — the same hash arm B recorded.

`buildPriceBrief()` is **kept**, tested, and still generated from `base-costs.json` rather than deleted. The open question is whether prices help when the model *derives* a total instead of being handed one; that experiment needs this generator, and the constant is a one-line switch back. The evidence table lives in the docblock above the constant, so the next reader finds the reasoning at the decision.

## Perturbation

| break | expected | result |
|---|---|---|
| set the constant back to `buildPriceBrief()` | both guards trip | 2 failed |
| leave it empty | both pass | 13 passed |

The source guard strips comments before matching, because the constant's own docblock names `buildPriceBrief()` as the way to re-enable it and that instruction is worth keeping readable.

## Gates

suite 437 files / 3385 passed / 207 skipped · typecheck 0

## Caveats

One model at one budget tier. A separate paired run last night had `qwen3.8:27b` scoring identically with and without prices on 7 of 8 scenarios, which points the same way. All five arms predate the actor viability floor, which changes what things cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)