### PR TITLE
fix(benchmark): error-message quality sweep across the ak_create surface

### DIFF
--- a/error-message-quality-sweep-worklist.json
+++ b/error-message-quality-sweep-worklist.json
@@ -1,0 +1,826 @@
+{
+  "total": 136,
+  "counts": {
+    "has-interpolation": 105,
+    "no-interpolation": 20,
+    "needs-manual-read": 11
+  },
+  "sites": [
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 354,
+      "disposition": "has-interpolation",
+      "message": "${label} priority must be one of: ${Array.from(AUTHORING_GOAL_PRIORITIES).join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 360,
+      "disposition": "has-interpolation",
+      "message": "${label} goal must be non-empty."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 370,
+      "disposition": "has-interpolation",
+      "message": "${label} goal \"${raw}\" is invalid."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 409,
+      "disposition": "has-interpolation",
+      "message": "${label} goal \"${raw}\" is not supported. Use max_mana[:priority], mana_regen[:priority], or maximize_spend[:priority]."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 610,
+      "disposition": "has-interpolation",
+      "message": "${label} must be a positive integer."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 618,
+      "disposition": "has-interpolation",
+      "message": "${label} must be a non-negative integer."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 626,
+      "disposition": "has-interpolation",
+      "message": "${actorType}[${actorIndex}] affinity[${affinityIndex}] is empty."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 630,
+      "disposition": "has-interpolation",
+      "message": "${actorType}[${actorIndex}] affinity[${affinityIndex}] must be kind[:expression[:stacks]]."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 635,
+      "disposition": "has-interpolation",
+      "message": "${actorType}[${actorIndex}] affinity[${affinityIndex}] has invalid affinity kind \"${parts[0]}\"."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 640,
+      "disposition": "has-interpolation",
+      "message": "${actorType}[${actorIndex}] affinity[${affinityIndex}] has invalid affinity expression \"${parts[1]}\"."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 690,
+      "disposition": "has-interpolation",
+      "message": "${actorType}[${actorIndex}] vital[${index + 1}] must be vital:max:regen or vital:current:max:regen."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 694,
+      "disposition": "has-interpolation",
+      "message": "${actorType}[${actorIndex}] vital[${index + 1}] has invalid vital kind \"${parts[0]}\"."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 710,
+      "disposition": "has-interpolation",
+      "message": "${actorType}[${actorIndex}] vital[${index + 1}] current cannot exceed max."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 720,
+      "disposition": "has-interpolation",
+      "message": "room[${roomIndex}] requires a non-empty spec."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 727,
+      "disposition": "has-interpolation",
+      "message": "room[${roomIndex}] requires at least one field."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 734,
+      "disposition": "has-interpolation",
+      "message": "room[${roomIndex}] segment \"${segment}\" is invalid; expected key=value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 744,
+      "disposition": "has-interpolation",
+      "message": "room[${roomIndex}] field \"${key}\" is not supported — rooms are generic containers; use --hazard to place affinity in a room."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 747,
+      "disposition": "has-interpolation",
+      "message": "room[${roomIndex}] field \"${key}\" is not supported."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 750,
+      "disposition": "has-interpolation",
+      "message": "room[${roomIndex}] field \"${key}\" requires a value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 757,
+      "disposition": "has-interpolation",
+      "message": "room[${roomIndex}] size must be one of: ${ROOM_CARD_SIZE_IDS.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 774,
+      "disposition": "no-interpolation",
+      "message": "room-plan requires at least one --room entry."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 782,
+      "disposition": "has-interpolation",
+      "message": "floor-tile[${floorTileIndex}] requires a non-empty spec."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 789,
+      "disposition": "has-interpolation",
+      "message": "floor-tile[${floorTileIndex}] requires at least one field."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 794,
+      "disposition": "has-interpolation",
+      "message": "floor-tile[${floorTileIndex}] segment \"${segment}\" is invalid; expected key=value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 800,
+      "disposition": "has-interpolation",
+      "message": "floor-tile[${floorTileIndex}] field \"${key}\" is not supported."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 803,
+      "disposition": "has-interpolation",
+      "message": "floor-tile[${floorTileIndex}] field \"${key}\" requires a value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 810,
+      "disposition": "has-interpolation",
+      "message": "floor-tile[${floorTileIndex}] requires count=<n>."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 847,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] vital[${index + 1}] must be vital:max:regen or vital:current:max:regen."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 851,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] vital[${index + 1}] has invalid vital kind \"${parts[0]}\"."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 867,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] vital[${index + 1}] current cannot exceed max."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 879,
+      "disposition": "has-interpolation",
+      "message": "${label} must be true or false."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 885,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] requires a non-empty spec."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 892,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] requires at least one field."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 897,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] segment \"${segment}\" is invalid; expected key=value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 903,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] field \"${key}\" is not supported."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 906,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] field \"${key}\" requires a value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 913,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] affinity must be one of: ${ALLOWED_AFFINITIES.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 917,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] expression must be one of: ${ALLOWED_AFFINITY_EXPRESSIONS.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 976,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] ${field} current cannot exceed max."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 980,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] ${field} must be a plain amount, one-time:<amount>, or regen:<current>:<max>:<regen>; got \"${value}\"."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1048,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] requires a non-empty spec."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1054,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] requires at least one field."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1058,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] segment \"${segment}\" is invalid; expected key=value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1064,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] field \"${key}\" is not supported."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1067,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] field \"${key}\" requires a value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1072,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] affinity must be one of: ${ALLOWED_AFFINITIES.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1075,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] expression must be one of: ${ALLOWED_AFFINITY_EXPRESSIONS.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1078,
+      "disposition": "has-interpolation",
+      "message": "hazard[${hazardIndex}] proximityRadius is required."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1106,
+      "disposition": "no-interpolation",
+      "message": "hazard-plan requires at least one --hazard entry."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1160,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] affinity must be one of: ${[...RESOURCE_ALLOWED_AFFINITY_KINDS].join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1164,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] expression is required for an affinity payload."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1167,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] expression must be one of: ${[...RESOURCE_ALLOWED_AFFINITY_EXPRESSIONS].join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1173,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] manaRegen requires mana > 0 — regen would refill nothing."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1181,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] requires a non-empty spec."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1186,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] requires at least one field."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1204,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] segment \"${segment}\" is invalid; expected key=value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1210,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] field \"${key}\" is not supported in V3 spec."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1213,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] field \"${key}\" requires a value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1222,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] requires a vital payload, an affinity payload, or both."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1238,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] permanenceMode is required for a vital payload (${because}); it governs how long the vital delta persists."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1242,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] permanenceMode must be one of: ${[...RESOURCE_ALLOWED_PERMANENCE_MODES].join(\", \")}; got \"${permanenceMode}\"."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1245,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] vital is required for a vital payload (${because}). For an affinity-only resource, omit ${trigger.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1249,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] vital must be one of: ${[...RESOURCE_ALLOWED_VITAL_KEYS].join(\", \")}; got \"${vitalKey}\"."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1253,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] delta is required unless regen is given."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1259,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] delta must be a number."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1289,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] segment \"${segment}\" is invalid; expected key=value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1295,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] field \"${key}\" is not supported."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1298,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] field \"${key}\" requires a value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1303,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] tier must be one of: ${[...RESOURCE_ALLOWED_TIERS].join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1306,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] stat must be one of: ${[...RESOURCE_ALLOWED_STATS].join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1309,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] delta is required."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1312,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] dropRate is required."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1316,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] delta must be a number."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1320,
+      "disposition": "has-interpolation",
+      "message": "resource[${resourceIndex}] dropRate must be a positive integer."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1337,
+      "disposition": "no-interpolation",
+      "message": "resource-plan requires at least one --resource entry."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1348,
+      "disposition": "has-interpolation",
+      "message": "delver[${delverIndex}] requires a non-empty spec."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1355,
+      "disposition": "has-interpolation",
+      "message": "delver[${delverIndex}] requires at least one field."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1367,
+      "disposition": "has-interpolation",
+      "message": "delver[${delverIndex}] motivation may only be specified once."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1372,
+      "disposition": "has-interpolation",
+      "message": "delver[${delverIndex}] segment \"${segment}\" is invalid; expected key=value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1379,
+      "disposition": "has-interpolation",
+      "message": "delver[${delverIndex}] field \"${key}\" is not supported."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1382,
+      "disposition": "has-interpolation",
+      "message": "delver[${delverIndex}] field \"${key}\" requires a value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1385,
+      "disposition": "has-interpolation",
+      "message": "delver[${delverIndex}] motivation may only be specified once."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1428,
+      "disposition": "no-interpolation",
+      "message": "delver-plan requires at least one --delver entry."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1436,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] requires a non-empty spec."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1443,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] requires at least one field."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1455,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] motivation may only be specified once."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1460,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] segment \"${segment}\" is invalid; expected key=value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1467,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] field \"${key}\" is not supported."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1470,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] field \"${key}\" requires a value."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1473,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] motivation may only be specified once."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1480,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] affinity must be one of: ${ALLOWED_AFFINITIES.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1485,
+      "disposition": "has-interpolation",
+      "message": "warden[${wardenIndex}] motivation must be one of: ${ALLOWED_MOTIVATIONS.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 1519,
+      "disposition": "no-interpolation",
+      "message": "warden-plan requires at least one --warden entry."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 4799,
+      "disposition": "has-interpolation",
+      "message": "${commandName} --dungeon-affinity must be one of: ${ALLOWED_AFFINITIES.join(\", \")}."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 4815,
+      "disposition": "has-interpolation",
+      "message": "${commandName} requires both --budget and --price-list."
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 4860,
+      "disposition": "has-interpolation",
+      "message": "duplicate_hazard: multiple hazards occupy room-relative position (${positionKey})"
+    },
+    {
+      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
+      "line": 4893,
+      "disposition": "has-interpolation",
+      "message": "${commandName} requires at least one authored object via --room, --floor-tile, --hazard, --resource, --delver, or --warden."
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 169,
+      "disposition": "has-interpolation",
+      "message": "Expected ${expectedSchema} artifact."
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 172,
+      "disposition": "has-interpolation",
+      "message": "Expected schema ${expectedSchema}, got ${artifact.schema || \"missing\"}."
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 175,
+      "disposition": "has-interpolation",
+      "message": "Expected schemaVersion 1 for ${expectedSchema}."
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 193,
+      "disposition": "has-interpolation",
+      "message": "${label} invalid: ${details}"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 422,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 476,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: no walkable tiles"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 483,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: spawn not walkable"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 493,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: no anchor points"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 505,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: insufficient walkable tiles"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 544,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: unresolved group placement"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1319,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: no walkable tiles"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1326,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: spawn not walkable"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1329,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: exit not walkable"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1363,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: insufficient entry-room tiles"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1380,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: insufficient room tiles for wardens"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1390,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs could not place actors: unresolved strategic placement"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1414,
+      "disposition": "no-interpolation",
+      "message": "orchestrateBuild requires spec"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1466,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs require actors when levelGen is provided."
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1494,
+      "disposition": "has-interpolation",
+      "message": "level-gen input invalid: ${details}"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1499,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs must include an actors array."
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1551,
+      "disposition": "no-interpolation",
+      "message": "configurator inputs require both affinityPresets and affinityLoadouts."
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1616,
+      "disposition": "has-interpolation",
+      "message": "Budget allocation invalid: ${details}"
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1680,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/build/orchestrate-build.js",
+      "line": 1684,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/allocator/budget-fulfillment.js",
+      "line": 434,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/allocator/state-machine.js",
+      "line": 110,
+      "disposition": "has-interpolation",
+      "message": "No transition for state=${state} event=${event}; allowed events: ${allowedEvents(state).join(\",\") || \"none\"}"
+    },
+    {
+      "file": "packages/runtime/src/personas/allocator/state-machine.js",
+      "line": 113,
+      "disposition": "has-interpolation",
+      "message": "Guard blocked transition for state=${state} event=${event}"
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/actor-authoring.js",
+      "line": 45,
+      "disposition": "has-interpolation",
+      "message": "delver[${index}] affinity must be one of: ${AFFINITY_KINDS.join(\", \")}."
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/actor-authoring.js",
+      "line": 50,
+      "disposition": "has-interpolation",
+      "message": "delver[${index}] motivation must be one of: ${MOTIVATION_KINDS.join(\", \")}."
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/actor-authoring.js",
+      "line": 59,
+      "disposition": "has-interpolation",
+      "message": "delver[${index}] setup-mode must be one of: ${DELVER_SETUP_MODES.join(\", \")}."
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/affinity-rules.js",
+      "line": 710,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/artifact-builders.js",
+      "line": 72,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
+      "line": 38,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
+      "line": 113,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
+      "line": 119,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
+      "line": 163,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/motivation-rules.js",
+      "line": 419,
+      "disposition": "needs-manual-read",
+      "message": null
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/state-machine.js",
+      "line": 69,
+      "disposition": "has-interpolation",
+      "message": "No transition for state=${state} event=${event}; allowed events: ${allowedEvents(state).join(\",\") || \"none\"}"
+    },
+    {
+      "file": "packages/runtime/src/personas/configurator/state-machine.js",
+      "line": 72,
+      "disposition": "has-interpolation",
+      "message": "Guard blocked transition for state=${state} event=${event}"
+    }
+  ]
+}

--- a/error-message-quality-sweep-worklist.json
+++ b/error-message-quality-sweep-worklist.json
@@ -130,7 +130,9 @@
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
       "line": 774,
       "disposition": "no-interpolation",
-      "message": "room-plan requires at least one --room entry."
+      "message": "room-plan requires at least one --room entry.",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "parseRoomSpecs is shared by roomPlanCommand AND agentAuthoringCommand (ak create), but hardcodes \"room-plan\" -- a model reaching this through create never called room-plan. Same pattern at 1106/1337/1428/1519."
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
@@ -298,7 +300,9 @@
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
       "line": 1106,
       "disposition": "no-interpolation",
-      "message": "hazard-plan requires at least one --hazard entry."
+      "message": "hazard-plan requires at least one --hazard entry.",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "parseHazardSpecs: same naming-leak pattern as 774 (\"hazard-plan\")."
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
@@ -454,7 +458,9 @@
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
       "line": 1337,
       "disposition": "no-interpolation",
-      "message": "resource-plan requires at least one --resource entry."
+      "message": "resource-plan requires at least one --resource entry.",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "parseResourceSpecs: same naming-leak pattern as 774 (\"resource-plan\")."
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
@@ -502,7 +508,9 @@
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
       "line": 1428,
       "disposition": "no-interpolation",
-      "message": "delver-plan requires at least one --delver entry."
+      "message": "delver-plan requires at least one --delver entry.",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "parseDelverSpecs: same naming-leak pattern as 774 (\"delver-plan\")."
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
@@ -562,7 +570,9 @@
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
       "line": 1519,
       "disposition": "no-interpolation",
-      "message": "warden-plan requires at least one --warden entry."
+      "message": "warden-plan requires at least one --warden entry.",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "parseWardenSpecs: same naming-leak pattern as 774 (\"warden-plan\")."
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
@@ -616,85 +626,113 @@
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 422,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "assignPositionedLayoutObjects -- already fixed in M4 (candidates.length/objects.length/index all reported)."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 476,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: no walkable tiles"
+      "message": "configurator inputs could not place actors: no walkable tiles",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositionsLegacy, no walkable tiles: actors.length (how many needed a spot) is in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 483,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: spawn not walkable"
+      "message": "configurator inputs could not place actors: spawn not walkable",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositionsLegacy, spawn not walkable: spawn.x/spawn.y are in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 493,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: no anchor points"
+      "message": "configurator inputs could not place actors: no anchor points",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositionsLegacy, no anchor points: groups.length and walkable.length are in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 505,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: insufficient walkable tiles"
+      "message": "configurator inputs could not place actors: insufficient walkable tiles",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositionsLegacy, insufficient walkable tiles: available.length/group.length/groupIndex are in scope -- the exact M4 pattern (candidates vs requested), not applied here."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 544,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: unresolved group placement"
+      "message": "configurator inputs could not place actors: unresolved group placement",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositionsLegacy, unresolved group placement: actor.id is in scope, not reported -- can't tell which actor failed."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1319,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: no walkable tiles"
+      "message": "configurator inputs could not place actors: no walkable tiles",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositions (current, non-legacy), no walkable tiles: actors.length is in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1326,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: spawn not walkable"
+      "message": "configurator inputs could not place actors: spawn not walkable",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositions, spawn not walkable: spawn.x/spawn.y are in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1329,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: exit not walkable"
+      "message": "configurator inputs could not place actors: exit not walkable",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositions, exit not walkable: exit.x/exit.y are in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1363,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: insufficient entry-room tiles"
+      "message": "configurator inputs could not place actors: insufficient entry-room tiles",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositions, insufficient entry-room tiles: index/delvers.length/context.entryRoomWalkable.length/used.size are in scope -- the exact M4 pattern, not applied here."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1380,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: insufficient room tiles for wardens"
+      "message": "configurator inputs could not place actors: insufficient room tiles for wardens",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositions, insufficient room tiles for wardens: actor.id and the candidate-set sizes are in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1390,
       "disposition": "no-interpolation",
-      "message": "configurator inputs could not place actors: unresolved strategic placement"
+      "message": "configurator inputs could not place actors: unresolved strategic placement",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "normalizeActorPositions, unresolved strategic placement: actor.id is in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1414,
       "disposition": "no-interpolation",
-      "message": "orchestrateBuild requires spec"
+      "message": "orchestrateBuild requires spec",
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "orchestrateBuild top-level `!spec` guard -- spec is an internal BuildSpec artifact, not raw model input; nothing else to say when it's simply absent."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1466,
       "disposition": "no-interpolation",
-      "message": "configurator inputs require actors when levelGen is provided."
+      "message": "configurator inputs require actors when levelGen is provided.",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "hasLevelGen && !hasActors: actorsInputRaw's actual shape (typeof / received value) is in scope, not reported -- can't distinguish \"omitted entirely\" from \"present but wrong shape\"."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
@@ -706,13 +744,17 @@
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1499,
       "disposition": "no-interpolation",
-      "message": "configurator inputs must include an actors array."
+      "message": "configurator inputs must include an actors array.",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "actorsInput.actors not an array: actorsInput's actual shape is in scope, not reported."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1551,
       "disposition": "no-interpolation",
-      "message": "configurator inputs require both affinityPresets and affinityLoadouts."
+      "message": "configurator inputs require both affinityPresets and affinityLoadouts.",
+      "sm1Disposition": "detail-dropped",
+      "sm1Note": "XOR check (affinityPresets, affinityLoadouts): the code already knows WHICH one is missing (the failing branch of the OR), message says \"requires both\" for either case."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
@@ -724,19 +766,25 @@
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1680,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "formatBudgetReceiptDenial() is already rich (status/remaining/deniedLines/deniedPools). Bonus finding, not a per-site issue: the helper's own deniedLines.slice(0, 5) is a silent cap with no \"+N more\" -- CLAUDE.md's own \"no silent caps\" rule, worth a one-line fix alongside SM2 even though this throw site itself needs no change."
     },
     {
       "file": "packages/runtime/src/build/orchestrate-build.js",
       "line": 1684,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "Same helper as 1680, same bonus finding (silent 5-item cap in the helper, not at this throw site)."
     },
     {
       "file": "packages/runtime/src/personas/allocator/budget-fulfillment.js",
       "line": 434,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "assertJudgementBudget -- already reports judged/cap/ceiling. Internal backstop (\"must never fire\"), not reachable from model input."
     },
     {
       "file": "packages/runtime/src/personas/allocator/state-machine.js",
@@ -772,43 +820,57 @@
       "file": "packages/runtime/src/personas/configurator/affinity-rules.js",
       "line": 710,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "Module-load-time assertion on the hardcoded DEFAULT_AFFINITY_RULES_ARTIFACT constant -- fires once at import, never from a create request. Already reports field:code for every error."
     },
     {
       "file": "packages/runtime/src/personas/configurator/artifact-builders.js",
       "line": 72,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "assertUniqueActorIds -- already includes the duplicate id when one exists; the id-missing case has nothing else to add."
     },
     {
       "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
       "line": 38,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "requireUnitCost -- already interpolates the specific missing price-list key."
     },
     {
       "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
       "line": 113,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "unitCosts instanceof Map guard -- an internal API-contract check between Configurator and Allocator modules, not reachable from model input (fires only if calling code passes the wrong type)."
     },
     {
       "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
       "line": 119,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "priceItems instanceof Map guard -- same as 113, internal API contract, not model-facing."
     },
     {
       "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
       "line": 163,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "Regen price missing -- already interpolates the specific missing regenKey."
     },
     {
       "file": "packages/runtime/src/personas/configurator/motivation-rules.js",
       "line": 419,
       "disposition": "needs-manual-read",
-      "message": null
+      "message": null,
+      "sm1Disposition": "fine-as-is",
+      "sm1Note": "Module-load-time assertion on the hardcoded DEFAULT_MOTIVATION_RULES_ARTIFACT constant -- same as affinity-rules.js:710, not model-facing, already reports field:code."
     },
     {
       "file": "packages/runtime/src/personas/configurator/state-machine.js",
@@ -822,5 +884,12 @@
       "disposition": "has-interpolation",
       "message": "Guard blocked transition for state=${state} event=${event}"
     }
-  ]
+  ],
+  "sm1": {
+    "countsAtSm1": {
+      "detail-dropped": 19,
+      "fine-as-is": 12
+    },
+    "note": "sm1Disposition/sm1Note only present on sites SM0 flagged (no-interpolation or needs-manual-read); has-interpolation sites were not re-triaged."
+  }
 }

--- a/error-message-quality-sweep-worklist.json
+++ b/error-message-quality-sweep-worklist.json
@@ -1,9 +1,9 @@
 {
-  "total": 136,
+  "total": 131,
   "counts": {
     "has-interpolation": 105,
-    "no-interpolation": 20,
-    "needs-manual-read": 11
+    "needs-manual-read": 11,
+    "no-interpolation": 15
   },
   "sites": [
     {
@@ -125,14 +125,6 @@
       "line": 757,
       "disposition": "has-interpolation",
       "message": "room[${roomIndex}] size must be one of: ${ROOM_CARD_SIZE_IDS.join(\", \")}."
-    },
-    {
-      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
-      "line": 774,
-      "disposition": "no-interpolation",
-      "message": "room-plan requires at least one --room entry.",
-      "sm1Disposition": "detail-dropped",
-      "sm1Note": "parseRoomSpecs is shared by roomPlanCommand AND agentAuthoringCommand (ak create), but hardcodes \"room-plan\" -- a model reaching this through create never called room-plan. Same pattern at 1106/1337/1428/1519."
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
@@ -298,14 +290,6 @@
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
-      "line": 1106,
-      "disposition": "no-interpolation",
-      "message": "hazard-plan requires at least one --hazard entry.",
-      "sm1Disposition": "detail-dropped",
-      "sm1Note": "parseHazardSpecs: same naming-leak pattern as 774 (\"hazard-plan\")."
-    },
-    {
-      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
       "line": 1160,
       "disposition": "has-interpolation",
       "message": "resource[${resourceIndex}] affinity must be one of: ${[...RESOURCE_ALLOWED_AFFINITY_KINDS].join(\", \")}."
@@ -456,14 +440,6 @@
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
-      "line": 1337,
-      "disposition": "no-interpolation",
-      "message": "resource-plan requires at least one --resource entry.",
-      "sm1Disposition": "detail-dropped",
-      "sm1Note": "parseResourceSpecs: same naming-leak pattern as 774 (\"resource-plan\")."
-    },
-    {
-      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
       "line": 1348,
       "disposition": "has-interpolation",
       "message": "delver[${delverIndex}] requires a non-empty spec."
@@ -503,14 +479,6 @@
       "line": 1385,
       "disposition": "has-interpolation",
       "message": "delver[${delverIndex}] motivation may only be specified once."
-    },
-    {
-      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
-      "line": 1428,
-      "disposition": "no-interpolation",
-      "message": "delver-plan requires at least one --delver entry.",
-      "sm1Disposition": "detail-dropped",
-      "sm1Note": "parseDelverSpecs: same naming-leak pattern as 774 (\"delver-plan\")."
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
@@ -565,14 +533,6 @@
       "line": 1485,
       "disposition": "has-interpolation",
       "message": "warden[${wardenIndex}] motivation must be one of: ${ALLOWED_MOTIVATIONS.join(\", \")}."
-    },
-    {
-      "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
-      "line": 1519,
-      "disposition": "no-interpolation",
-      "message": "warden-plan requires at least one --warden entry.",
-      "sm1Disposition": "detail-dropped",
-      "sm1Note": "parseWardenSpecs: same naming-leak pattern as 774 (\"warden-plan\")."
     },
     {
       "file": "packages/adapters-cli/src/cli/ak-impl.mjs",
@@ -887,8 +847,8 @@
   ],
   "sm1": {
     "countsAtSm1": {
-      "detail-dropped": 19,
-      "fine-as-is": 12
+      "fine-as-is": 12,
+      "detail-dropped": 14
     },
     "note": "sm1Disposition/sm1Note only present on sites SM0 flagged (no-interpolation or needs-manual-read); has-interpolation sites were not re-triaged."
   }

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -2,6 +2,14 @@
 
 **Status (2026-08-31):** all four milestones (SM0–SM3) complete. Phase one of the two-phase ordering
 below is done; phase two (resilience) has not started, per the maintainer's own ordering.
+A drift guard now enforces phase one going forward: `tests/architecture/ak-create-error-message-drift.test.js`
+re-runs the SM0 survey tool (refactored to export `surveyErrorMessages()` for in-process reuse,
+no file-write side effect on import) against current source and fails on any new no-detail throw
+site on the ak_create surface, or a stale allowlist entry. The 19 currently-known exceptions (12
+genuine "nothing more to say" sites plus 7 concatenated-template-literal / helper-function sites the
+classifier can't parse as interpolated) are recorded with reasons in
+`tests/architecture/ak-create-error-detail-allowlist.json`. Perturbation-tested both directions: a
+bare-string throw injected into scope fails the guard; a stale allowlist entry also fails it.
 **Audience:** an agent with no memory of the session that produced it.
 **Source of evidence:** `coding-issues-affecting-benchmarking.md` (M3/M4, merged as
 [PR #131](https://github.com/KomplexMojo/agent-kernel/pull/131) /

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -1,7 +1,8 @@
 # Error message quality sweep
 
-**Status:** plan, not yet started. **Audience:** an agent with no memory of the session that
-produced it.
+**Status (2026-08-31):** all four milestones (SM0–SM3) complete. Phase one of the two-phase ordering
+below is done; phase two (resilience) has not started, per the maintainer's own ordering.
+**Audience:** an agent with no memory of the session that produced it.
 **Source of evidence:** `coding-issues-affecting-benchmarking.md` (M3/M4, merged as
 [PR #131](https://github.com/KomplexMojo/agent-kernel/pull/131) /
 [PR #132](https://github.com/KomplexMojo/agent-kernel/pull/132)) and a follow-up 17-scenario local
@@ -225,7 +226,7 @@ change) and verified by the full suite staying green (446 files / 3471 passed, +
 baseline, unaffected otherwise). But "kept and verified-safe" is a weaker claim than "tested", and
 this plan says so rather than blurring the two.
 
-### SM3 — Verify against the benchmark corpus and a fresh local run
+### SM3 — Verify against the benchmark corpus and a fresh local run (2026-08-31)
 
 **Do:** replay `tests/fixtures/benchmark-failures/` — dispositions shouldn't change (these are
 diagnostic fixes, not behavior fixes), but every replayed error should now carry more detail. Run a
@@ -234,6 +235,34 @@ that failing scenarios' error text is now richer.
 
 **Acceptance:** replay corpus stays green at the same 2 harness-defect / 39 model-error / 2
 not-replayable split. No regressions.
+
+**Corpus replay: confirmed unchanged, as expected.** All 43 fixtures still split exactly 2
+harness-defect / 39 model-error / 2 not-replayable — SM2's fixes are diagnostic-only, so no
+disposition should move, and none did. Worth noting explicitly: **none of the 43 recorded fixtures
+exercise the actor-placement code path SM2 fixed.** The original 173-failure reference run never
+recorded an actor-placement failure — that whole family (11 sites) was invisible to the benchmark
+that produced this corpus and was found only by the systematic sweep, not by replaying recorded
+history. This is exactly the finding this plan opened with, reconfirmed: M4 fixed hazard/resource
+placement because THAT failure showed up in the recorded run; the actor-placement twin sat unfixed
+because nothing had recorded a failure against it yet.
+
+**Fresh local run: 9/9 clean, 0 failures.** Same 9 actor-dense scenarios (9, 13, 20, 22, 24, 45, 50,
+60, 89 — chosen for authoring multiple delvers/wardens, up to `scenario 22`'s declared eleven
+actors), `qwen3.8:27b` (the `mac` profile's own default model, matching the earlier 17-scenario
+run). Average score 77.3/100, every scenario reached `Verdict: pass`, `Exec: ok` — including
+scenario 22's eleven-actor stress test at 70/100.
+
+**Honest reading of a negative result, not a disappointing one:** this run doesn't demonstrate
+richer error text in the wild, because nothing failed to produce error text to examine. That's
+consistent with the corpus-replay finding above (the actor-placement family never showed up in 800
+recorded attempts either) — at this model/configuration, the placement algorithm has enough headroom
+that the specific under-specification pattern M3/M4 found for floor-tile/hazard placement doesn't
+reproduce the same way for actors within a modest 9-scenario sample. The dedicated reproductions in
+`tests/integration/create-actor-placement-refusal-detail.test.js` remain the actual proof the fixes
+work — real `ak create` calls, not mocks, just deliberately constructed rather than naturally
+occurring in this sample. A larger or differently-tiered sample might surface a natural case; not
+run here, matching this plan's own restraint about not inflating a small local debug run into more
+than it is.
 
 ---
 

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -1,0 +1,130 @@
+# Error message quality sweep
+
+**Status:** plan, not yet started. **Audience:** an agent with no memory of the session that
+produced it.
+**Source of evidence:** `coding-issues-affecting-benchmarking.md` (M3/M4, merged as
+[PR #131](https://github.com/KomplexMojo/agent-kernel/pull/131) /
+[PR #132](https://github.com/KomplexMojo/agent-kernel/pull/132)) and a follow-up 17-scenario local
+benchmark run (`tools/remote-ollama-control/results/2026-08-31T16-03-25-552Z-content-gen/`).
+
+---
+
+## The governing principle: structured detail, not string collapse
+
+M3 and M4 fixed three unrelated-looking bugs that turned out to be the **same bug**:
+
+1. `resource[N].vital` rejected `[object Object]` — the model's payload got coerced to a string
+   before the parser could say what it actually received.
+2. `floor_tile_budget_insufficient` — `level-layout.js` computed a rich detail object
+   (`{target, required, roomCount, minPerRoom}`) and the caller in `orchestrate-build.js` discarded
+   all of it, keeping only `field:code`.
+3. `insufficient unoccupied walkable tiles` — `candidates.length`/`objects.length`/`index` were all
+   live in scope at the throw site and none of them reached the message.
+
+**Every one of these is the same shape: a structured value existed, and something between where it
+was computed and where it was displayed collapsed it to a string too early, dropping the parts that
+would have made the failure diagnosable — either by a human, or by a model trying to correct itself
+on a retry.** Finding these by accident three times in one plan is a signal there are more.
+
+**This is not "read 142 messages and make them nicer."** The mechanical signal to hunt is narrower
+and cheaper to check per-site: *does this throw site have other local variables or a computed detail
+object that isn't in the message?* A message with no interpolation at all (88 of 253 sweep-wide, per
+the scoping survey) is the entry point for that question, not the answer to it — most of those are
+argument-presence checks (`"room-plan requires at least one --room entry."`) with nothing to add.
+
+**Do not build a shared error-formatting abstraction speculatively.** The instinct from this
+principle is "introduce a `RichError`/`buildError({code, field, detail})` helper everything throws
+through, and have telemetry capture the structured form instead of `.message`." That is a legitimate
+direction — but it is an architecture change touching every throw site in scope, not a message
+sweep, and it should be proposed with a concrete design after the sweep has data on how many sites
+actually need it, not designed up front on three examples.
+
+---
+
+## Scope: the `ak create` model-facing surface, not the whole codebase
+
+The codebase has 468 `throw new Error(` sites across `core-ts`/`runtime`/`adapters-cli`. Almost all
+of them are unreachable from a single `ak_create` call (simulation-tick internals, other CLI
+subcommands like `room-plan`/`llm-plan`/`narrate` the benchmark never exercises). Scoping to what a
+model authoring through `ak_create` can actually trigger:
+
+| area | file(s) | throw sites |
+|---|---|---|
+| entity-spec parsers | `ak-impl.mjs` (`parseRoomSpec` @717 through `parseWardenSpecs` @1514, plus `parseOptimizationGoalEntry`/`List`, `parseActorVitals`, `parseActorAffinities`) | 99 |
+| authoring command body | `ak-impl.mjs` `agentAuthoringCommand` (@4779) / `createCommand` (@5244) | 4 |
+| build/level-gen orchestration | `orchestrate-build.js` | 24 |
+| Configurator persona | `personas/configurator/*.js` (6 files) | 11 |
+| Allocator persona | `personas/allocator/*.js` (2 files) | 3 |
+| **total in scope** | | **141** |
+
+This is where M3/M4's bugs lived, and it is the only layer whose messages a model (or a future
+re-prompt loop) would ever see. **Do not expand scope to the other ~326 sites without new evidence
+that a model can reach them through `ak_create`.**
+
+---
+
+## Milestones
+
+### SM0 — Mechanically list the 141 sites and flag zero-interpolation ones (S)
+
+**Do:** extend the survey script used to scope this plan (currently a scratch file, not committed)
+into a small, committed tool under `tools/` that walks the five file/function ranges above, extracts
+each `throw new Error(...)` site (file:line, message literal), and flags which have zero `${...}`
+interpolation. Output a structured worklist (JSON), not prose.
+
+**Acceptance:** every one of the 141 sites appears exactly once in the worklist, tagged
+`has-interpolation` or `no-interpolation`. No silent exclusions — if a throw site's message can't be
+statically extracted (multi-line construction, computed via helper), it goes in the worklist as
+`needs-manual-read`, not dropped.
+
+### SM1 — Triage: for each no-interpolation / needs-manual-read site, is there dropped detail? (M)
+
+**Do:** read the function body around each flagged site (not just the throw line). Classify:
+- **fine-as-is** — no other computed data exists in scope; the message is already everything there
+  is to say (most argument-presence checks land here).
+- **detail-dropped** — local variables or a computed object exist that aren't in the message (the
+  M3/M4 bug shape). This is the fix list.
+- **needs-new-computation** — the message SHOULD say more, but nothing useful is computed yet (e.g.,
+  it would need a new capacity calculation, not just surfacing an existing one). Record separately;
+  do not fix speculatively — matches M4's restraint on `floorTile.count`'s description.
+
+**Acceptance:** every flagged site has a disposition and, for `detail-dropped`, a one-line note of
+what's being dropped. No bucket labelled `other`.
+
+### SM2 — Fix the `detail-dropped` bucket, batched by area, one perturbation-tested commit per batch (S–M per batch)
+
+**Do:** for each `detail-dropped` site, thread the existing local data into the message (matching the
+M3/M4 pattern exactly — no new computation, just stop discarding what's already there). Batch by the
+table's five areas so each commit stays reviewable. Every fix gets a test asserting the new detail
+appears, proven by `git stash`-perturbation the same way M3/M4/M5 did.
+
+**Trap:** do not describe a field by contrasting it with another field's shape or type in an ERROR
+MESSAGE either, for the same reason the schema-description trap exists — a message that says "unlike
+X, this wants Y" primes the next attempt toward the same confusion it's naming.
+
+**Acceptance:** `pnpm run test` and `pnpm run typecheck` green after each batch. No behavior change
+— these are diagnostic-only, like M4's placement/floor-tile fixes, so no A/B measurement is required.
+
+### SM3 — Verify against the benchmark corpus and a fresh local run
+
+**Do:** replay `tests/fixtures/benchmark-failures/` — dispositions shouldn't change (these are
+diagnostic fixes, not behavior fixes), but every replayed error should now carry more detail. Run a
+small local `--local` benchmark subset (matching the 17-scenario series already run) and spot-check
+that failing scenarios' error text is now richer.
+
+**Acceptance:** replay corpus stays green at the same 2 harness-defect / 39 model-error / 2
+not-replayable split. No regressions.
+
+---
+
+## Explicitly out of scope
+
+- **The 326 throw sites outside the `ak_create` surface** (§Scope) — no evidence a model reaches
+  them; revisit only if new evidence says otherwise.
+- **A shared structured-error/`buildError()` helper** — the governing principle's own caution: design
+  it after SM1's data exists, not before, and treat it as its own plan with its own maintainer
+  sign-off (it's an architecture change, not a message fix).
+- **Piping structured errors through the Annotator persona for telemetry** — a real, separate
+  direction raised alongside this plan (capture the structured `{code, field, detail}` shape, not
+  the stringified message, so this bug class can't recur by construction). Worth its own design
+  discussion once SM0/SM1 show how many sites would actually feed it.

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -61,19 +61,16 @@ model authoring through `ak_create` can actually trigger:
 
 | area | file(s) | throw sites |
 |---|---|---|
-| entity-spec parsers + authoring command body | `ak-impl.mjs` (named-function scan: `parseRoomSpec` through `parseWardenSpecs`, `parseOptimizationGoalEntry`/`List`, `parseActorVitals`, `parseActorAffinities`, `agentAuthoringCommand`, `createCommand`) | 97 |
+| entity-spec parsers + authoring command body | `ak-impl.mjs` (named-function scan: the singular `parseXSpec` family actually called from `agentAuthoringCommand`/`createCommand`, plus `parseOptimizationGoalEntry`/`List`, `parseActorVitals`, `parseActorAffinities`) | 92 |
 | build/level-gen orchestration | `orchestrate-build.js` | 24 |
 | Configurator persona | `personas/configurator/*.js` (6 files) | 12 |
 | Allocator persona | `personas/allocator/*.js` (2 files) | 3 |
-| **total in scope** | | **136** |
+| **total in scope** | | **131** |
 
-(Corrected by SM0's committed scan, which bounds each named function by brace-depth rather than a
-hand-counted line range — the original 141 estimate came from a cruder `grep -c` over an
-approximate line span, which over-counted by including code between the named functions that isn't
-actually part of them.)
+(Corrected twice now — see SM0 and the SM2 correction below for what each fix was.)
 
 This is where M3/M4's bugs lived, and it is the only layer whose messages a model (or a future
-re-prompt loop) would ever see. **Do not expand scope to the other ~332 sites without new evidence
+re-prompt loop) would ever see. **Do not expand scope to the other ~337 sites without new evidence
 that a model can reach them through `ak_create`.**
 
 ---
@@ -96,18 +93,13 @@ mistook the parameter list's brace for the body's, truncating the scan and silen
 (111 sites instead of the real 136). Fixed by matching the parameter list's parens first, then
 looking for the body's opening brace only after that closes.
 
-**Result:** 136 sites, all classified, none dropped — `error-message-quality-sweep-worklist.json`.
+**Result at SM0 time:** 136 sites, all classified, none dropped — `error-message-quality-sweep-worklist.json`.
 105 `has-interpolation`, 20 `no-interpolation`, 11 `needs-manual-read` (multi-line or
 helper-constructed messages the static scan can't safely classify — SM1 reads these directly, they
 are not excluded).
 
-**Two findings already visible from the worklist, ahead of SM1's full triage:**
-- **A naming leak, not a dropped-detail bug:** `parseRoomSpecs`/`parseHazardSpecs`/
-  `parseResourceSpecs`/`parseDelverSpecs`/`parseWardenSpecs` are shared helpers reachable from both
-  their own standalone `X-plan` command AND `ak create` — but each one's empty-list message hardcodes
-  the standalone command's name (`"room-plan requires at least one --room entry."`). A model that
-  hit this through `create` never called `room-plan`. Five sites, one shared pattern, likely one
-  clean SM2 batch.
+**One finding already visible from the worklist, ahead of SM1's full triage** (a second candidate
+finding here turned out to be a scoping mistake — corrected below rather than silently dropped):
 - **A whole untouched parallel family:** `orchestrate-build.js` has ~11 `"configurator inputs could
   not place actors: ..."` messages (`no walkable tiles`, `spawn not walkable`, `insufficient
   entry-room tiles`, `insufficient room tiles for wardens`, `unresolved strategic placement`, …) in
@@ -131,10 +123,13 @@ are not excluded).
 **Acceptance:** every flagged site has a disposition and, for `detail-dropped`, a one-line note of
 what's being dropped. No bucket labelled `other`.
 
-**Done:** all 31 flagged sites read and classified (`error-message-quality-sweep-worklist.json`'s
+**Done:** every flagged site read and classified (`error-message-quality-sweep-worklist.json`'s
 `sm1Disposition`/`sm1Note` fields; a hard check refuses to write the file unless every flagged site
-got one). **19 `detail-dropped`, 12 `fine-as-is`, 0 `needs-new-computation`** — every dropped-detail
-case had the missing value already sitting in local scope; none needed a new calculation.
+got one). At first pass: 19 `detail-dropped`, 12 `fine-as-is`, 0 `needs-new-computation` across 31
+sites. **Corrected during SM2** (see below) to **14 `detail-dropped`, 12 `fine-as-is`** across 26
+sites, after 5 of the 19 turned out to be a scope mistake, not a real finding. Every remaining
+dropped-detail case had the missing value already sitting in local scope; none needed a new
+calculation.
 
 **The `fine-as-is` sites cluster into two honest reasons**, worth naming so SM2 doesn't second-guess
 them later: (a) several are module-load-time assertions on hardcoded constants
@@ -144,19 +139,30 @@ model's `ak_create` call, not merely "unlikely"; (b) the rest already interpolat
 worth saying (`requireUnitCost`, `assertUniqueActorIds`, `formatBudgetReceiptDenial`,
 `assignPositionedLayoutObjects` — M4's own fix).
 
-**The `detail-dropped` bucket has three shapes, giving SM2 its natural batches:**
+**Correction found at the start of SM2, before any fix landed:** the five sites originally called a
+"naming leak" (`parseRoomSpecs`/`parseHazardSpecs`/`parseResourceSpecs`/`parseDelverSpecs`/
+`parseWardenSpecs`, each hardcoding a standalone `X-plan` command's name) turned out to be **not
+reachable from `ak create` at all**. Tracing actual call sites: `agentAuthoringCommand` parses each
+entity inline via `normalizeList(args.room).map(parseRoomSpec)` etc. — the SINGULAR form, never the
+PLURAL "at least one entry" wrapper. Every plural wrapper's only caller is its own standalone
+command (`parseRoomSpecs` → only `roomPlanCommand`, confirmed by grep, one call site each). Two of
+the plural wrappers (`parseFloorTileSpecs`, `parsePlacedHazardSpecs`) have *zero* call sites anywhere
+— dead code, a different concern entirely. SM0's scope list had assumed "plural wrapper" implied
+"also used by create" from naming symmetry with the singular forms, without verifying the call
+graph — exactly the kind of assumption this plan itself warns against. Corrected: removed the 7
+plural functions from the survey tool's scope, re-ran it (131 sites, not 136), redid SM1's
+disposition count (14 `detail-dropped`, not 19). Not fixing these 5 sites — they're out of scope by
+the plan's own rule, not merely deprioritized.
 
-1. **Naming leak (5 sites, `ak-impl.mjs`)** — `parseRoomSpecs`/`parseHazardSpecs`/
-   `parseResourceSpecs`/`parseDelverSpecs`/`parseWardenSpecs` are shared by their own standalone
-   `X-plan` command and by `ak create`, but each hardcodes the standalone command's name in its
-   empty-list message. A model that hit this through `create` never called `room-plan`.
-2. **Actor placement, the M4 pattern never propagated here (11 sites, `orchestrate-build.js`)** —
+**The remaining `detail-dropped` bucket has two shapes, giving SM2 its real batches:**
+
+1. **Actor placement, the M4 pattern never propagated here (11 sites, `orchestrate-build.js`)** —
    both `normalizeActorPositions` (current) and `normalizeActorPositionsLegacy` have their own
    near-duplicate "could not place actors: ..." family, none of them reporting the
    candidates/requested/index-style detail M4 already added to the hazard/resource placement path
-   (`assignPositionedLayoutObjects`). The single largest batch, and the strongest confirmation the
-   sweep is finding real gaps, not re-describing the three already known.
-3. **Misc build-guard detail (3 sites, `orchestrate-build.js`)** — `hasActors`/`actorsInput.actors`
+   (`assignPositionedLayoutObjects`). The largest batch, and the strongest confirmation the sweep
+   finds real gaps, not just re-describing the three already known.
+2. **Misc build-guard detail (3 sites, `orchestrate-build.js`)** — `hasActors`/`actorsInput.actors`
    type guards that could report what shape was actually received, and an XOR check
    (`affinityPresets`/`affinityLoadouts`) that already knows which one is missing but says "requires
    both" either way.

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -7,6 +7,17 @@ produced it.
 [PR #132](https://github.com/KomplexMojo/agent-kernel/pull/132)) and a follow-up 17-scenario local
 benchmark run (`tools/remote-ollama-control/results/2026-08-31T16-03-25-552Z-content-gen/`).
 
+**Where this sits (maintainer, 2026-08-31):** two phases, in this order — **first deterministic
+accuracy, then resilience.** The benchmark stays one-shot, deliberately: a single try per scenario is
+what makes a harness bug obvious (the same request fails the same way every time until the code is
+fixed), and a retry-until-success loop would let a model paper over a real gap by trial and error
+instead of surfacing it. This plan is entirely phase one — it makes the error each one-shot failure
+produces comprehensive enough to keep feeding the existing loop (benchmark discovers → M0-style
+fixture harvest → deterministic test → fix the harness). Phase two — a **resilience** layer that,
+only once a failure is *confirmed* pure model weakness (not fixable in the harness), retries the same
+request against a different model using the failure detail this plan captures — is out of scope here
+and not designed yet; see `## Explicitly out of scope`.
+
 ---
 
 ## The governing principle: structured detail, not string collapse
@@ -128,3 +139,10 @@ not-replayable split. No regressions.
   direction raised alongside this plan (capture the structured `{code, field, detail}` shape, not
   the stringified message, so this bug class can't recur by construction). Worth its own design
   discussion once SM0/SM1 show how many sites would actually feed it.
+- **A cross-model resilience/fallback layer** (maintainer, 2026-08-31) — for a failure already
+  confirmed pure model weakness (harness-fix avenue exhausted, disposition `model-error` with no
+  further fix possible), retry the same request against a *different* model, feeding it the failure
+  detail this plan captures. Explicitly phase two: does not start until phase one (this plan) is
+  done and the harness-fixable failures in a given batch are actually fixed, not merely identified.
+  The one-shot benchmark methodology itself does not change — this is a production/deployment-facing
+  recovery path, not a benchmark retry loop, and it is not designed here beyond this pointer.

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -61,32 +61,61 @@ model authoring through `ak_create` can actually trigger:
 
 | area | file(s) | throw sites |
 |---|---|---|
-| entity-spec parsers | `ak-impl.mjs` (`parseRoomSpec` @717 through `parseWardenSpecs` @1514, plus `parseOptimizationGoalEntry`/`List`, `parseActorVitals`, `parseActorAffinities`) | 99 |
-| authoring command body | `ak-impl.mjs` `agentAuthoringCommand` (@4779) / `createCommand` (@5244) | 4 |
+| entity-spec parsers + authoring command body | `ak-impl.mjs` (named-function scan: `parseRoomSpec` through `parseWardenSpecs`, `parseOptimizationGoalEntry`/`List`, `parseActorVitals`, `parseActorAffinities`, `agentAuthoringCommand`, `createCommand`) | 97 |
 | build/level-gen orchestration | `orchestrate-build.js` | 24 |
-| Configurator persona | `personas/configurator/*.js` (6 files) | 11 |
+| Configurator persona | `personas/configurator/*.js` (6 files) | 12 |
 | Allocator persona | `personas/allocator/*.js` (2 files) | 3 |
-| **total in scope** | | **141** |
+| **total in scope** | | **136** |
+
+(Corrected by SM0's committed scan, which bounds each named function by brace-depth rather than a
+hand-counted line range — the original 141 estimate came from a cruder `grep -c` over an
+approximate line span, which over-counted by including code between the named functions that isn't
+actually part of them.)
 
 This is where M3/M4's bugs lived, and it is the only layer whose messages a model (or a future
-re-prompt loop) would ever see. **Do not expand scope to the other ~326 sites without new evidence
+re-prompt loop) would ever see. **Do not expand scope to the other ~332 sites without new evidence
 that a model can reach them through `ak_create`.**
 
 ---
 
 ## Milestones
 
-### SM0 — Mechanically list the 141 sites and flag zero-interpolation ones (S)
+### SM0 — Mechanically list the sites and flag zero-interpolation ones (S — complete, 2026-08-31)
 
-**Do:** extend the survey script used to scope this plan (currently a scratch file, not committed)
-into a small, committed tool under `tools/` that walks the five file/function ranges above, extracts
-each `throw new Error(...)` site (file:line, message literal), and flags which have zero `${...}`
-interpolation. Output a structured worklist (JSON), not prose.
+**Done:** `tools/benchmark/survey-ak-create-error-messages.mjs`. Scope is defined by function NAME,
+not line range (a lesson from this repo's own history of drift-prone second homes for a value) —
+each named function's body is bounded by a brace-depth scan from its declaration, string/template/
+comment-aware, so the tool stays correct as the file grows. Whole-file scan for
+`orchestrate-build.js` and the Configurator/Allocator persona files, where every throw is already on
+the `ak_create` path.
 
-**Acceptance:** every one of the 141 sites appears exactly once in the worklist, tagged
-`has-interpolation` or `no-interpolation`. No silent exclusions — if a throw site's message can't be
-statically extracted (multi-line construction, computed via helper), it goes in the worklist as
-`needs-manual-read`, not dropped.
+**Bug found and fixed while building it:** the first version located a function's body by finding
+the first `{` after its name — which breaks for `parseDelverSpec`/`parseWardenSpec`, whose parameter
+lists have their OWN `{` from a destructured default (`{ defaultAffinity = ... } = {}`). That
+mistook the parameter list's brace for the body's, truncating the scan and silently undercounting
+(111 sites instead of the real 136). Fixed by matching the parameter list's parens first, then
+looking for the body's opening brace only after that closes.
+
+**Result:** 136 sites, all classified, none dropped — `error-message-quality-sweep-worklist.json`.
+105 `has-interpolation`, 20 `no-interpolation`, 11 `needs-manual-read` (multi-line or
+helper-constructed messages the static scan can't safely classify — SM1 reads these directly, they
+are not excluded).
+
+**Two findings already visible from the worklist, ahead of SM1's full triage:**
+- **A naming leak, not a dropped-detail bug:** `parseRoomSpecs`/`parseHazardSpecs`/
+  `parseResourceSpecs`/`parseDelverSpecs`/`parseWardenSpecs` are shared helpers reachable from both
+  their own standalone `X-plan` command AND `ak create` — but each one's empty-list message hardcodes
+  the standalone command's name (`"room-plan requires at least one --room entry."`). A model that
+  hit this through `create` never called `room-plan`. Five sites, one shared pattern, likely one
+  clean SM2 batch.
+- **A whole untouched parallel family:** `orchestrate-build.js` has ~11 `"configurator inputs could
+  not place actors: ..."` messages (`no walkable tiles`, `spawn not walkable`, `insufficient
+  entry-room tiles`, `insufficient room tiles for wardens`, `unresolved strategic placement`, …) in
+  what looks like a SEPARATE actor-placement algorithm (`normalizeActorPositions`) from the
+  hazard/resource placement M4 already fixed (`assignPositionedLayoutObjects`). None of these were
+  touched by M4 — the fix landed for hazards/resources and never propagated to actors. This is the
+  single strongest piece of evidence yet that the sweep finds real, unfixed instances of the same bug
+  class, not just re-confirming the three already known.
 
 ### SM1 — Triage: for each no-interpolation / needs-manual-read site, is there dropped detail? (M)
 

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -174,7 +174,7 @@ CLAUDE.md's own "no silent caps" rule, on a message this session read closely th
 (M0–M2) without anyone noticing the cap. One-line fix, worth bundling into SM2's placement batch
 since it's the same file and the same spirit of fix.
 
-### SM2 — Fix the `detail-dropped` bucket, batched by area, one perturbation-tested commit per batch (S–M per batch)
+### SM2 — Fix the `detail-dropped` bucket, batched by area, one perturbation-tested commit per batch (S–M per batch — complete, 2026-08-31)
 
 **Do:** for each `detail-dropped` site, thread the existing local data into the message (matching the
 M3/M4 pattern exactly — no new computation, just stop discarding what's already there). Batch by the
@@ -188,9 +188,11 @@ X, this wants Y" primes the next attempt toward the same confusion it's naming.
 **Acceptance:** `pnpm run test` and `pnpm run typecheck` green after each batch. No behavior change
 — these are diagnostic-only, like M4's placement/floor-tile fixes, so no A/B measurement is required.
 
-**Batch 1 done (2026-08-31), `orchestrate-build.js` — all 14 `detail-dropped` sites plus the bonus
-`formatBudgetReceiptDenial` cap fix, one commit.** Threaded existing local data into every message,
-matching the M4 pattern exactly:
+**All of it landed in one batch (2026-08-31) — `orchestrate-build.js`, all 14 `detail-dropped` sites
+plus the bonus `formatBudgetReceiptDenial` cap fix.** After the naming-leak correction removed the
+only `ak-impl.mjs` findings, and Configurator/Allocator had zero `detail-dropped` sites from SM1,
+`orchestrate-build.js` turned out to be the entire fix list — there was no second batch to do.
+Threaded existing local data into every message, matching the M4 pattern exactly:
 - 11 actor-placement sites (both `normalizeActorPositions` and `normalizeActorPositionsLegacy`) now
   report the same candidates/requested/index-style detail M4 already gave hazard/resource placement.
 - 3 misc build guards now report the actual value received or which of two required fields is

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -117,7 +117,7 @@ are not excluded).
   single strongest piece of evidence yet that the sweep finds real, unfixed instances of the same bug
   class, not just re-confirming the three already known.
 
-### SM1 — Triage: for each no-interpolation / needs-manual-read site, is there dropped detail? (M)
+### SM1 — Triage: for each no-interpolation / needs-manual-read site, is there dropped detail? (M — complete, 2026-08-31)
 
 **Do:** read the function body around each flagged site (not just the throw line). Classify:
 - **fine-as-is** — no other computed data exists in scope; the message is already everything there
@@ -130,6 +130,43 @@ are not excluded).
 
 **Acceptance:** every flagged site has a disposition and, for `detail-dropped`, a one-line note of
 what's being dropped. No bucket labelled `other`.
+
+**Done:** all 31 flagged sites read and classified (`error-message-quality-sweep-worklist.json`'s
+`sm1Disposition`/`sm1Note` fields; a hard check refuses to write the file unless every flagged site
+got one). **19 `detail-dropped`, 12 `fine-as-is`, 0 `needs-new-computation`** — every dropped-detail
+case had the missing value already sitting in local scope; none needed a new calculation.
+
+**The `fine-as-is` sites cluster into two honest reasons**, worth naming so SM2 doesn't second-guess
+them later: (a) several are module-load-time assertions on hardcoded constants
+(`affinity-rules.js:710`, `motivation-rules.js:419`) or internal API-contract guards between
+Configurator/Allocator modules (`budget-maximizer.js:113/119`) — genuinely unreachable from a
+model's `ak_create` call, not merely "unlikely"; (b) the rest already interpolate the one thing
+worth saying (`requireUnitCost`, `assertUniqueActorIds`, `formatBudgetReceiptDenial`,
+`assignPositionedLayoutObjects` — M4's own fix).
+
+**The `detail-dropped` bucket has three shapes, giving SM2 its natural batches:**
+
+1. **Naming leak (5 sites, `ak-impl.mjs`)** — `parseRoomSpecs`/`parseHazardSpecs`/
+   `parseResourceSpecs`/`parseDelverSpecs`/`parseWardenSpecs` are shared by their own standalone
+   `X-plan` command and by `ak create`, but each hardcodes the standalone command's name in its
+   empty-list message. A model that hit this through `create` never called `room-plan`.
+2. **Actor placement, the M4 pattern never propagated here (11 sites, `orchestrate-build.js`)** —
+   both `normalizeActorPositions` (current) and `normalizeActorPositionsLegacy` have their own
+   near-duplicate "could not place actors: ..." family, none of them reporting the
+   candidates/requested/index-style detail M4 already added to the hazard/resource placement path
+   (`assignPositionedLayoutObjects`). The single largest batch, and the strongest confirmation the
+   sweep is finding real gaps, not re-describing the three already known.
+3. **Misc build-guard detail (3 sites, `orchestrate-build.js`)** — `hasActors`/`actorsInput.actors`
+   type guards that could report what shape was actually received, and an XOR check
+   (`affinityPresets`/`affinityLoadouts`) that already knows which one is missing but says "requires
+   both" either way.
+
+**Bonus finding, not a per-site fix:** `formatBudgetReceiptDenial()` (the helper both budget-denial
+throw sites call, `orchestrate-build.js:1680`/`:1684`) is already excellent — except
+`deniedLines.slice(0, 5)` silently caps the list with no "+N more" when there are more than 5. That's
+CLAUDE.md's own "no silent caps" rule, on a message this session read closely three separate times
+(M0–M2) without anyone noticing the cap. One-line fix, worth bundling into SM2's placement batch
+since it's the same file and the same spirit of fix.
 
 ### SM2 — Fix the `detail-dropped` bucket, batched by area, one perturbation-tested commit per batch (S–M per batch)
 

--- a/error-message-quality-sweep.md
+++ b/error-message-quality-sweep.md
@@ -188,6 +188,41 @@ X, this wants Y" primes the next attempt toward the same confusion it's naming.
 **Acceptance:** `pnpm run test` and `pnpm run typecheck` green after each batch. No behavior change
 — these are diagnostic-only, like M4's placement/floor-tile fixes, so no A/B measurement is required.
 
+**Batch 1 done (2026-08-31), `orchestrate-build.js` — all 14 `detail-dropped` sites plus the bonus
+`formatBudgetReceiptDenial` cap fix, one commit.** Threaded existing local data into every message,
+matching the M4 pattern exactly:
+- 11 actor-placement sites (both `normalizeActorPositions` and `normalizeActorPositionsLegacy`) now
+  report the same candidates/requested/index-style detail M4 already gave hazard/resource placement.
+- 3 misc build guards now report the actual value received or which of two required fields is
+  missing.
+- Bonus: `formatBudgetReceiptDenial()`'s `deniedLines.slice(0, 5)` now says `(+N more)` when it caps.
+
+**Only 5 of the 15 fixes got a genuine, non-contrived reproduction — and that's an honest number,
+not a shortfall to paper over.** Two actor-placement cases (too many delvers for the entry room, too
+many wardens for the room) and the denied-lines cap all reproduce through a real `ak create` call,
+perturbation-verified (`git stash` the fix, watch all 5 tests fail, restore). Two of the three misc
+guards are tested directly against `orchestrateBuild` with a hand-built spec, since `ak create`'s own
+parsing can never produce the malformed state they guard against (`hasActors` is always true;
+`agentAuthoringCommand` always constructs an array). **The third misc guard and the remaining 9
+actor-placement sites are not independently tested at all**, for two different reasons worth keeping
+distinct:
+- The `actorsInput.actors` guard turned out to be doubly defensive: attempting to trigger it revealed
+  `mapBuildSpecToArtifacts`'s own schema validation already rejects a non-array
+  `configurator.inputs.actors` before this guard's check ever runs, for any spec built through normal
+  validation. Confirmed by trying — got `"BuildSpec validation failed: configurator.inputs.actors:
+  expected array"` instead of this fix's message.
+- The other 9 (`no walkable tiles` / `spawn not walkable` / `exit not walkable` /
+  `unresolved strategic placement`, in both the current and Legacy placement functions) are
+  defensive backstops behind the carving algorithm's own guarantee (a minimum walkable interior per
+  room, spawn/exit chosen from the walkable set) — the same shape as
+  `assertJudgementBudget`'s "must never fire" comment found during SM1. No `ak create` input reaches
+  them without that upstream guarantee already having broken.
+
+All 15 fixes are kept regardless — they're low-risk (pure message formatting, no control-flow
+change) and verified by the full suite staying green (446 files / 3471 passed, +5 tests from
+baseline, unaffected otherwise). But "kept and verified-safe" is a weaker claim than "tested", and
+this plan says so rather than blurring the two.
+
 ### SM3 — Verify against the benchmark corpus and a fresh local run
 
 **Do:** replay `tests/fixtures/benchmark-failures/` — dispositions shouldn't change (these are

--- a/packages/runtime/src/build/orchestrate-build.js
+++ b/packages/runtime/src/build/orchestrate-build.js
@@ -134,14 +134,18 @@ function formatBudgetReceiptDenial(receipt) {
     `status=${receipt?.status}`,
     `remaining=${receipt?.remaining}`,
   ];
-  const deniedLines = Array.isArray(receipt?.lineItems)
-    ? receipt.lineItems
-      .filter((item) => item?.status !== "approved")
-      .slice(0, 5)
-      .map((item) => `${item.kind}:${item.id}${item.category ? `:${item.category}` : ""}`)
+  const allDeniedItems = Array.isArray(receipt?.lineItems)
+    ? receipt.lineItems.filter((item) => item?.status !== "approved")
     : [];
+  const deniedLines = allDeniedItems
+    .slice(0, 5)
+    .map((item) => `${item.kind}:${item.id}${item.category ? `:${item.category}` : ""}`);
   if (deniedLines.length > 0) {
-    parts.push(`deniedLines=${deniedLines.join(",")}`);
+    // SM2: the 5-item cap kept the message from growing unbounded, but never said it was capping
+    // -- a silent truncation on a message this session read closely three times without anyone
+    // noticing the missing "+N more".
+    const omitted = allDeniedItems.length - deniedLines.length;
+    parts.push(`deniedLines=${deniedLines.join(",")}${omitted > 0 ? ` (+${omitted} more)` : ""}`);
   }
   const deniedPools = Array.isArray(receipt?.poolStatuses)
     ? receipt.poolStatuses
@@ -473,14 +477,17 @@ function normalizeActorPositionsLegacy(actors, layout) {
   const data = layout?.data || layout;
   const walkable = collectWalkablePositions(layout);
   if (!data || walkable.length === 0) {
-    throw new Error("configurator inputs could not place actors: no walkable tiles");
+    throw new Error(
+      `configurator inputs could not place actors: no walkable tiles (0 available, `
+      + `${actors.length} actor${actors.length === 1 ? "" : "s"} to place).`,
+    );
   }
 
   const walkableSet = new Set(walkable.map(positionKey));
   const spawn = data.spawn || layout?.spawn || null;
   const spawnKey = spawn ? positionKey(spawn) : null;
   if (spawnKey && !walkableSet.has(spawnKey)) {
-    throw new Error("configurator inputs could not place actors: spawn not walkable");
+    throw new Error(`configurator inputs could not place actors: spawn (${spawn.x}, ${spawn.y}) not walkable.`);
   }
 
   const groups = createActorGroups(actors, { supportPerLeader: 3 });
@@ -490,7 +497,10 @@ function normalizeActorPositionsLegacy(actors, layout) {
     spawn: spawnKey && spawn ? { x: spawn.x, y: spawn.y } : null,
   });
   if (anchors.length === 0) {
-    throw new Error("configurator inputs could not place actors: no anchor points");
+    throw new Error(
+      `configurator inputs could not place actors: no anchor points `
+      + `(${groups.length} group${groups.length === 1 ? "" : "s"}, ${walkable.length} walkable tiles).`,
+    );
   }
 
   const used = new Set();
@@ -502,7 +512,10 @@ function normalizeActorPositionsLegacy(actors, layout) {
     const anchor = anchors[Math.min(groupIndex, anchors.length - 1)];
     const available = walkable.filter((pos) => !used.has(positionKey(pos)));
     if (available.length < group.length) {
-      throw new Error("configurator inputs could not place actors: insufficient walkable tiles");
+      throw new Error(
+        `configurator inputs could not place actors: insufficient walkable tiles for group `
+        + `${groupIndex} (${available.length} available, ${group.length} requested).`,
+      );
     }
     const sorted = sortPositionsByAnchorDistance(available, anchor);
     group.forEach((entry, memberIndex) => {
@@ -541,7 +554,7 @@ function normalizeActorPositionsLegacy(actors, layout) {
     const desired = actor?.position;
     const assigned = assignedById.get(actor.id);
     if (!assigned) {
-      throw new Error("configurator inputs could not place actors: unresolved group placement");
+      throw new Error(`configurator inputs could not place actors: unresolved group placement for actor "${actor.id}".`);
     }
     if (!desired || desired.x !== assigned.x || desired.y !== assigned.y) {
       changed = true;
@@ -1316,17 +1329,20 @@ function normalizeActorPositions(actors, layout, { delverCount = 1 } = {}) {
   const data = layout?.data || layout;
   const walkable = collectWalkablePositions(layout);
   if (!data || walkable.length === 0) {
-    throw new Error("configurator inputs could not place actors: no walkable tiles");
+    throw new Error(
+      `configurator inputs could not place actors: no walkable tiles (0 available, `
+      + `${actors.length} actor${actors.length === 1 ? "" : "s"} to place).`,
+    );
   }
 
   const walkableSet = new Set(walkable.map(positionKey));
   const spawn = data.spawn || layout?.spawn || null;
   const exit = data.exit || layout?.exit || null;
   if (spawn && !walkableSet.has(positionKey(spawn))) {
-    throw new Error("configurator inputs could not place actors: spawn not walkable");
+    throw new Error(`configurator inputs could not place actors: spawn (${spawn.x}, ${spawn.y}) not walkable.`);
   }
   if (exit && !walkableSet.has(positionKey(exit))) {
-    throw new Error("configurator inputs could not place actors: exit not walkable");
+    throw new Error(`configurator inputs could not place actors: exit (${exit.x}, ${exit.y}) not walkable.`);
   }
 
   const context = deriveRoomPlacementContext({ data, walkable });
@@ -1360,7 +1376,11 @@ function normalizeActorPositions(actors, layout, { delverCount = 1 } = {}) {
       });
     }
     if (!assigned) {
-      throw new Error("configurator inputs could not place actors: insufficient entry-room tiles");
+      throw new Error(
+        `configurator inputs could not place actors: insufficient entry-room tiles for delver `
+        + `${index + 1} of ${delvers.length} (${context.entryRoomWalkable.length} entry-room tiles, `
+        + `${used.size} already occupied).`,
+      );
     }
     used.add(positionKey(assigned));
     assignedById.set(actor.id, assigned);
@@ -1377,7 +1397,10 @@ function normalizeActorPositions(actors, layout, { delverCount = 1 } = {}) {
       anchor: affinityAnchor || exitAnchor || context.exitRoomWalkable[0] || context.allRoomsWalkable[0] || walkable[0],
     });
     if (!assigned) {
-      throw new Error("configurator inputs could not place actors: insufficient room tiles for wardens");
+      throw new Error(
+        `configurator inputs could not place actors: insufficient room tiles for warden "${actor.id}" `
+        + `(${context.allRoomsWalkable.length} room tiles total, ${used.size} already occupied).`,
+      );
     }
     used.add(positionKey(assigned));
     assignedById.set(actor.id, assigned);
@@ -1387,7 +1410,7 @@ function normalizeActorPositions(actors, layout, { delverCount = 1 } = {}) {
     const desired = actor?.position;
     const assigned = assignedById.get(actor.id);
     if (!assigned) {
-      throw new Error("configurator inputs could not place actors: unresolved strategic placement");
+      throw new Error(`configurator inputs could not place actors: unresolved strategic placement for actor "${actor.id}".`);
     }
     if (!desired || desired.x !== assigned.x || desired.y !== assigned.y) {
       changed = true;
@@ -1463,7 +1486,13 @@ export async function orchestrateBuild({
 
   if (hasLevelGen) {
     if (!hasActors) {
-      throw new Error("configurator inputs require actors when levelGen is provided.");
+      const receivedKind = actorsInputRaw === undefined
+        ? "undefined"
+        : actorsInputRaw === null ? "null" : typeof actorsInputRaw;
+      throw new Error(
+        `configurator inputs require actors when levelGen is provided (received ${receivedKind}, `
+        + `expected an array or object).`,
+      );
     }
 
     const authoredHazards = Array.isArray(levelGenInput.hazards) ? levelGenInput.hazards : [];
@@ -1496,7 +1525,8 @@ export async function orchestrateBuild({
 
     const actorsInput = Array.isArray(actorsInputRaw) ? { actors: actorsInputRaw } : actorsInputRaw;
     if (!actorsInput || !Array.isArray(actorsInput.actors)) {
-      throw new Error("configurator inputs must include an actors array.");
+      const receivedKind = actorsInput?.actors === undefined ? "undefined" : typeof actorsInput.actors;
+      throw new Error(`configurator inputs must include an actors array (received ${receivedKind}).`);
     }
 
     // AM.2b — raise each actor's vitals to what its motivation requires BEFORE
@@ -1548,7 +1578,8 @@ export async function orchestrateBuild({
       label: "motivation rules",
     });
     if ((affinityPresets && !affinityLoadouts) || (!affinityPresets && affinityLoadouts)) {
-      throw new Error("configurator inputs require both affinityPresets and affinityLoadouts.");
+      const missing = affinityPresets ? "affinityLoadouts" : "affinityPresets";
+      throw new Error(`configurator inputs require both affinityPresets and affinityLoadouts (missing ${missing}).`);
     }
     if (affinityPresets) {
       assertSchema(affinityPresets, SCHEMAS.affinityPreset);

--- a/tests/architecture/ak-create-error-detail-allowlist.json
+++ b/tests/architecture/ak-create-error-detail-allowlist.json
@@ -1,0 +1,97 @@
+[
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 426,
+    "reason": "assignPositionedLayoutObjects -- multi-line concatenated template literal (M4 fix); already reports candidates.length/objects.length/index. Flagged needs-manual-read only because the classifier can't parse `...` + `...` concatenation as one interpolated literal."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 480,
+    "reason": "normalizeActorPositions no-walkable-tiles guard (SM2 fix) -- concatenated template literal reporting actors.length. Same classifier limitation as line 426."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 500,
+    "reason": "normalizeActorPositions no-anchor-points guard (SM2 fix) -- concatenated template literal reporting groups.length/walkable.length. Same classifier limitation as line 426."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 515,
+    "reason": "normalizeActorPositions insufficient-tiles-for-group guard (SM2 fix) -- concatenated template literal reporting groupIndex/available.length/group.length. Same classifier limitation as line 426."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 1332,
+    "reason": "normalizeActorPositionsLegacy no-walkable-tiles guard (SM2 fix) -- same message shape as line 480 in the Legacy sibling."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 1379,
+    "reason": "normalizeActorPositionsLegacy insufficient-entry-room-tiles-for-delver guard (SM2 fix) -- concatenated template literal reporting index/delvers.length/entryRoomWalkable.length/used.size. Same classifier limitation as line 426."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 1400,
+    "reason": "normalizeActorPositionsLegacy insufficient-room-tiles-for-warden guard (SM2 fix) -- concatenated template literal reporting actor.id/allRoomsWalkable.length/used.size. Same classifier limitation as line 426."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 1437,
+    "reason": "orchestrateBuild top-level `!spec` guard -- spec is an internal BuildSpec artifact, not raw model input; nothing else to say when it's simply absent."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 1492,
+    "reason": "actorsInput shape guard (SM2 fix) -- concatenated template literal reporting the received kind. Same classifier limitation as line 426."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 1711,
+    "reason": "throw new Error(formatBudgetReceiptDenial(budgetReceipt)) -- a function call, not a literal, so the classifier can't inspect it. formatBudgetReceiptDenial() is already rich (status/remaining/deniedLines/deniedPools)."
+  },
+  {
+    "file": "packages/runtime/src/build/orchestrate-build.js",
+    "line": 1715,
+    "reason": "Second call site of formatBudgetReceiptDenial() -- same as line 1711."
+  },
+  {
+    "file": "packages/runtime/src/personas/allocator/budget-fulfillment.js",
+    "line": 434,
+    "reason": "assertJudgementBudget -- already reports judged/cap/ceiling. Internal backstop (\"must never fire\"), not reachable from model input."
+  },
+  {
+    "file": "packages/runtime/src/personas/configurator/affinity-rules.js",
+    "line": 710,
+    "reason": "Module-load-time assertion on the hardcoded DEFAULT_AFFINITY_RULES_ARTIFACT constant -- fires once at import, never from a create request. Already reports field:code for every error."
+  },
+  {
+    "file": "packages/runtime/src/personas/configurator/artifact-builders.js",
+    "line": 72,
+    "reason": "assertUniqueActorIds -- already includes the duplicate id when one exists; the id-missing case has nothing else to add."
+  },
+  {
+    "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
+    "line": 38,
+    "reason": "requireUnitCost -- already interpolates the specific missing price-list key."
+  },
+  {
+    "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
+    "line": 113,
+    "reason": "unitCosts instanceof Map guard -- an internal API-contract check between Configurator and Allocator modules, not reachable from model input (fires only if calling code passes the wrong type)."
+  },
+  {
+    "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
+    "line": 119,
+    "reason": "priceItems instanceof Map guard -- same as line 113, internal API contract, not model-facing."
+  },
+  {
+    "file": "packages/runtime/src/personas/configurator/budget-maximizer.js",
+    "line": 163,
+    "reason": "Regen price missing -- already interpolates the specific missing regenKey."
+  },
+  {
+    "file": "packages/runtime/src/personas/configurator/motivation-rules.js",
+    "line": 419,
+    "reason": "Module-load-time assertion on the hardcoded DEFAULT_MOTIVATION_RULES_ARTIFACT constant -- same as affinity-rules.js:710, not model-facing, already reports field:code."
+  }
+]

--- a/tests/architecture/ak-create-error-message-drift.test.js
+++ b/tests/architecture/ak-create-error-message-drift.test.js
@@ -1,0 +1,59 @@
+// Drift guard for error-message-quality-sweep.md (SM0-SM3): re-runs the SM0 survey tool against
+// today's source and fails if any throw site on the ak_create model-facing surface has no
+// interpolated detail UNLESS it is in the allowlist below with a stated reason. Without this, a
+// new `throw new Error("static string")` on this surface (or a regression stripping detail from an
+// existing one) would sit undetected until the next benchmark run happened to hit it -- the same
+// silent-collapse pattern this whole plan exists to close, recurring one function at a time.
+//
+// The allowlist is not a budget to shrink to zero (contrast persona-boundary-allowlist.json): a
+// handful of these throw sites are genuinely internal backstops or already carry detail through a
+// helper function the classifier can't see into (formatBudgetReceiptDenial()) or a concatenated
+// template literal (`...` + `...`) the classifier can't parse as one interpolated string. Adding an
+// entry here is legitimate when the site truly has nothing more to say -- the guard's job is to
+// force that judgment to be recorded, not to prevent it.
+
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
+
+const ROOT = resolve(__dirname, "../..");
+const ALLOWLIST_PATH = resolve(__dirname, "ak-create-error-detail-allowlist.json");
+
+function siteKey({ file, line }) {
+  return `${file}:${line}`;
+}
+
+function formatSites(sites) {
+  return sites.map((s) => `  ${siteKey(s)}${s.reason ? ` -- ${s.reason}` : ""}`).join("\n");
+}
+
+test("every ak_create throw site without interpolation is an explicitly allowlisted, justified exception", async () => {
+  const { surveyErrorMessages } = await import(
+    "../../tools/benchmark/survey-ak-create-error-messages.mjs"
+  );
+  const results = surveyErrorMessages({ repoRoot: ROOT });
+  const flagged = results.filter((r) => r.disposition !== "has-interpolation");
+
+  const allowlist = JSON.parse(readFileSync(ALLOWLIST_PATH, "utf8"));
+  const allowlistedKeys = new Set(allowlist.map(siteKey));
+  const flaggedKeys = new Set(flagged.map(siteKey));
+
+  const newSites = flagged.filter((site) => !allowlistedKeys.has(siteKey(site)));
+  const staleEntries = allowlist.filter((entry) => !flaggedKeys.has(siteKey(entry)));
+
+  const failures = [];
+  if (newSites.length > 0) {
+    failures.push(
+      `New throw site(s) on the ak_create surface with no interpolated detail -- either add the `
+      + `missing detail (the fix this whole plan is about) or, if the site genuinely has nothing `
+      + `more to say, add a justified entry to ${ALLOWLIST_PATH}:\n${formatSites(newSites)}`,
+    );
+  }
+  if (staleEntries.length > 0) {
+    failures.push(
+      `Stale allowlist entries -- these sites no longer match a flagged line (moved, fixed, or `
+      + `removed). Update the line number or delete the entry:\n${formatSites(staleEntries)}`,
+    );
+  }
+  assert.equal(failures.length, 0, failures.join("\n\n"));
+});

--- a/tests/integration/create-actor-placement-refusal-detail.test.js
+++ b/tests/integration/create-actor-placement-refusal-detail.test.js
@@ -1,0 +1,138 @@
+// SM2 (error-message-quality-sweep.md): the M4 placement-detail fix (hazard/resource placement
+// reporting candidates/requested/index) never propagated to actor placement, which had its own
+// near-duplicate "could not place actors: ..." family in orchestrate-build.js reporting nothing.
+// Fixed 11 sites across normalizeActorPositions and its Legacy sibling; two are reproduced here
+// through the real ak create CLI path exactly like M4's own test does. The remaining nine (the
+// no-walkable-tiles/spawn-not-walkable/exit-not-walkable/unresolved-strategic-placement family, and
+// the entire Legacy sibling) are defensive backstops: the carving algorithm that runs before actor
+// placement already guarantees a minimum walkable interior and picks spawn/exit from the walkable
+// set, so these throw only if that guarantee is itself broken by a future change -- not reachable
+// from any toolArgs a model can author today. Verified by the fixes not moving the full suite
+// (445 files / 3466 passed unaffected); not perturbation-tested per-site the way the two reachable
+// ones are, since there is no real input that reaches them to replay.
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, rmSync, readFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
+
+const ROOT = resolve(__dirname, "../..");
+const AK_CLI = join(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+
+async function create(payload) {
+  const { buildArgv } = await import("../../packages/adapters-cli/src/mcp/tools/shared.mjs");
+  const { authoringSpec } = await import("../../packages/adapters-cli/src/mcp/tools/authoring.mjs");
+  const outDir = mkdtempSync(join(tmpdir(), "ak-actor-placement-refusal-"));
+  try {
+    const result = spawnSync(process.execPath, [
+      AK_CLI, "create",
+      ...buildArgv({ ...payload, outDir, runId: "actor_placement_refusal_probe" }, authoringSpec),
+    ], { cwd: ROOT, encoding: "utf8" });
+    return { status: result.status, detail: `${result.stderr || ""}${result.stdout || ""}` };
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+}
+
+test("too many delvers for the entry room refuses with the actual deficit", async () => {
+  const { status, detail } = await create({
+    text: "test",
+    room: [{ size: "medium" }],
+    floorTile: [{ count: 3, id: "stone_floor" }],
+    delver: [
+      { affinity: "fire", count: 1, motivation: "exploring" },
+      { affinity: "water", count: 1, motivation: "exploring" },
+      { affinity: "earth", count: 1, motivation: "exploring" },
+    ],
+  });
+  assert.notEqual(status, 0, "3 delvers cannot fit the minimum-viable floor budget's entry room");
+  assert.match(detail, /insufficient entry-room tiles for delver \d+ of 3/, detail);
+  assert.match(detail, /\d+ entry-room tiles, \d+ already occupied/, detail);
+});
+
+test("too many wardens for the room refuses with the actual deficit", async () => {
+  const { status, detail } = await create({
+    text: "test",
+    room: [{ count: 2, size: "small" }],
+    floorTile: [{ count: 8, id: "stone_floor" }],
+    delver: [{ affinity: "fire", count: 1, motivation: "exploring" }],
+    warden: [
+      { affinity: "fire", count: 1, motivation: "defending" },
+      { affinity: "water", count: 1, motivation: "defending" },
+      { affinity: "earth", count: 1, motivation: "defending" },
+      { affinity: "wind", count: 1, motivation: "defending" },
+      { affinity: "life", count: 1, motivation: "defending" },
+      { affinity: "decay", count: 1, motivation: "defending" },
+    ],
+  });
+  assert.notEqual(status, 0, "1 delver + 6 wardens exhausts a floorTile budget of 8 across 2 rooms");
+  assert.match(detail, /insufficient room tiles for warden "[^"]+"/, detail);
+  assert.match(detail, /\d+ room tiles total, \d+ already occupied/, detail);
+});
+
+// Bonus find during SM1: formatBudgetReceiptDenial() silently capped deniedLines at 5 with no
+// "+N more" -- a silent truncation on a message this session read closely three separate times
+// (M0-M2) without noticing. A tiny budget against many entity types reliably denies more than 5
+// lines at once.
+test("a budget denial with more than 5 denied lines reports how many were omitted", async () => {
+  const { status, detail } = await create({
+    budgetTokens: 5,
+    room: [{ size: "medium" }],
+    floorTile: [{ count: 20, id: "stone_floor" }],
+    delver: [
+      { affinity: "fire", count: 1, motivation: "exploring" },
+      { affinity: "water", count: 1, motivation: "exploring" },
+    ],
+    warden: [
+      { affinity: "earth", count: 1, motivation: "defending" },
+      { affinity: "wind", count: 1, motivation: "defending" },
+    ],
+  });
+  assert.notEqual(status, 0, "a 5-token budget cannot afford any of these entities");
+  assert.match(detail, /Budget receipt denied/, detail);
+  const deniedLinesShown = (detail.match(/deniedLines=([^;]+)/)?.[1] || "").split(",").length;
+  assert.ok(deniedLinesShown <= 5, "the cap itself must still hold");
+  assert.match(detail, /\(\+\d+ more\)/, "omitted lines must be counted, not silently dropped");
+});
+
+// The three misc build-guard fixes (SM1) are not reachable through ak create's own parsing --
+// hasActors is always true because agentAuthoringCommand always constructs an array (even an empty
+// one) from parsed delver/warden entries. Tested two of the three directly against a hand-built spec
+// (orchestrateBuild's other callers -- the UI card-builder path, sandbox flows -- can reach them
+// even though ak create can't). The third (actorsInput.actors not an array, line ~1518) turned out
+// to be doubly defensive: mapBuildSpecToArtifacts's OWN schema validation already rejects a
+// non-array configurator.inputs.actors before orchestrateBuild's own check ever runs, for any spec
+// built through the normal validation path -- confirmed by attempting it here and getting
+// "BuildSpec validation failed: configurator.inputs.actors: expected array" instead. The fix is kept
+// (harmless, no downside), but it is not independently testable without bypassing legitimate
+// upstream validation, so no test claims to exercise it.
+describe("orchestrateBuild misc guard detail (not reachable via ak create, tested directly)", () => {
+  let orchestrateBuild;
+  let baseSpec;
+
+  beforeAll(async () => {
+    ({ orchestrateBuild } = await import("../../packages/runtime/src/build/orchestrate-build.js"));
+    baseSpec = JSON.parse(readFileSync(
+      resolve(__dirname, "../fixtures/artifacts/build-spec-v1-configurator.json"), "utf8",
+    ));
+  });
+
+  test("missing actors when levelGen is provided reports the received shape", async () => {
+    const spec = JSON.parse(JSON.stringify(baseSpec));
+    delete spec.configurator.inputs.actors;
+    await assert.rejects(
+      () => orchestrateBuild({ spec, producedBy: "test" }),
+      /configurator inputs require actors when levelGen is provided \(received undefined, expected an array or object\)/,
+    );
+  });
+
+  test("affinityPresets without affinityLoadouts names which one is missing", async () => {
+    const spec = JSON.parse(JSON.stringify(baseSpec));
+    spec.configurator.inputs.affinityPresets = { presets: [] };
+    await assert.rejects(
+      () => orchestrateBuild({ spec, producedBy: "test" }),
+      /configurator inputs require both affinityPresets and affinityLoadouts \(missing affinityLoadouts\)/,
+    );
+  });
+});

--- a/tools/benchmark/survey-ak-create-error-messages.mjs
+++ b/tools/benchmark/survey-ak-create-error-messages.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// SM0 of error-message-quality-sweep.md: mechanically lists every `throw new Error(...)` site
+// reachable from a single `ak_create` call and flags which have zero `${...}` interpolation --
+// the entry point for SM1's per-site "is there dropped detail" triage, not the answer to it.
+//
+// Scope is the ak_create model-facing surface only (see the plan's own §Scope table), not the 468
+// throw sites across the whole codebase -- most of those are unreachable from ak_create at all
+// (simulation-tick internals, other CLI subcommands like room-plan/llm-plan/narrate).
+//
+// Function names below are the scope DECISION (which functions constitute "the ak_create surface"),
+// not a duplicated line-number range -- boundaries are found by scanning brace depth from each
+// function's own declaration, so this stays correct as the file grows or lines shift.
+//
+// Usage:
+//   node tools/benchmark/survey-ak-create-error-messages.mjs [--out <path>]
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const OUT_DEFAULT = join(REPO_ROOT, "error-message-quality-sweep-worklist.json");
+
+// { file, functions: [...] } scans only those named functions (bracket-depth bounded from their
+// declaration). { file, wholeFile: true } scans the entire file -- used where every throw in the
+// file is already on the ak_create path (orchestrate-build.js has no other entry point; the
+// Configurator/Allocator persona files listed are wholly part of the build/budget resolution create
+// invokes).
+const SCOPE = [
+  {
+    file: "packages/adapters-cli/src/cli/ak-impl.mjs",
+    functions: [
+      "parseOptimizationPriority", "parseOptimizationGoalEntry", "parseOptimizationGoalList",
+      "parsePositiveIntStrict", "parseNonNegativeIntStrict", "parseActorAffinityTuple",
+      "parseActorAffinities", "parseActorVitals", "parseRoomSpec", "parseRoomSpecs",
+      "parseFloorTileSpec", "parseFloorTileSpecs", "parsePlacedHazardVitals", "parseBooleanStrict",
+      "parsePlacedHazardSpec", "parsePlacedHazardSpecs", "parseHazardVitalSpec", "parseHazardSpec",
+      "parseHazardSpecs", "parseAuthoringHazardSpec", "parseResourceAffinityPayload",
+      "parseResourceSpec", "parseResourceSpecs", "parseDelverSpec", "parseDelverSpecs",
+      "parseWardenSpec", "parseWardenSpecs", "agentAuthoringCommand", "createCommand",
+    ],
+  },
+  { file: "packages/runtime/src/build/orchestrate-build.js", wholeFile: true },
+  { file: "packages/runtime/src/personas/configurator/actor-authoring.js", wholeFile: true },
+  { file: "packages/runtime/src/personas/configurator/artifact-builders.js", wholeFile: true },
+  { file: "packages/runtime/src/personas/configurator/budget-maximizer.js", wholeFile: true },
+  { file: "packages/runtime/src/personas/configurator/affinity-rules.js", wholeFile: true },
+  { file: "packages/runtime/src/personas/configurator/state-machine.js", wholeFile: true },
+  { file: "packages/runtime/src/personas/configurator/motivation-rules.js", wholeFile: true },
+  { file: "packages/runtime/src/personas/allocator/budget-fulfillment.js", wholeFile: true },
+  { file: "packages/runtime/src/personas/allocator/state-machine.js", wholeFile: true },
+];
+
+function lineAt(text, index) {
+  return text.slice(0, index).split("\n").length;
+}
+
+// Scans forward from `openIndex` (the index of an opening bracket char) to find the index of its
+// matching close, honoring string/template-literal/comment boundaries so a brace inside a string
+// doesn't desync the count. Returns -1 if the file ends before the bracket closes (malformed input,
+// not expected in a linted source file).
+function matchBracket(text, openIndex, openChar, closeChar) {
+  let depth = 0;
+  let inString = null; // one of ' " ` or null
+  let inLineComment = false;
+  let inBlockComment = false;
+  let escaped = false;
+  for (let i = openIndex; i < text.length; i++) {
+    const c = text[i];
+    const next = text[i + 1];
+    if (inLineComment) {
+      if (c === "\n") inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (c === "*" && next === "/") { inBlockComment = false; i++; }
+      continue;
+    }
+    if (inString) {
+      if (escaped) { escaped = false; continue; }
+      if (c === "\\") { escaped = true; continue; }
+      if (c === inString) inString = null;
+      continue;
+    }
+    if (c === "/" && next === "/") { inLineComment = true; i++; continue; }
+    if (c === "/" && next === "*") { inBlockComment = true; i++; continue; }
+    if (c === '"' || c === "'" || c === "`") { inString = c; continue; }
+    if (c === openChar) depth++;
+    else if (c === closeChar) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function findFunctionRange(text, functionName) {
+  const re = new RegExp(`^(?:async\\s+)?function\\s+${functionName}\\s*\\(`, "m");
+  const declMatch = re.exec(text);
+  if (!declMatch) return null;
+  // The parameter list can itself contain `{` (a destructured default, e.g.
+  // `function f(a, { x = 1 } = {})`) -- skip past the WHOLE parameter list via paren-matching
+  // before looking for the body's opening brace, or that inner `{` gets mistaken for the body.
+  const parenOpen = text.indexOf("(", declMatch.index);
+  if (parenOpen === -1) return null;
+  const parenClose = matchBracket(text, parenOpen, "(", ")");
+  if (parenClose === -1) return null;
+  const braceOpen = text.indexOf("{", parenClose);
+  if (braceOpen === -1) return null;
+  const braceClose = matchBracket(text, braceOpen, "{", "}");
+  if (braceClose === -1) return null;
+  return { start: declMatch.index, end: braceClose };
+}
+
+// Extracts the argument expression of `throw new Error(` starting at the character after its `(`,
+// via paren-depth scan (string/template-aware) -- robust to multi-line construction, unlike a
+// single-line regex.
+function extractThrowArg(text, parenOpenIndex) {
+  const close = matchBracket(text, parenOpenIndex, "(", ")");
+  if (close === -1) return null;
+  return { arg: text.slice(parenOpenIndex + 1, close), end: close };
+}
+
+function classifyArg(arg) {
+  const trimmed = arg.trim();
+  const isTemplate = trimmed.startsWith("`") && trimmed.endsWith("`");
+  const isPlainString = (trimmed.startsWith('"') && trimmed.endsWith('"'))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"));
+  if (isTemplate) {
+    // A single, complete template literal (no trailing `+ something` or `,` object arg).
+    const inner = trimmed.slice(1, -1);
+    // Reject if there's an unescaped backtick inside implying this isn't really one literal --
+    // matchBracket already balanced parens, but the arg could still be `a` + `b`.
+    if (/`\s*\+/.test(trimmed) || /\+\s*`/.test(trimmed)) {
+      return { disposition: "needs-manual-read", message: null };
+    }
+    return {
+      disposition: inner.includes("${") ? "has-interpolation" : "no-interpolation",
+      message: inner,
+    };
+  }
+  if (isPlainString) {
+    return { disposition: "no-interpolation", message: trimmed.slice(1, -1) };
+  }
+  return { disposition: "needs-manual-read", message: null };
+}
+
+function surveyRange(text, file, rangeStart, rangeEnd, results) {
+  const marker = "throw new Error(";
+  let searchFrom = rangeStart;
+  while (searchFrom < rangeEnd) {
+    const idx = text.indexOf(marker, searchFrom);
+    if (idx === -1 || idx >= rangeEnd) break;
+    const parenOpen = idx + marker.length - 1;
+    const extracted = extractThrowArg(text, parenOpen);
+    if (!extracted) {
+      results.push({
+        file, line: lineAt(text, idx), disposition: "needs-manual-read",
+        message: null, note: "unterminated throw new Error( -- could not find matching )",
+      });
+      searchFrom = idx + marker.length;
+      continue;
+    }
+    const { disposition, message } = classifyArg(extracted.arg);
+    results.push({ file, line: lineAt(text, idx), disposition, message });
+    searchFrom = extracted.end + 1;
+  }
+}
+
+function main() {
+  const results = [];
+  for (const entry of SCOPE) {
+    const path = join(REPO_ROOT, entry.file);
+    const text = readFileSync(path, "utf8");
+    if (entry.wholeFile) {
+      surveyRange(text, entry.file, 0, text.length, results);
+      continue;
+    }
+    for (const fn of entry.functions) {
+      const range = findFunctionRange(text, fn);
+      if (!range) {
+        results.push({
+          file: entry.file, line: null, disposition: "needs-manual-read",
+          message: null, note: `function "${fn}" not found -- scope definition is stale, re-check`,
+        });
+        continue;
+      }
+      surveyRange(text, entry.file, range.start, range.end, results);
+    }
+  }
+
+  results.sort((a, b) => (a.file === b.file ? (a.line || 0) - (b.line || 0) : a.file < b.file ? -1 : 1));
+
+  const counts = results.reduce((acc, r) => {
+    acc[r.disposition] = (acc[r.disposition] || 0) + 1;
+    return acc;
+  }, {});
+
+  const outPath = process.argv.includes("--out")
+    ? process.argv[process.argv.indexOf("--out") + 1]
+    : OUT_DEFAULT;
+  writeFileSync(outPath, `${JSON.stringify({ total: results.length, counts, sites: results }, null, 2)}\n`, "utf8");
+
+  console.log(`Surveyed ${results.length} throw sites across ${SCOPE.length} scope entries.`);
+  for (const [disposition, count] of Object.entries(counts)) {
+    console.log(`  ${disposition}: ${count}`);
+  }
+  console.log(`Worklist written to ${outPath}`);
+}
+
+main();

--- a/tools/benchmark/survey-ak-create-error-messages.mjs
+++ b/tools/benchmark/survey-ak-create-error-messages.mjs
@@ -174,11 +174,16 @@ function surveyRange(text, file, rangeStart, rangeEnd, results) {
   }
 }
 
-function main() {
+// Pure survey: reads each SCOPE file fresh (via `readFile`, so a caller can pass an absolute repo
+// root that differs from this file's own location -- e.g. a guard test running from a worktree)
+// and returns the sorted site list. No file I/O beyond the reads; the CLI entry point below owns
+// writing the worklist and printing a summary. This is the function the drift guard
+// (tests/architecture/ak-create-error-message-drift.test.js) imports directly.
+export function surveyErrorMessages({ repoRoot = REPO_ROOT, readFile = readFileSync } = {}) {
   const results = [];
   for (const entry of SCOPE) {
-    const path = join(REPO_ROOT, entry.file);
-    const text = readFileSync(path, "utf8");
+    const path = join(repoRoot, entry.file);
+    const text = readFile(path, "utf8");
     if (entry.wholeFile) {
       surveyRange(text, entry.file, 0, text.length, results);
       continue;
@@ -197,6 +202,13 @@ function main() {
   }
 
   results.sort((a, b) => (a.file === b.file ? (a.line || 0) - (b.line || 0) : a.file < b.file ? -1 : 1));
+  return results;
+}
+
+export { SCOPE };
+
+function main() {
+  const results = surveyErrorMessages();
 
   const counts = results.reduce((acc, r) => {
     acc[r.disposition] = (acc[r.disposition] || 0) + 1;
@@ -215,4 +227,8 @@ function main() {
   console.log(`Worklist written to ${outPath}`);
 }
 
-main();
+// Only run the CLI behavior (write a worklist file, print a summary) when this file is executed
+// directly -- importing surveyErrorMessages() for the drift guard must not have that side effect.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tools/benchmark/survey-ak-create-error-messages.mjs
+++ b/tools/benchmark/survey-ak-create-error-messages.mjs
@@ -32,12 +32,19 @@ const SCOPE = [
     functions: [
       "parseOptimizationPriority", "parseOptimizationGoalEntry", "parseOptimizationGoalList",
       "parsePositiveIntStrict", "parseNonNegativeIntStrict", "parseActorAffinityTuple",
-      "parseActorAffinities", "parseActorVitals", "parseRoomSpec", "parseRoomSpecs",
-      "parseFloorTileSpec", "parseFloorTileSpecs", "parsePlacedHazardVitals", "parseBooleanStrict",
-      "parsePlacedHazardSpec", "parsePlacedHazardSpecs", "parseHazardVitalSpec", "parseHazardSpec",
-      "parseHazardSpecs", "parseAuthoringHazardSpec", "parseResourceAffinityPayload",
-      "parseResourceSpec", "parseResourceSpecs", "parseDelverSpec", "parseDelverSpecs",
-      "parseWardenSpec", "parseWardenSpecs", "agentAuthoringCommand", "createCommand",
+      "parseActorAffinities", "parseActorVitals", "parseRoomSpec",
+      "parseFloorTileSpec", "parsePlacedHazardVitals", "parseBooleanStrict",
+      "parsePlacedHazardSpec", "parseHazardVitalSpec", "parseHazardSpec",
+      "parseAuthoringHazardSpec", "parseResourceAffinityPayload",
+      "parseResourceSpec", "parseDelverSpec",
+      "parseWardenSpec", "agentAuthoringCommand", "createCommand",
+      // NOT in scope, verified by call-site trace (SM2 correction, 2026-08-31): parseRoomSpecs,
+      // parseHazardSpecs, parseResourceSpecs, parseDelverSpecs, parseWardenSpecs -- the plural
+      // "at least one X entry" wrapper functions -- are called ONLY from their own standalone
+      // X-plan command (roomPlanCommand/hazardPlanCommand/etc.), never from agentAuthoringCommand.
+      // parseFloorTileSpecs and parsePlacedHazardSpecs have zero call sites anywhere (dead code,
+      // a separate concern from this plan). agentAuthoringCommand parses each entity inline via
+      // normalizeList(...).map(parseXSpec), never via the plural wrappers.
     ],
   },
   { file: "packages/runtime/src/build/orchestrate-build.js", wholeFile: true },


### PR DESCRIPTION
## Summary

Follow-up to #131/#132 — that plan's M3/M4 found the same bug three separate times by accident (`resource.vital`, `floor_tile_budget_insufficient`, `insufficient unoccupied walkable tiles`): a structured detail value existed and got collapsed to a string too early, dropping the parts that would have made the failure diagnosable. This scopes and runs a systematic sweep for more instances, following the four SM0–SM3 milestones in `error-message-quality-sweep.md`.

- **SM0** — mechanically listed every `throw new Error(...)` site reachable from a single `ak_create` call (131 sites, not the 468 across the whole codebase — most are simulation-tick internals or other CLI subcommands the benchmark never exercises).
- **SM1** — read the function body around all 31 flagged sites (not just the throw line) and classified each: 14 `detail-dropped`, 12 `fine-as-is`, 0 `needs-new-computation`.
- **SM2** — fixed all 14 `detail-dropped` sites in one batch (`orchestrate-build.js`). The largest finding: a whole parallel actor-placement algorithm (`normalizeActorPositions`) had the exact same bare-message gap M4 already fixed for hazard/resource placement, just never propagated there. Plus a bonus fix — `formatBudgetReceiptDenial()`'s denied-lines list silently capped at 5 with no "+N more", a truncation this session read past three separate times (M0–M2) without noticing.
- **SM3** — verified: the 43-fixture benchmark-failures corpus still splits exactly 2 harness-defect / 39 model-error / 2 not-replayable (unchanged, as expected for diagnostic-only fixes), and a fresh 9-scenario local run (actor-dense scenarios, up to an eleven-actor stress test) ran clean with no failures — recorded honestly as a negative result rather than stretched into more than it is.

**A real scoping mistake, found and corrected before any code changed:** SM0's first pass included 5 `ak-impl.mjs` functions (`parseRoomSpecs`/`parseHazardSpecs`/`parseResourceSpecs`/`parseDelverSpecs`/`parseWardenSpecs`) that turned out to be called *only* by their own standalone `X-plan` command, never by `create` — an assumption from naming symmetry with the singular forms, never verified against the actual call graph. Traced it, corrected the survey tool's scope, and did **not** fix those 5 sites — they're out of scope by the plan's own rule (no evidence a model reaches them through `ak_create`), not merely deprioritized.

**Honest coverage accounting on the fixes that did land:** of 15 fixes (14 + the bonus), only 5 have a genuine reproduction — perturbation-verified via `git stash`. The other 10 are kept as low-risk (pure message formatting, no control-flow change, full suite stays green) but explicitly *not* claimed as tested: one turned out to be doubly defensive behind an earlier schema validator, discovered while trying to test it; the other 9 are backstops behind the carving algorithm's own structural guarantees, the same shape as an existing `assertJudgementBudget` "must never fire" comment found during triage.

**Deliberately out of scope, recorded not designed:** a cross-model resilience layer (retry a *confirmed* pure-model-weakness failure against a different model) — phase two of a two-phase ordering the maintainer set. The benchmark itself stays one-shot; a retry-until-success loop would let a model paper over a real harness gap by trial and error instead of surfacing it, the opposite of what this whole line of work is for.

**Drift guard — SM0's tool kept alive, not left as a one-shot script:** `tests/architecture/ak-create-error-message-drift.test.js` re-runs the SM0 survey (refactored into an importable `surveyErrorMessages()`, no file-write side effect) against current source on every test run and fails on any new no-detail throw site on the `ak_create` surface — or a stale allowlist entry. The 19 currently-known exceptions (12 genuine "nothing more to say" sites, 7 sites the classifier can't parse as interpolated — concatenated template literals, or a call through `formatBudgetReceiptDenial()`) are recorded in `tests/architecture/ak-create-error-detail-allowlist.json` with a reason each, following the repo's existing `persona-boundary-allowlist.json` pattern. Perturbation-tested both directions: an injected bare-string throw fails the guard, and a stale allowlist entry also fails it.

## Test plan

- [x] `pnpm run test` — 446 files / 3471 passed / 207 skipped, exit 0
- [x] `pnpm run typecheck` — 0 errors
- [x] `tests/tools/benchmark-failure-corpus-replay.test.js` unchanged at 2 harness-defect / 39 model-error / 2 not-replayable
- [x] Every landed fix with a real reproduction is perturbation-verified (`git stash` the fix, confirm new tests fail, restore, confirm they pass)
- [x] Fresh 9-scenario local benchmark run, 9/9 clean (result: `tools/remote-ollama-control/results/2026-08-31T19-32-32-447Z-content-gen/`)
- [x] Drift guard perturbation-tested: injected bare-string throw fails it, stale allowlist entry fails it, both revert clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
