### PR TITLE
docs: a benchmark is a discovery instrument, not a test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,34 @@ Tests verify correctness; benchmarks verify that the LLM tool-call surface holds
 
 Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`).
 
+🔴 **A benchmark is a discovery instrument, not a test suite. Never use one to catch what a
+deterministic test can catch.**
+
+A full run costs ~14 hours across six GPU configurations and answers non-deterministically. Most of
+what it surfaces is not model behaviour at all — it is a property of the code that holds or fails
+whichever model is driving. Measured on run `2026-08-28T17-48-28`, of 173 failures only two classes
+genuinely required a model:
+
+| question | needs a model? |
+|---|---|
+| does the schema advertise a shape the CLI rejects? | no — a pure function of schema and parser |
+| is a required enum missing? is a grammar unparseable? | no |
+| what is the minimum spend for this spec? does the tile budget suffice? | no — arithmetic |
+| can a hazard be placed in a room of this size? | no — geometry |
+| should a parser-level 500 abort the run? | no — policy |
+| **does the model CHOOSE a valid shape?** | **yes** |
+| **can the model budget under pressure?** | **yes** |
+
+So: when a run surfaces a failure, the question is *which property should have caught this*, and the
+answer belongs in `pnpm run test` where it fails in seconds. A recorded `toolArgs` that broke
+something is a free, non-synthetic fixture — replay it through
+`normalizeToolArgs → buildArgv → ak create` with no LLM. Do not hand-write such a case: a
+hand-written sample passes against a defective schema too, which makes it a mirror of the defect
+rather than a guard on it.
+
+A fix is proven by a deterministic test flipping red to green. Re-run a benchmark only to ask
+whether model BEHAVIOUR changed — never to ask whether the code is correct now.
+
 **There are two kinds of benchmark run, and only one of them is outside the development process.**
 
 ### Local debug runs — IN the loop (maintainer, 2026-08-25)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ pnpm run demo:cli                                     # CLI demo
 
 **There is no CI test job.** `.github/workflows/` holds only the `@claude` responder and an advisory PR review. The gates above are local and are the only ones that run — see `AGENTS.md → Review`.
 
-**Benchmarks are outside development** (maintainer, 2026-08-13): a standalone offline tool. Never run one from a session, never gate a diff on one. Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`). Read results rather than producing them — fetch `benchmark-results` and use `benchmark-result-reader.js` (`latest_attempt` for current health, `latest_success` for the last qualifying baseline; identity mismatch is an error). Full rule in `AGENTS.md → Benchmark strategy`.
+**Benchmarks never substitute for tests.** If a benchmark run surfaced it and a deterministic test could have, the fix is the test — a recorded failing `toolArgs` replays with no LLM. **Full-scale remote runs stay outside development** (maintainer, 2026-08-13): never start one from a session, never gate a diff on one. **Local `--local` subset runs are in the loop** (maintainer, 2026-08-25) for debugging code deltas, never as a gate, and `scripts/benchmark-preflight.sh` first. Canonical content-gen scenario count: 100 (source: `loadScenarioCatalog()`). Read results rather than producing them — fetch `benchmark-results` and use `benchmark-result-reader.js` (`latest_attempt` for current health, `latest_success` for the last qualifying baseline; identity mismatch is an error). Full rule in `AGENTS.md → Benchmark strategy`.
 
 ---
 
@@ -188,7 +188,7 @@ Run on every diff. **Fix failures — don't just flag them.** The guards in `tes
 
 **Types** — `pnpm run typecheck` stays at zero (gate: `tsconfig.typecheck.json`, enforced by `tests/architecture/typecheck-gate.test.js`). The gate covers **core-ts and its tests only** — the code genuinely clean under `strict`. Do not widen it casually: the five `_shared/*.mts` modules carry **180 errors** that leak into every scope importing them, so widening is a fix-first project, not a config change. ⚠️ `checkJs` is **off**, so an all-`.js` package reports 0 because there is nothing to check — read the file count the report prints alongside.
 
-**Tests** — failing tests written *before* production code · new behavior covered under `tests/` · deterministic behavior uses fixtures · negative cases under `tests/fixtures/artifacts/invalid/` · no test hits live external services · base test file ends with `## TODO: Test Permutations` before Ollama handoff · persona behavior tests live in `tests/personas/<persona>/` named `<persona>-<behavior>.test.*` · label-only persona tests are legacy: replace with a behavior test, then remove — never before.
+**Tests** — failing tests written *before* production code · new behavior covered under `tests/` · anything a benchmark surfaced that a deterministic test could catch is landed as that test, not left to the next run · deterministic behavior uses fixtures · negative cases under `tests/fixtures/artifacts/invalid/` · no test hits live external services · base test file ends with `## TODO: Test Permutations` before Ollama handoff · persona behavior tests live in `tests/personas/<persona>/` named `<persona>-<behavior>.test.*` · label-only persona tests are legacy: replace with a behavior test, then remove — never before.
 
 **Code quality** — every changed line traces to the current milestone spec (no drive-by cleanup) · not over-engineered · assumptions stated before implementation.
 


### PR DESCRIPTION
Records in both governing documents that benchmarks must not stand in for deterministic tests — each in its **owning scope**, so neither restates the other (`AGENTS.md` owns test and benchmark strategy; `CLAUDE.md` owns the enforcement checklist).

## The rule

A full run costs ~14 hours across six GPU configurations and answers non-deterministically. Of the 173 failures in run `2026-08-28T17-48-28`, only **two classes genuinely required a model**:

| question | needs a model? |
|---|---|
| does the schema advertise a shape the CLI rejects? | no — pure function of schema and parser |
| is a required enum missing? is a grammar unparseable? | no |
| what is the minimum spend? does the tile budget suffice? | no — arithmetic |
| can a hazard be placed in a room of this size? | no — geometry |
| should a parser-level 500 abort the run? | no — policy |
| **does the model CHOOSE a valid shape?** | **yes** |
| **can the model budget under pressure?** | **yes** |

Everything else holds or fails whichever model is driving, and belongs in `pnpm run test` where it fails in seconds.

A recorded `toolArgs` that broke something is a **free, non-synthetic fixture** — replay it through `normalizeToolArgs → buildArgv → ak create` with no LLM. Hand-writing such a case instead is how the earlier resource-schema tests became tautological: a hand-written sample passes against a defective schema too, making it a mirror of the defect rather than a guard on it.

A fix is proven by a deterministic test flipping red to green. Re-run a benchmark only to ask whether model *behaviour* changed.

## Also corrects a stale rule

`CLAUDE.md` still said benchmarks are outside development with no qualification. That has contradicted `AGENTS.md` since local `--local` subset runs were brought into the loop on 2026-08-25. A doc that contradicts another doc is blocking by this repo's own checklist.

Gates: suite 441 files / 3411 passed / 207 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)