### PR TITLE
feat(benchmark): results say which scenarios failed, and a selector that uses it

### DIFF
--- a/tests/tools/scenario-selection.test.js
+++ b/tests/tools/scenario-selection.test.js
@@ -1,0 +1,61 @@
+const assert = require("node:assert/strict");
+const {
+  DEFAULT_POLICY, classify, selectScenarios,
+} = require("../../tools/remote-ollama-control/scripts/lib/scenario-selection");
+
+const rows = (spec) => spec.map(([i, rate, avgScore = 90]) => ({ i, tier: "t", n: 2, pass: 0, rate, avgScore }));
+
+// Selection is on MEASURED pass rate, never on the tier label. Measured 2026-08-24, four of six
+// configurations were non-monotonic across tiers -- qwen3-coder:30b scored 1.00 on `complex` and
+// 0.48 on `constrained` -- so a tier-driven selector would skip the wrong scenarios.
+test("scenarios are banded by measured pass rate, not by tier", () => {
+  const p = DEFAULT_POLICY;
+  assert.equal(classify({ rate: 0.0, avgScore: 10 }, p), "failing");
+  assert.equal(classify({ rate: 0.5, avgScore: 50 }, p), "discriminating");
+  assert.equal(classify({ rate: 1.0, avgScore: 40 }, p), "marginal", "a high pass rate with a poor score is about to break");
+  assert.equal(classify({ rate: 1.0, avgScore: 95 }, p), "healthy");
+});
+
+test("everything informative is selected and the settled majority is not", () => {
+  const r = selectScenarios(rows([[1, 0], [2, 0.5], [3, 1.0, 40], [4, 1.0, 95], [5, 1.0, 95]]), { runOrdinal: 1 });
+  for (const i of [1, 2, 3]) assert.ok(r.selected.includes(i), `scenario ${i} is informative and must be run`);
+  assert.ok(r.selected.length < 5, "a run that selects everything has selected nothing");
+});
+
+// Running only what fails is how a suite goes blind: the set self-selects toward the hard cases and
+// nothing notices the day a change breaks something that used to work.
+test("healthy scenarios rotate so every one is exercised across a period", () => {
+  const catalog = rows(Array.from({ length: 20 }, (_, n) => [n + 1, 1.0, 95]));
+  const seen = new Set();
+  for (let run = 0; run < DEFAULT_POLICY.rotationPeriod; run += 1) {
+    for (const i of selectScenarios(catalog, { runOrdinal: run }).selected) seen.add(i);
+  }
+  assert.equal(seen.size, 20,
+    "every healthy scenario must be covered within one rotation, or regressions in the passing set go undetected");
+});
+
+test("selection is deterministic — the same inputs give the same subset", () => {
+  const catalog = rows([[1, 0], [2, 0.5], [3, 1.0], [4, 1.0], [5, 1.0]]);
+  const a = selectScenarios(catalog, { runOrdinal: 2 });
+  const b = selectScenarios(catalog, { runOrdinal: 2 });
+  assert.deepEqual(a.selected, b.selected);
+  assert.equal(a.scenarioSubsetHash, b.scenarioSubsetHash);
+});
+
+// A subset is not the catalog. Naming its identity `scenarioSetHash` would let a reader compare a
+// selected run against a full baseline, which is comparing different questions.
+test("a subset carries its own identity, never a scenarioSetHash", () => {
+  const r = selectScenarios(rows([[1, 0], [2, 0.5]]), {});
+  assert.ok(r.scenarioSubsetHash, "a subset run must be identifiable");
+  assert.ok(!("scenarioSetHash" in r), "a subset must never present itself as a full catalog identity");
+  const other = selectScenarios(rows([[1, 0], [2, 0.5], [3, 0.4]]), {});
+  assert.notEqual(r.scenarioSubsetHash, other.scenarioSubsetHash, "different subsets must be distinguishable");
+});
+
+// No silent caps: what was left out travels with what was selected.
+test("what was excluded is reported, not dropped", () => {
+  const r = selectScenarios(rows([[1, 0], [2, 1.0, 95], [3, 1.0, 95]]), { runOrdinal: 0 });
+  const accounted = r.selected.length + r.excluded.length;
+  assert.equal(accounted, 3, "every scenario must be either selected or explicitly excluded");
+  for (const e of r.excluded) assert.equal(typeof e.rate, "number", "an exclusion states the rate that justified it");
+});

--- a/tools/remote-ollama-control/scripts/lib/ak-compare.js
+++ b/tools/remote-ollama-control/scripts/lib/ak-compare.js
@@ -58,6 +58,47 @@ function canStillQualify(records, { remainingAttempts = 0, thresholds = DEFAULT_
     && ((score + (remainingAttempts * 100)) / Math.max(1, finalTotal)) >= thresholds.averageScore;
 }
 
+/**
+ * Per-scenario outcomes, compact enough to publish.
+ *
+ * The published record carried tier AGGREGATES and nothing finer, so "which scenarios does this
+ * configuration actually fail?" could not be answered from evidence -- only from runs.jsonl on the
+ * box, which is deliberately never published. That makes every selective-run strategy impossible:
+ * you cannot re-run the problematic scenarios, or skip the ones a model always passes, without
+ * knowing which those are.
+ *
+ * Tier labels are not a substitute. Measured on 2026-08-24, four of six configurations were
+ * NON-MONOTONIC across tiers -- qwen3-coder:30b scored 1.00 on `complex` and 0.48 on `constrained`,
+ * and qwen3.8:27b found `affinity` easier than `simple`. Difficulty is a property of the
+ * model-scenario pair, not of the label.
+ *
+ * One row per scenario, aggregated over repeats: attempts, passes, mean score. That is what a
+ * selector needs and roughly 100 short rows per configuration -- kilobytes against a branch that
+ * was carrying 15.9 MB of source until it was cleaned.
+ */
+function perScenarioAggregate(records) {
+  const byIndex = new Map();
+  for (const record of records) {
+    const index = record.scenarioIndex;
+    if (!Number.isInteger(index)) continue;
+    const row = byIndex.get(index) || { i: index, tier: record.scenarioTier, n: 0, pass: 0, score: 0 };
+    row.n += 1;
+    if (record.scenarioVerdict?.passed) row.pass += 1;
+    row.score += record.score || 0;
+    byIndex.set(index, row);
+  }
+  return [...byIndex.values()]
+    .sort((left, right) => left.i - right.i)
+    .map((row) => ({
+      i: row.i,
+      tier: row.tier,
+      n: row.n,
+      pass: row.pass,
+      rate: ratio(row.pass, row.n),
+      avgScore: round1(row.score / Math.max(1, row.n)),
+    }));
+}
+
 function tierAggregate(records) {
   const output = {};
   for (const record of records) {
@@ -121,6 +162,8 @@ function aggregateContentGenResults(records, {
       historicalContentGen,
       scenarioVerdict: { pass: verdictPass, total: attempts.length, rate: ratio(verdictPass, attempts.length) },
       perTier: tierAggregate(attempts),
+      // The finer grain the tier aggregate cannot provide. Selective runs are driven from this.
+      perScenario: perScenarioAggregate(attempts),
       verdict: { qualifies: failedGates.length === 0, failedGates }
     };
   });

--- a/tools/remote-ollama-control/scripts/lib/scenario-selection.js
+++ b/tools/remote-ollama-control/scripts/lib/scenario-selection.js
@@ -1,0 +1,92 @@
+'use strict';
+
+/**
+ * Which scenarios are worth running against a given configuration?
+ *
+ * A full matrix run is 100 scenarios x every configuration x up to 3 passes. Most of that buys
+ * nothing on a frequent cadence: a scenario a configuration passes every time, and one it fails
+ * every time, each yield almost no information per attempt. Information peaks where the pass rate
+ * is near 0.5 -- the ordinary result from adaptive testing, and the reason this selects on MEASURED
+ * pass rate rather than on the tier label.
+ *
+ * Tier labels cannot do this job. Measured 2026-08-24, four of six configurations were
+ * NON-MONOTONIC across tiers: qwen3-coder:30b scored 1.00 on `complex` and 0.48 on `constrained`;
+ * qwen3.8:27b found `affinity` easier than `simple`. "Complex" is not reliably harder than
+ * "constrained", and the ordering differs per model, so difficulty is a property of the
+ * model-scenario pair and has to be measured.
+ *
+ * TWO THINGS THIS DELIBERATELY DOES NOT DO.
+ *
+ * It does not replace the qualification run. `minimumSuccessfulConfiguration` reports the cheapest
+ * configuration that qualifies, which is a comparison ACROSS configurations and only means anything
+ * if every configuration answered the same questions. Selecting per configuration makes verdict
+ * rates incomparable, so a selected run is for development signal and carries its own identity to
+ * keep the two apart.
+ *
+ * It does not drop the healthy scenarios entirely. Running only what fails is how a suite goes
+ * blind to regressions: the set self-selects toward the hard cases and nothing notices the day a
+ * change breaks something that used to work. `rotating` keeps every scenario in circulation. It is
+ * also what protects the canary signal -- models.json keeps qwen3.5:9b because "a uniform drop
+ * across the whole matrix says harness, not model", and that only works while the weak model still
+ * runs the easy scenarios.
+ */
+
+const crypto = require('crypto');
+
+const DEFAULT_POLICY = Object.freeze({
+  // The discriminating band. Outside it, an attempt mostly confirms what is already known.
+  lowerRate: 0.2,
+  upperRate: 0.8,
+  // A scenario that passes but scores poorly is the one about to break; worth watching even at a
+  // high pass rate.
+  marginalScore: 60,
+  // Healthy scenarios are rotated so the whole catalog is covered every `rotationPeriod` runs.
+  rotationPeriod: 5,
+});
+
+function classify(row, policy) {
+  if (row.rate <= policy.lowerRate) return 'failing';
+  if (row.rate < policy.upperRate) return 'discriminating';
+  if (row.avgScore < policy.marginalScore) return 'marginal';
+  return 'healthy';
+}
+
+/**
+ * @param {Array} perScenario rows as published by ak-compare's perScenarioAggregate
+ * @param {number} runOrdinal which focused run this is; rotates the healthy slice
+ */
+function selectScenarios(perScenario, { runOrdinal = 0, policy = {} } = {}) {
+  const settings = { ...DEFAULT_POLICY, ...policy };
+  const rows = Array.isArray(perScenario) ? [...perScenario].sort((a, b) => a.i - b.i) : [];
+  const bands = { failing: [], discriminating: [], marginal: [], healthy: [] };
+  for (const row of rows) bands[classify(row, settings)].push(row.i);
+
+  // Deterministic round-robin over the healthy set: slice `runOrdinal mod period`, so every healthy
+  // scenario is exercised once per full rotation and the choice never depends on a random seed.
+  const period = Math.max(1, settings.rotationPeriod);
+  const rotating = bands.healthy.filter((_, position) => position % period === runOrdinal % period);
+
+  const selected = [...new Set([...bands.failing, ...bands.discriminating, ...bands.marginal, ...rotating])]
+    .sort((left, right) => left - right);
+
+  return {
+    selected,
+    bands: {
+      failing: bands.failing.length,
+      discriminating: bands.discriminating.length,
+      marginal: bands.marginal.length,
+      healthy: bands.healthy.length,
+      rotating: rotating.length,
+    },
+    // Never reported as a scenarioSetHash: a subset is not the catalog, and a reader that compared
+    // the two would be comparing different questions. Its own name, so the difference is loud.
+    scenarioSubsetHash: crypto.createHash('sha256')
+      .update(JSON.stringify({ contract: 'scenario-subset-v1', selected }))
+      .digest('hex'),
+    // No silent caps: what was left out, and why, travels with what was selected.
+    excluded: rows.filter((row) => !selected.includes(row.i)).map((row) => ({ i: row.i, rate: row.rate })),
+    policy: settings,
+  };
+}
+
+module.exports = { DEFAULT_POLICY, classify, selectScenarios };


### PR DESCRIPTION
Step 1 of selective benchmarking, plus the primitive that consumes it.

## Why it was impossible before

The published record carried **tier aggregates and nothing finer**. "Which scenarios does this configuration fail?" could only be answered from `runs.jsonl` on the box, which is deliberately never published — so every selective strategy was blocked on evidence that did not exist.

`perScenario` now publishes one row per scenario: attempts, passes, rate, mean score. Kilobytes, against a branch that was carrying 15.9 MB of source until this morning.

## Why tier labels cannot drive it

Measured on the 2026-08-24 run, **four of six configurations are non-monotonic across tiers**:

| configuration | simple | affinity | complex | constrained |
|---|---|---|---|---|
| qwen3:14b primary | 0.96 | 0.84 | **0.88** | 0.52 |
| qwen3.8:27b primary | 0.92 | **0.96** | 0.72 | **0.80** |
| qwen3.8:27b dual | 1.00 | 0.96 | 0.84 | **0.86** |
| qwen3-coder:30b dual | 1.00 | 0.96 | **1.00** | 0.48 |

`qwen3-coder:30b` scores **1.00 on complex and 0.48 on constrained**. "Complex" is not reliably harder than "constrained", and the ordering differs per model. Difficulty is a property of the model-scenario **pair** — a tier-driven selector would skip the wrong scenarios.

## What the selector does

Bands by measured pass rate: **failing**, **discriminating** (0.2–0.8, where an attempt actually informs), **marginal** (passing but scoring poorly — about to break), **healthy**. Selects the first three plus a rotating slice of the healthy set.

## Two things it deliberately does not do

**It does not replace the qualification run.** `minimumSuccessfulConfiguration` reports the cheapest configuration that qualifies — a comparison *across* configurations, meaningless unless each answered the same questions. A selected run carries a `scenarioSubsetHash` and **never** a `scenarioSetHash`, so a subset cannot be compared against a full baseline.

**It does not drop the healthy scenarios.** Running only what fails is how a suite goes blind — the set self-selects toward the hard cases and nothing notices when a change breaks something that used to work. Rotation covers every scenario within one period. It also protects the canary: `models.json` keeps `qwen3.5:9b` because *"a uniform drop across the whole matrix says harness, not model"*, which only holds while the weak model still runs the easy scenarios.

Exclusions are reported with the rate that justified them. No silent caps.

## Not built yet, deliberately

**Quarantine** of scenarios that can never pass on a configuration. It needs consecutive-failure evidence at the *same* identity, and today's viability floor plus the denial-scoring change reset every prior judgement. The in-flight run is the first sample of the new economy and should seed it.

## Perturbation

Emptying the rotating band fails the regression-coverage guard.

Gates: suite 441 files / 3411 passed / 207 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)