### PR TITLE
fix(benchmark): the results branch must carry evidence, not the source tree

### DIFF
--- a/tests/tools/benchmark-publisher-remote-url.test.js
+++ b/tests/tools/benchmark-publisher-remote-url.test.js
@@ -91,3 +91,57 @@ test('publishing twice to a URL remote appends rather than conflicting', async (
 // - a cache directory that exists but was cloned from a different remote
 // - concurrent publishers racing on the same workDir
 // - a remote path that exists locally but is not a git repository
+
+// A bootstrap publish must carry EVIDENCE ONLY.
+//
+// `git checkout --orphan` starts a new history but keeps the index, and the publisher runs inside a
+// mirror of the source repo. So the first ever commit swept the whole source tree onto the evidence
+// branch -- 1496 files, 15.9 MB of packages/ tests/ and .github/ against ~0 MB of results -- and
+// every commit after it inherited them. Nothing caught it because the branch was never wrong in a
+// way that broke a publish.
+test("a bootstrap publish commits evidence only, never the source tree", () => {
+  const { execFileSync } = require("node:child_process");
+  const { mkdtempSync, writeFileSync, mkdirSync } = require("node:fs");
+  const { tmpdir } = require("node:os");
+  const { join } = require("node:path");
+  const git = (cwd, args) => execFileSync("git", args, { cwd, encoding: "utf8" });
+
+  // A "source repo" the publisher would be mirroring, with a file that must not travel.
+  const repo = mkdtempSync(join(tmpdir(), "pub-src-"));
+  git(repo, ["init", "--quiet", "-b", "main", "."]);
+  git(repo, ["config", "user.email", "t@t"]); git(repo, ["config", "user.name", "t"]);
+  mkdirSync(join(repo, "packages"), { recursive: true });
+  writeFileSync(join(repo, "packages", "runtime.js"), "// source, must not reach the evidence branch\n");
+  git(repo, ["add", "-A"]); git(repo, ["commit", "--quiet", "-m", "source"]);
+
+  // What prepareCheckout does on the bootstrap path.
+  git(repo, ["checkout", "--orphan", "benchmark-results"]);
+  git(repo, ["rm", "-rf", "--cached", "--ignore-unmatch", "."]);
+  mkdirSync(join(repo, "history", "2026", "08"), { recursive: true });
+  writeFileSync(join(repo, "history", "2026", "08", "run.json"), "{}\n");
+  writeFileSync(join(repo, "latest.json"), "{}\n");
+  git(repo, ["add", "--", "history", "latest.json"]);
+  git(repo, ["commit", "--quiet", "-m", "benchmark: run"]);
+
+  const tracked = git(repo, ["ls-tree", "-r", "--name-only", "HEAD"]).trim().split("\n").sort();
+  assert.deepEqual(
+    tracked, ["history/2026/08/run.json", "latest.json"],
+    "the bootstrap commit carried files beyond the evidence — the index was not cleared after the "
+    + "orphan checkout, which is how 15.9 MB of source ended up on benchmark-results",
+  );
+});
+
+// The clearing must NOT happen on the existing-branch path: the publisher's own docblock warns that
+// dropping prior results there is "not a failed publish, it is a destroyed archive".
+test("the index is cleared only on the orphan path, never for an existing branch", () => {
+  const { readFileSync } = require("node:fs");
+  const { resolve } = require("node:path");
+  const src = readFileSync(
+    resolve(__dirname, "../../tools/remote-ollama-control/scripts/lib/benchmark-publisher.js"), "utf8");
+  const orphanBlock = src.slice(src.indexOf("checkout', '--orphan'"));
+  const existingBlock = src.slice(src.indexOf("'checkout', '-B'"), src.indexOf("checkout', '--orphan'"));
+  assert.match(orphanBlock.slice(0, 1400), /rm', '-rf', '--cached'/,
+    "the orphan path must clear the index");
+  assert.doesNotMatch(existingBlock, /rm', '-rf', '--cached'/,
+    "clearing the index on the existing-branch path would destroy every prior result");
+});

--- a/tools/remote-ollama-control/scripts/lib/benchmark-publisher.js
+++ b/tools/remote-ollama-control/scripts/lib/benchmark-publisher.js
@@ -101,6 +101,20 @@ function prepareCheckout(remote, branch, workDir) {
     git(workDir, ['checkout', '-B', branch, `origin/${branch}`]);
   } else {
     git(workDir, ['checkout', '--orphan', branch]);
+    // An orphan checkout starts a new history but KEEPS the index, and workDir is a mirror of the
+    // source repo -- so the first commit swept the entire source tree onto the evidence branch and
+    // every commit after it inherited the result: 1496 files and 15.9 MB of `packages/`, `tests/`
+    // and `.github/` against ~0 MB of actual evidence. Nothing detected it, because the branch was
+    // never wrong in a way that broke a publish.
+    //
+    // It is not only bloat. AGENTS.md states that result-branch commits "cannot trigger source
+    // benchmarks", and that held only because nothing watched the branch -- it carried real
+    // workflow files, one trigger away from being untrue.
+    //
+    // The heartbeat publisher has always done this; the two were written apart and only one knew.
+    // Scoped to the orphan branch deliberately: doing it on the `checkout -B` path above would
+    // destroy every prior result, which is the failure the docblock warns about.
+    git(workDir, ['rm', '-rf', '--cached', '--ignore-unmatch', '.']);
   }
 }
 


### PR DESCRIPTION
`benchmark-results` is an orphan evidence branch that has carried a **full source-tree snapshot since its bootstrap commit** — 1496 files, 15.9 MB of `packages/`, `tests/` and `.github/` against ~0 MB of actual results.

`git checkout --orphan` starts a new history but **keeps the index**, and the publisher runs inside a mirror of the source repo. The first commit swept the whole tree in; every commit after inherited it. Nothing detected it because the branch was never wrong in a way that broke a publish — 15 result commits landed correctly on top of it.

Not only bloat: `AGENTS.md` states result-branch commits *"cannot trigger source benchmarks"*, which held only because nothing watched a branch carrying real workflow files.

The heartbeat publisher has always done `git rm -rf --cached` before writing. The two were written apart and only one knew.

**Scoped to the orphan path deliberately.** On the existing-branch path it would destroy every prior result — the exact failure `prepareCheckout`'s own docblock warns about — and a test asserts it is absent there.

## Tests
- a bootstrap publish commits evidence only, never the source tree
- the index is cleared only on the orphan path, never for an existing branch

Gates: publisher + agent suites 14 passed; publisher suite 8 passed.

**The branch rewrite is not in this PR** — see the conversation; it needs a force-push that was blocked by the permission classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)