### PR TITLE
fix(benchmark): score a denial like any other scenario

### DIFF
--- a/tests/tools/content-gen-denial-scoring.test.js
+++ b/tests/tools/content-gen-denial-scoring.test.js
@@ -1,0 +1,73 @@
+const assert = require("node:assert/strict");
+const { scoreRun } = require("../../tools/remote-ollama-control/scripts/lib/ak-compare");
+
+// A scenario that is SUPPOSED to be denied must be scored like any other.
+//
+// scoreRun used to return early when the build did not succeed, so the six catalog scenarios
+// expecting `budget_denied` could never earn more than the 20-point tool-call gate -- and were
+// scored BLIND: a model that authored exactly the right spec and one that authored nonsense both
+// scored 20, provided both were denied. The verdict rate cannot separate them either, because it
+// only compares outcome labels. Correct authoring was unrewardable on 6% of the catalog.
+
+const denialScenario = {
+  index: 93, budgetMode: "constrained", budget: 85, expectedOutcome: "budget_denied",
+  reference: { entityCounts: { warden: 1 }, affinitiesByType: { warden: ["dark"] }, totalSpend: 86 },
+};
+const denied = (toolArgs, over = 1) => ({
+  toolCallProduced: true, toolArgs, outDir: null,
+  execResult: { succeeded: false, stdout: "", stderr: `Budget receipt denied: status=denied; remaining=-${over};` },
+});
+
+test("a correctly denied build is scored on what it authored, not capped at the gate", () => {
+  const right = scoreRun(denied({ warden: [{ count: 1, affinity: "dark", motivation: "defending" }] }),
+    denialScenario, undefined, undefined, { outcome: "budget_denied" });
+  assert.ok(right.points > 20,
+    `a correct denial scored ${right.points}; it used to be capped at the 20-point tool-call gate`);
+  assert.equal(right.breakdown.outcomeMatched, 10, "matching the expected outcome must be credited");
+});
+
+test("a wrong spec that is also denied scores far below a right one", () => {
+  const opts = { outcome: "budget_denied" };
+  const right = scoreRun(denied({ warden: [{ count: 1, affinity: "dark", motivation: "defending" }] }),
+    denialScenario, undefined, undefined, opts).points;
+  const wrong = scoreRun(denied({
+    warden: [{ count: 9, affinity: "fire", motivation: "attacking" }],
+    delver: [{ count: 5, affinity: "life", motivation: "patrolling" }],
+  }), denialScenario, undefined, undefined, opts).points;
+  assert.ok(right > wrong + 20,
+    `right=${right} wrong=${wrong} — the two must be distinguishable, which is the whole defect: `
+    + "under the old rules both scored exactly 20 and nothing could tell them apart");
+});
+
+test("succeeding when denial was expected is not rewarded for succeeding", () => {
+  const succeeded = {
+    toolCallProduced: true, toolArgs: { warden: [{ count: 1, affinity: "dark" }] }, outDir: null,
+    execResult: { succeeded: true, stdout: "", stderr: "" },
+  };
+  const r = scoreRun(succeeded, denialScenario, undefined, undefined, { outcome: "success" });
+  assert.equal(r.breakdown.outcomeMatched, 0,
+    "the old execSucceeded gate paid 10 points for succeeding when the scenario expected a denial");
+});
+
+// The overshoot is real information: denied by 1 token shows a grasp of the economy that denied by
+// 400 does not, and both used to be discarded.
+test("how far over the budget a denial went changes the score", () => {
+  const args = { warden: [{ count: 1, affinity: "dark", motivation: "defending" }] };
+  const near = scoreRun(denied(args, 1), denialScenario, undefined, undefined, { outcome: "budget_denied" });
+  const far = scoreRun(denied(args, 400), denialScenario, undefined, undefined, { outcome: "budget_denied" });
+  assert.ok(near.breakdown.budgetDelta > far.breakdown.budgetDelta,
+    `near=${near.breakdown.budgetDelta} far=${far.breakdown.budgetDelta}`);
+  assert.equal(far.breakdown.budgetDelta, 0, "wildly over the budget earns nothing for proximity");
+});
+
+// The change must be invisible to scenarios that succeed: those read the BUILT spec, and the
+// tool-args fallback exists only for builds that never produced one.
+test("a successful build still scores from the built spec, not the tool call", () => {
+  const successScenario = { ...denialScenario, expectedOutcome: "success" };
+  const r = scoreRun({
+    toolCallProduced: true, toolArgs: { warden: [{ count: 99, affinity: "fire" }] }, outDir: null,
+    execResult: { succeeded: true, stdout: "", stderr: "" },
+  }, successScenario, undefined, undefined, { outcome: "success" });
+  assert.equal(r.breakdown.outcomeMatched, 10);
+  assert.ok(Number.isInteger(r.points) && r.points <= 100);
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-compare.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-compare.js
@@ -279,7 +279,41 @@ function partialOverlap(genSet, refSet) {
   return hits / denom;
 }
 
-function scoreRun(runResult, scenario, refSpecPath, refReceiptPath) {
+/**
+ * A scenario that is SUPPOSED to be denied must be scored like any other.
+ *
+ * This used to return early when the build did not succeed, so the six catalog scenarios whose
+ * expected outcome is `budget_denied` could never earn more than the 20-point tool-call gate -- and,
+ * worse, were scored BLIND: a model that authored exactly the right spec and one that authored
+ * nonsense both scored 20, as long as both were denied. The verdict rate could not separate them
+ * either, since it only compares outcome labels. Correct authoring was unrewardable on 6% of the
+ * catalog.
+ *
+ * Everything needed was already to hand. What the model ASKED FOR is in `runResult.toolArgs`
+ * whether or not it was affordable, and the refusal reports how far over it went, so all 100 points
+ * have an honest meaning for a denial.
+ *
+ * `outcome` is passed in rather than derived here: classifyExecutionOutcome lives in ak-runner,
+ * which would make this module import its own caller.
+ */
+/**
+ * The card set a tool call describes, in the shape the built spec would have produced. Used only
+ * when there is no built spec -- a denial -- so that WHAT the model asked for is still judged.
+ */
+function cardSetFromToolArgs(toolArgs) {
+  if (!toolArgs || typeof toolArgs !== 'object') return [];
+  const cards = [];
+  for (const type of ['room', 'floorTile', 'hazard', 'resource', 'delver', 'warden']) {
+    for (const entry of Array.isArray(toolArgs[type]) ? toolArgs[type] : []) {
+      if (!entry || typeof entry !== 'object') continue;
+      const count = Number.isInteger(entry.count) && entry.count > 0 ? entry.count : 1;
+      cards.push({ type, count, affinity: entry.affinity });
+    }
+  }
+  return cards;
+}
+
+function scoreRun(runResult, scenario, refSpecPath, refReceiptPath, { outcome = null } = {}) {
   const breakdown = {};
   let points = 0;
 
@@ -292,18 +326,25 @@ function scoreRun(runResult, scenario, refSpecPath, refReceiptPath) {
     return { points, max: 100, breakdown };
   }
 
-  // Exec succeeded: 10 pts
-  if (runResult.execResult?.succeeded) {
-    points += 10;
-    breakdown.execSucceeded = 10;
-  } else {
-    breakdown.execSucceeded = 0;
-    return { points, max: 100, breakdown };
-  }
+  // Outcome matched expectation: 10 pts.
+  //
+  // Was `execSucceeded`, which rewarded a build for succeeding even when the scenario expected it to
+  // be denied -- backwards for the six that do -- and early-returned, ending scoring. Now it asks
+  // the question the scenario actually poses, and scoring continues either way.
+  const expected = scenario?.expectedOutcome || 'success';
+  const actual = outcome || (runResult.execResult?.succeeded ? 'success' : null);
+  const outcomeMatched = actual !== null && actual === expected;
+  points += outcomeMatched ? 10 : 0;
+  breakdown.outcomeMatched = outcomeMatched ? 10 : 0;
+  // Only a missing tool call stops scoring: there is no authored spec to judge.
+  const deniedAsExpected = outcomeMatched && expected !== 'success';
 
   const genSpecPath = runResult.outDir ? path.join(runResult.outDir, 'spec.json') : null;
   const genSpec = genSpecPath ? readJson(genSpecPath) : null;
-  const genCardSet = genSpec?.plan?.hints?.cardSet || [];
+  // A denied build writes no spec.json, but the authored intent is in the tool call itself. Prefer
+  // the built spec where it exists -- it is post-normalisation, so successful scenarios keep the
+  // scores they had -- and fall back to what was asked for when it does not.
+  const genCardSet = genSpec?.plan?.hints?.cardSet || cardSetFromToolArgs(runResult.toolArgs);
   let refTypes;
   let refCounts;
   let refAffinities;
@@ -377,7 +418,26 @@ function scoreRun(runResult, scenario, refSpecPath, refReceiptPath) {
   const genReceiptPath = runResult.outDir ? path.join(runResult.outDir, 'budget-receipt.json') : null;
   const genReceipt = genReceiptPath ? readJson(genReceiptPath) : null;
   const genSpend = genReceipt?.totalCost ?? null;
-  if (scenario?.budgetMode !== 'constrained') {
+  // A denial has a budget signal of its own: the refusal reports how far over it went. Being denied
+  // by 4 tokens shows a far better grasp of the economy than being denied by 400, and that
+  // distinction used to be discarded along with the rest of the score.
+  if (deniedAsExpected) {
+    const detail = `${runResult.execResult?.stdout || ''}${runResult.execResult?.stderr || ''}`;
+    const over = detail.match(/remaining=-(\d+)/) || detail.match(/minimum required spend is (\d+)/);
+    const budget = Number.isInteger(scenario?.budget) && scenario.budget > 0 ? scenario.budget : null;
+    if (over && budget) {
+      const overshoot = over[0].startsWith('remaining')
+        ? Number(over[1])
+        : Math.max(0, Number(over[1]) - budget);
+      // Full marks within 5% of the boundary, tapering to zero at 80% over -- the same shape the
+      // constrained branch below uses for spend accuracy.
+      const score = Math.round(10 * Math.max(0, 1 - Math.max(0, overshoot / budget - 0.05) / 0.8));
+      points += score;
+      breakdown.budgetDelta = score;
+    } else {
+      breakdown.budgetDelta = 0;
+    }
+  } else if (scenario?.budgetMode !== 'constrained') {
     breakdown.budgetDelta = genSpend !== null && genSpend > 0 ? 10 : 0;
     points += breakdown.budgetDelta;
   } else if (genSpend !== null && refSpend !== null && refSpend > 0) {

--- a/tools/remote-ollama-control/scripts/remote-ollama-mac.js
+++ b/tools/remote-ollama-control/scripts/remote-ollama-mac.js
@@ -1438,8 +1438,8 @@ async function runContentGen(options) {
             outDir: null
           };
         }
-        const scoreResult = scoreRun(runResult, scenario);
         const executionOutcome = classifyExecutionOutcome(runResult);
+        const scoreResult = scoreRun(runResult, scenario, undefined, undefined, { outcome: executionOutcome });
         return {
           timestamp: new Date().toISOString(),
           scenarioBudget: scenario.budget,


### PR DESCRIPTION
Six of the 100 catalog scenarios expect `budget_denied`. `scoreRun` returned early when the build did not succeed, so those six could never earn more than the 20-point tool-call gate — and, worse, were scored **blind**.

A model that authored exactly the right spec and one that authored nonsense both scored 20, provided both were denied. The verdict rate cannot separate them either, because it compares outcome labels only. **Correct authoring was unrewardable on 6% of the catalog.**

## Three changes

1. **`execSucceeded` → `outcomeMatched`.** The old gate paid 10 points for a build *succeeding* even when the scenario expected a denial — backwards for the six that do — and early-returned, ending scoring. It now asks the question the scenario poses, and scoring continues either way.
2. **The card set falls back to `toolArgs`** when there is no built spec. A denied build writes no `spec.json`, but what the model asked for is in the tool call regardless of affordability. The built spec is still preferred where it exists, so successful scenarios keep the scores they had.
3. **Budget delta gains a meaning for denials.** The refusal reports the overshoot: denied by 1 token shows a grasp of the economy that denied by 400 does not. Full marks within 5% of the boundary, tapering to zero at 80% over — the same shape the existing constrained branch uses.

`outcome` is passed in rather than derived: `classifyExecutionOutcome` lives in `ak-runner`, and deriving it here would make this module import its own caller.

## Measured, on the five hardest constrained scenarios

Authored by Opus 5, scored through the real pipeline (only generation substituted):

| scenario | expected | old | new |
|---|---|---|---|
| #93 Under Single Warden | denied | 20 | **100** |
| #92 Exact Single Warden | success | 94 | 94 |
| #96 Exact Two Room Route | success | 97 | 97 |
| #62 Floor Tile Guard Room | success | 74 | 74 |
| #99 Truncation Boundary | denied | 20 | **90** |
| **mean** | | **61.0** | **91.0** |

**Successful scenarios are unchanged** — that was the design constraint.

**And the blindness is gone.** Deliberately wrong specs that are also denied:

| | correct spec | wrong spec |
|---|---|---|
| #93 | 100 | **37** |
| #99 | 90 | **37** |

Both used to score exactly 20.

## Why now

This makes `averageScore >= 75` attainable across the whole catalog for the first time, which is a precondition for re-tuning the 0.96 verdict gate — otherwise that tuning happens against numbers that are about to move.

**Note:** this changes what historical scores mean. A run is in flight against the installed copy and will be scored under the old rules; the discontinuity is deliberate and coincides with the baseline reset already underway.

## Perturbation

Restoring the early return fails the wrong-spec and overshoot guards (2 of 5).

Gates: suite 440 files / 3405 passed / 207 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)