### PR TITLE
fix(cli): remove unreachable duplicate hazard case in makeAgentCommandRoutes

### DIFF
--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -3555,10 +3555,6 @@ function makeAgentCommandRoutes(kind) {
       ];
     case "hazard":
       return [
-        { target: "build_spec_configurator", path: "configurator.inputs.levelGen.placedHazards", legacyFlow: "configurator" },
-      ];
-    case "hazard":
-      return [
         { target: "build_spec_configurator", path: "configurator.inputs.levelGen.hazards", legacyFlow: "hazard-plan" },
       ];
     case "resource":

--- a/tests/fixtures/goldens/create-g1/spec.json
+++ b/tests/fixtures/goldens/create-g1/spec.json
@@ -2173,8 +2173,8 @@
             "compileTo": [
               {
                 "target": "build_spec_configurator",
-                "path": "configurator.inputs.levelGen.placedHazards",
-                "legacyFlow": "configurator"
+                "path": "configurator.inputs.levelGen.hazards",
+                "legacyFlow": "hazard-plan"
               }
             ]
           },
@@ -2212,9 +2212,10 @@
         "preserveExistingCommands": true,
         "supportedLegacyFlows": [
           "room-plan",
-          "configurator",
+          "hazard-plan",
           "delver-plan",
-          "build"
+          "build",
+          "configurator"
         ]
       }
     },


### PR DESCRIPTION
## Summary

`makeAgentCommandRoutes()` has two back-to-back `case "hazard":` blocks — the second is unreachable JS `switch` dead code. The first (reachable) block reports the wrong `compileTo` path (`configurator.inputs.levelGen.placedHazards`, which does not exist in the compiled spec) and the wrong `legacyFlow` (`"configurator"` instead of `"hazard-plan"`). Deleted the dead-but-correct-looking first block, keeping the real one.

Docs/provenance-only: verified the compiled sim-config, initial-state, and receipts are byte-identical before and after — only the `AgentCommandRequestArtifact`'s self-reported path changes. Regenerated the `create-g1` golden fixture to match.

This was found and fixed on 2026-08-20 but never opened as a PR. Rediscovered while sweeping unmerged branches during a repo cleanup pass; confirmed the duplicate is still present on current `main` (unaffected by everything merged since), and that this change still applies with zero conflicts.

## Test plan

- [x] `pnpm run test` — 447 files / 3472 passed / 207 skipped, exit 0 (merged onto current `main`)
- [x] `pnpm run typecheck` — 0 errors
- [x] Merges onto current `main` with no conflicts (verified via test-merge before opening this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)