### PR TITLE
MCP harness run-through: friction log, config-permutation sweep, fix #142-#149

### DIFF
--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -219,11 +219,12 @@ axis at baseline. `budgetTokens` is fixed at 2000 for every scenario — well ab
 scenario costs — specifically so budget denial doesn't confound the sweep; that fixed cap is also the
 "don't let generated configs grow unmanaged" rail the maintainer asked for.
 
-**Matrix — 46 scenarios across 7 axes**, widened three times on 2026-09-01 (34 → 41 → 42 → 46):
+**Matrix — 50 scenarios across 7 axes**, widened four times on 2026-09-01 (34 → 41 → 42 → 46 → 50):
 axis D went from a 3-affinity spot-check to the full 10-affinity domain, axis B grew from the
-non-control motivation domain only to all 4 motivation families (including `user_controlled`), then
-axis C grew a position sub-sweep — the room's two diagonals (4 corners) — alongside its original
-expression sweep:
+non-control motivation domain only to all 4 motivation families (including `user_controlled`), axis C
+grew a position sub-sweep (the room's two diagonals, 4 corners) alongside its original expression
+sweep, then axis E grew the same diagonal-corner sub-sweep for an *actor* (the warden) rather than a
+static hazard:
 
 | Axis | What it sweeps | Domain size | Count |
 |---|---|---|---|
@@ -231,9 +232,19 @@ expression sweep:
 | B | delver motivation | full domain, all 4 families, minus `exploring` (baseline) | 11 |
 | C | hazard expression (3) + hazard position, room's two diagonals (4 corners) | full expression domain minus `emit`; diagonal corners of a 5x5 interior | 7 |
 | D | hazard affinity | full (10 kinds) | 10 |
-| E | warden present (actor-vs-actor incl. 2-delver+warden stress) | hand-picked | 3 |
+| E | warden present (actor-vs-actor incl. 2-delver+warden stress, 3 hand-picked) + warden repositioned to the room's two diagonals (4 corners) | hand-picked + diagonal corners | 7 |
 | F | resource authoring (vital payload x2, affinity payload x1) | hand-picked | 3 |
 | G | multi-hazard stress (2 and 3 hazards) | hand-picked | 2 |
+
+Axis E's diagonal sub-sweep can't reuse axis C's approach directly — `create`/`configure` has no
+x/y field for `--delver`/`--warden` (level-gen auto-places actors; only hazards/resources take
+authoring-time positions). Instead it reuses `E1-warden-basic`'s exact authored config and
+repositions the auto-placed warden at **run time** via `ak run --actor <id>,<x>,<y>` — a CLI flag
+meant for deterministic-replay overrides, now doing double duty as this sweep's actor-placement
+mechanism. The warden's id (`card_warden_1-1`) is fixed and confirmed from E1's own
+`initial-state.json` (single warden, `count=1`). Corners are absolute grid coordinates — the room's
+walkable interior is confirmed absolute `1..5` on each axis (the same interior axis C's diagonal
+hazards use, offset by the room's `(1,1)` origin from their room-relative `0..4`).
 
 Axis C's diagonal-position sub-sweep exists because hazard x/y are room-relative offsets into the
 target room's carved interior, and a "small" room's interior is confirmed 5x5 (relative `0..4` on
@@ -263,17 +274,22 @@ being written up as a finding.
 G2's out-of-bounds hazard is left in the matrix deliberately as a standing regression probe for #148
 — it should keep failing with a malformed message until that's fixed.
 
-**Results (re-run 2026-09-01 after widening axis D, then axis B, then axis C — 46 scenarios):**
+**Results (re-run 2026-09-01 after widening axis D, then B, then C, then E — 50 scenarios):**
 
 - `ak create --dry-run` only (authoring-layer validation, no artifacts written, no `ak run`):
-  **46/46 PASS.** No anomalies.
-- `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **45/46 PASS** on create,
-  **45/45 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple` —
-  see finding 6. All 10 axis-D hazard affinities and all 4 axis-C diagonal-corner positions passed
-  clean on both create and run. `B-delver-motivation-user_controlled` also passed clean on both:
-  `create=PASS`, `run=PASS`, `actions=0, effects=5` — inert at the run layer as expected
-  (player-controlled actors need streamed simulation playback per the Actor persona README; a plain
-  `ak_run` pass has no player input to stream), informational only, not a failure.
+  **50/50 PASS.** No anomalies.
+- `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **49/50 PASS** on create,
+  **49/49 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple` —
+  see finding 6. All 10 axis-D hazard affinities, all 4 axis-C diagonal-corner hazard positions, and
+  all 4 new axis-E diagonal-corner warden placements passed clean on both create and run — verified
+  the `--actor` override actually took effect (not silently ignored) by reading
+  `world-state.json` after each: the warden really ended up at `(1,1)`/`(5,5)`/`(5,1)`/`(1,5)`
+  respectively and, with no hostile adjacent at any of those corners, stayed there for the whole run
+  (`defending` doesn't move without an adjacent hostile — same documented behavior already noted for
+  axis B). `B-delver-motivation-user_controlled` also passed clean on both: `create=PASS`,
+  `run=PASS`, `actions=0, effects=5` — inert at the run layer as expected (player-controlled actors
+  need streamed simulation playback per the Actor persona README; a plain `ak_run` pass has no
+  player input to stream), informational only, not a failure.
 
 **Informational note, not a finding:** the run pass recorded `acceptedActions`/`emittedEffects` counts
 per scenario as metadata only, never as a pass/fail signal — treating "an actor did nothing" as

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -1,17 +1,18 @@
 # MCP harness run-through — open issues & handoff context
 
-**Status (2026-09-01):** first pass, actively growing. The maintainer asked to drive `agent-kernel`
-end-to-end through the `agent-kernel-cli` MCP server from inside a Claude Code harness (Bash +
-Browser-pane tools), have results display back in that harness, and file every piece of friction hit
-along the way as a standalone `gh issue`, immediately, as it's found — per
-`AGENTS.md → Working agreement`. This document is the handoff artifact: a running summary of every
-issue opened from this activity plus enough standalone context (repro steps, root cause, evidence,
-code locations) that **a different agent with no memory of this session can pick any one issue up and
-fix it without re-deriving anything above what's written here.**
+**Status (2026-09-01):** all 7 issues this activity found and diagnosed (#142-#145, #147-#149) are
+now **fixed, verified, and closed** — see "Fix pass" below. The maintainer's original ask was to drive
+`agent-kernel` end-to-end through the `agent-kernel-cli` MCP server from inside a Claude Code harness
+(Bash + Browser-pane tools), have results display back in that harness, and file every piece of
+friction hit along the way as a standalone `gh issue`, immediately, as it's found — per
+`AGENTS.md → Working agreement`. That scope later widened, on explicit instruction, to fixing and
+closing every issue found. This document is the record: repro steps, root cause, evidence, code
+locations, and (now) the fix commit for each.
 
-**This document does not itself fix anything.** Issues found here are filed to GitHub and logged below
-as they're identified; resolving them is explicitly out of scope for the session that finds them —
-that's separate work, for whoever (or whichever session) picks an issue off the list.
+**Two new issues surfaced *while fixing* the original seven and are deliberately left open** — out of
+scope for the fixes that found them, tracked separately: **#150** (two more call sites share #149's
+wall-clock-meta-stamp bug, unconfirmed — no scenario exercises them yet) and **#151** (the MCP
+README's Tool Index is stale — 27 documented vs. ~45 actual tools).
 
 **Audience:** an agent with no memory of the session that produced it.
 **Source of evidence:** live MCP tool calls (`ak_create`, `ak_run`, `ak_push_to_ui`, `ak_show_state`,
@@ -27,22 +28,26 @@ this file.
 
 ---
 
-## Open issues (start here)
+## Issues (start here)
 
-| # | Title | Status | Blocking? | Context |
+| # | Title | Status | Fix commit | Context |
 |---|---|---|---|---|
-| [#142](https://github.com/KomplexMojo/agent-kernel/issues/142) | `ak_push_to_ui`'s sandbox WebSocket bridge is unreachable from a sandboxed MCP-driving harness | Open | No — `ak_show_state`/`ak_tick_forward` are a working substitute | Finding 1 |
-| [#143](https://github.com/KomplexMojo/agent-kernel/issues/143) | `ak_show_state`/`ak_tick_forward`/`ak_tick_backward` resolve runs from a different root than `ak_create`/`ak_run`/`ak_show` | Open | No — workaround: pass `outDir=artifacts/runs/<runId>/<command>` explicitly | Finding 2 |
-| [#144](https://github.com/KomplexMojo/agent-kernel/issues/144) | `ak_show_state`'s `image` visualization mode blows the MCP tool-result size limit | Open | No — `ascii` mode works | Finding 3 |
-| [#145](https://github.com/KomplexMojo/agent-kernel/issues/145) | `ak_create` budget denial doesn't say what budget would have worked | Open | No — workaround: retry with a larger `budgetTokens` | Finding 4 |
+| [#142](https://github.com/KomplexMojo/agent-kernel/issues/142) | `ak_push_to_ui`'s sandbox WebSocket bridge is unreachable from a sandboxed MCP-driving harness | **Closed** — documented, not code-fixable (environment constraint) | `1a79486` | Finding 1 |
+| [#143](https://github.com/KomplexMojo/agent-kernel/issues/143) | `ak_show_state`/`ak_tick_forward`/`ak_tick_backward` resolve runs from a different root than `ak_create`/`ak_run`/`ak_show` | **Closed** — fixed | `f2f8de6` | Finding 2 |
+| [#144](https://github.com/KomplexMojo/agent-kernel/issues/144) | `ak_show_state`'s `image` visualization mode blows the MCP tool-result size limit | **Closed** — fixed | `b1dd21d` | Finding 3 |
+| [#145](https://github.com/KomplexMojo/agent-kernel/issues/145) | `ak_create` budget denial doesn't say what budget would have worked | **Closed** — fixed | `65b9173` | Finding 4 |
 | [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) | Open question: does plain `ak_run` ever invoke autonomous actor decision-making? | **Closed, not planned** | — | Superseded by #147; premise was wrong, see finding 5 |
-| [#147](https://github.com/KomplexMojo/agent-kernel/issues/147) | `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn position, single-frame overlay instead of cumulative replay | Open | No — top-level `ascii` field on `ak_show_state` (built by `renderAscii`) is a working substitute | Finding 5 |
-| [#148](https://github.com/KomplexMojo/agent-kernel/issues/148) | level-gen error formatter in `orchestrate-build.js` bakes literal `"undefined"` into messages for 4 of 5 error codes | Open | No — the underlying rejection is correct, only the message text is broken | Finding 6 |
-| [#149](https://github.com/KomplexMojo/agent-kernel/issues/149) | `ak run`'s `action-log.json`/`run-summary.json`/`world-state.json` use wall-clock meta stamps, breaking reproducibility the simulation itself has | Open | No — the simulation trace (tick-frames/effects-log/decision-captures) is unaffected; only these three artifacts' `meta.id`/`meta.createdAt` | Finding 7 |
+| [#147](https://github.com/KomplexMojo/agent-kernel/issues/147) | `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn position, single-frame overlay instead of cumulative replay | **Closed** — fixed | `a4e1287` | Finding 5 |
+| [#148](https://github.com/KomplexMojo/agent-kernel/issues/148) | level-gen error formatter in `orchestrate-build.js` bakes literal `"undefined"` into messages for 4 of 5 error codes | **Closed** — fixed | `453d278` | Finding 6 |
+| [#149](https://github.com/KomplexMojo/agent-kernel/issues/149) | `ak run`'s `action-log.json`/`run-summary.json`/`world-state.json` use wall-clock meta stamps, breaking reproducibility the simulation itself has | **Closed** — fixed | `4efffe7` | Finding 7 |
+| [#150](https://github.com/KomplexMojo/agent-kernel/issues/150) | `affinity-summary.json`/`deferred-coordination.json` likely share #149's bug (unconfirmed) | Open | — | Found while fixing #149; different files, not exercised by any scenario yet |
+| [#151](https://github.com/KomplexMojo/agent-kernel/issues/151) | MCP README's Tool Index is stale (27 documented vs. ~45 actual tools) | Open | — | Found while fixing #142 |
 
-None of the open issues above block continued use of the MCP surface — every one has a stated
-workaround. Full repro steps, root-cause evidence, and code pointers for each are in the numbered
-findings below.
+All 7 originally-found issues are fixed, each verified against its exact original repro plus a full
+`pnpm run test` + `pnpm run typecheck` pass (green throughout — see each finding's "Fix" note and the
+commit messages for exact before/after numbers). #150 and #151 are genuinely new, out of scope for
+the fixes that found them, and still open. Full repro steps, root-cause evidence, and code pointers
+for the original seven are in the numbered findings below; each now also carries a **Fix** note.
 
 ---
 
@@ -95,6 +100,14 @@ this kind of sandboxed pair — not a fixture/data problem, an environment-reach
 state inline over the MCP response itself (ASCII or a PNG data URI) — no second network hop needed.
 That's the channel that actually works here; see finding 3 for its own limitation.
 
+**Fix (`1a79486`):** there's no code fix for the network isolation itself — an environment constraint
+the MCP server can't see into (it only knows "no client connected," never "no client *can* connect").
+`requireClient: true` (default) already surfaces the honest signal it's capable of
+(`SANDBOX_UI_NOT_CONNECTED`); this session's repro used `requireClient: false`, which intentionally
+suppresses that signal to tolerate a not-yet-connected client — that's what made the failure silent.
+Fixed by making `ak_push_to_ui`'s own tool description state the constraint plainly and point to the
+`ak_show_state`/`ak_tick_forward`/`ak_tick_backward` workaround above.
+
 ## 2. `ak_show_state` / `ak_tick_forward` / `ak_tick_backward` resolve runs from a different root than `ak_create` / `ak_run` / `ak_show` / `ak_runs_list`
 
 **What's failing:** after a clean `ak_create` → `ak_run` with `outDir` omitted (the default —
@@ -123,6 +136,14 @@ with no hint that the fix is "pass `outDir=artifacts/runs/<runId>/<command>` exp
 instead." Confirmed as the fix: re-running `ak_create`/`ak_run` with `outDir` pinned under
 `<repo>/artifacts/runs/<runId>/{create,run}` made `ak_show_state`/`ak_tick_forward` work immediately.
 
+**Fix (`f2f8de6`):** `resolveRunDir()` now accepts an optional override; `server.mjs`'s dispatch
+layer supplies one for the three tick tools when it has a remembered "run" outDir for that `runId`
+(the same internal-field-injection pattern `resolveDefaultOutDir`/`maybeResolveRememberedInputs`
+already use elsewhere in that file). The plain CLI (`ak tick`, no session/remembered-run concept) is
+unaffected. Verified end-to-end against the real MCP server with the exact repro above — both
+`ak_show_state` and `ak_tick_forward` now succeed immediately after `ak_create`+`ak_run` with `outDir`
+left to default.
+
 ## 3. `ak_show_state`'s `image` visualization mode blows the MCP tool-result size limit
 
 **What's failing:** `ak_show_state({runId, visualization: "image"})` on the same run that answered
@@ -137,6 +158,11 @@ paths to a fix, not mutually exclusive: (a) MCP image results should use the pro
 content-block type instead of embedding a data URI inside the JSON text result, or (b) `ak_show_state`
 should support writing the PNG to a file and returning its path, the way every artifact-producing `ak_*`
 tool already does, instead of always inlining bytes.
+
+**Fix (`b1dd21d`):** took path (b). `visualizationDataUri` is now always `null` in image mode; a new
+`visualizationPath` field (additive to the `VisualizationSnapshotImageV1` schema) points at the PNG on
+disk instead. Verified end-to-end against the real MCP server: overall tool-result text dropped from
+443,790 to 1,716 characters; the 332,157-byte PNG file was confirmed on disk and renders correctly.
 
 ## 4. `ak_create`'s budget denial doesn't say what budget would have worked
 
@@ -158,6 +184,12 @@ size or the total that would resolve it. This is the same family of "comprehensi
 work already tracked in `error-message-quality-sweep.md` (SM0–SM3, merged) but for a category that
 sweep's own scope note (`budget receipt denial` is a distinct code path from the `ak_create` field
 validators it audited) didn't cover.
+
+**Fix (`65b9173`):** `deniedPools` entries now append the shortfall —
+`deniedPools=delver:92/72 (short 20)`. Deliberately didn't attempt the minimum-total-budget
+computation: `capTokens`' relationship to the overall budget isn't a simple proportion (the same
+receipt's `scenarioSpendReport.categories` carries a different "target" number for the same
+category), so guessing that formula risked being subtly wrong. Verified against the exact repro above.
 
 ## 5. RESOLVED — root-caused with Serena: the actor did act; `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn
 
@@ -204,6 +236,16 @@ frozen. Two functions in the same package solve the identical problem; only one 
 whole run` (merged via #140) — a tick-cursor visualization reading a stale/wrong single frame instead
 of replaying accepted actions cumulatively. That fix apparently didn't extend to this MCP-side
 visualization path.
+
+**Fix (`a4e1287`):** two independent copies of the same bug — `computeActorPositions()`
+(visualization-snapshot.js, the ascii/actorDetails path) and `buildPngDataUri()` (tick-session.mjs,
+the image path) both now replay every accepted move cumulatively from the full `tick-frames.json`
+history instead of overlaying one always-empty frame; `buildPngDataUri()` reuses the already-correct
+`resolveActorPositionsAtTick()` instead of a third duplicate. Also found and fixed the identical bug
+independently present in `ak-impl.mjs`'s `tickCommand` (the CLI `ak tick` command) — not covered by
+the original diagnosis above. Verified against the original repro: `ak tick forward --visualization
+ascii`/`image` now both show the delver actually moving (3,2)→(2,2)→(1,1) across ticks instead of
+frozen at spawn.
 
 ---
 
@@ -412,6 +454,12 @@ fix only patched the one code it was chasing; the generic formatter producing ev
 error was never made shape-aware, so the same failure mode is still reachable through hazard/element
 placement errors, which this sweep's axis G hit on its very first out-of-bounds scenario.
 
+**Fix (`453d278`):** replaced the single template with `LEVEL_GEN_ERROR_DETAIL_FORMATTERS`, a
+per-code lookup, each formatting its own known shape; a code with no formatter (or a detail object
+missing the fields it expects) falls back to no parenthetical instead of guessing wrong. Verified
+against the exact G2 repro — the message now reads `(position 5,1 is outside the target room — room
+R1's interior is 5x5)` instead of the `undefined`-polluted text.
+
 ## 7. `ak run`'s `action-log.json`/`run-summary.json`/`world-state.json` use wall-clock meta stamps, breaking reproducibility the simulation itself has
 
 Full writeup is in "Hazard interaction — what this sweep found" above (this is where the
@@ -425,13 +473,31 @@ run's own seeded clock, so those two fields — and only those two fields — di
 given byte-identical input. Filed as
 **[#149](https://github.com/KomplexMojo/agent-kernel/issues/149)**.
 
+**Fix (`4efffe7`):** moved the clock construction earlier in `run()` and added
+`deterministicRunArtifactMeta()`, used for exactly the three confirmed call sites (action-log's two
+branches, run-summary, world-state). Two same-pattern-but-unconfirmed sites (`affinity-summary.json`,
+`deferred-coordination.json`) weren't touched — filed separately as
+**[#150](https://github.com/KomplexMojo/agent-kernel/issues/150)** rather than bundled in, since no
+scenario in the matrix exercises them. Verified: re-ran `ak run` twice against identical
+`sim-config.json`/`initial-state.json` with a 1s sleep between — all three files now byte-identical.
+
 ---
 
 ## Workflow for the rest of this activity
 
-**Corrected 2026-09-01** (see conversation): every issue found gets filed to GitHub immediately, as
-it's identified — not batched into an end-of-session sweep. What's deferred is *fixing* them: this
-session's job is to run the app, find friction, root-cause it enough to hand off cleanly, and file the
-issue with that context attached (repro, root cause, code pointers, evidence) — not to patch the code.
-The table at the top of this document is the running index; append a row there and a numbered finding
-section below for every new issue, in the same pattern as #142-#147 above.
+**Corrected 2026-09-01, twice:**
+
+1. Every issue found gets filed to GitHub immediately, as it's identified — not batched into an
+   end-of-session sweep.
+2. **Later the same day, on explicit instruction ("sweep it, close out #142-#149"), the scope widened
+   to fixing and closing every issue found**, not just documenting them. All 7 (#142-#145, #147-#149)
+   were fixed, each verified against its original repro plus a full `pnpm run test` +
+   `pnpm run typecheck` pass, and closed — see the table at the top and each finding's **Fix** note.
+   #150 and #151, found *while* fixing the others, were deliberately left open (out of scope for the
+   fix that found them) rather than bundled in.
+
+For whatever comes next in this activity: the table at the top of this document is the running index;
+append a row there and a numbered finding section below for every new issue found, in the same
+pattern as #142-#151 above. Whether a newly-found issue also gets fixed immediately or just logged
+depends on what's asked at the time — check the most recent instruction rather than assuming either
+default going forward.

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -219,14 +219,15 @@ axis at baseline. `budgetTokens` is fixed at 2000 for every scenario — well ab
 scenario costs — specifically so budget denial doesn't confound the sweep; that fixed cap is also the
 "don't let generated configs grow unmanaged" rail the maintainer asked for.
 
-**Matrix — 34 scenarios across 7 axes:**
+**Matrix — 41 scenarios across 7 axes** (widened from 34 on 2026-09-01: axis D went from a
+3-affinity spot-check to the full 10-affinity domain):
 
 | Axis | What it sweeps | Domain size | Count |
 |---|---|---|---|
 | A | delver affinity | full (10 kinds) | 10 |
 | B | delver motivation | full non-control domain minus `exploring` (baseline) | 10 |
 | C | hazard expression | full minus `emit` (baseline) | 3 |
-| D | hazard affinity | spot-check subset | 3 |
+| D | hazard affinity | full (10 kinds) | 10 |
 | E | warden present (actor-vs-actor incl. 2-delver+warden stress) | hand-picked | 3 |
 | F | resource authoring (vital payload x2, affinity payload x1) | hand-picked | 3 |
 | G | multi-hazard stress (2 and 3 hazards) | hand-picked | 2 |
@@ -251,13 +252,13 @@ being written up as a finding.
 G2's out-of-bounds hazard is left in the matrix deliberately as a standing regression probe for #148
 — it should keep failing with a malformed message until that's fixed.
 
-**Results:**
+**Results (re-run 2026-09-01 after widening axis D to 41 scenarios):**
 
-- First pass, `ak create --dry-run` only (authoring-layer validation, no artifacts written, no
-  `ak run`): **34/34 PASS.** No anomalies.
-- Second pass, `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **33/34 PASS**
-  on create, **33/33 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple`
-  — see finding 6.
+- `ak create --dry-run` only (authoring-layer validation, no artifacts written, no `ak run`):
+  **41/41 PASS.** No anomalies.
+- `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **40/41 PASS** on create,
+  **40/40 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple` —
+  see finding 6. All 10 axis-D hazard affinities passed clean on both create and run.
 
 **Informational note, not a finding:** the run pass recorded `acceptedActions`/`emittedEffects` counts
 per scenario as metadata only, never as a pass/fail signal — treating "an actor did nothing" as

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -219,13 +219,15 @@ axis at baseline. `budgetTokens` is fixed at 2000 for every scenario — well ab
 scenario costs — specifically so budget denial doesn't confound the sweep; that fixed cap is also the
 "don't let generated configs grow unmanaged" rail the maintainer asked for.
 
-**Matrix — 41 scenarios across 7 axes** (widened from 34 on 2026-09-01: axis D went from a
-3-affinity spot-check to the full 10-affinity domain):
+**Matrix — 42 scenarios across 7 axes**, widened twice on 2026-09-01 (34 → 41 → 42): axis D went
+from a 3-affinity spot-check to the full 10-affinity domain, then axis B grew from the non-control
+motivation domain only to all 4 motivation families, including the control family's
+`user_controlled`:
 
 | Axis | What it sweeps | Domain size | Count |
 |---|---|---|---|
 | A | delver affinity | full (10 kinds) | 10 |
-| B | delver motivation | full non-control domain minus `exploring` (baseline) | 10 |
+| B | delver motivation | full domain, all 4 families, minus `exploring` (baseline) | 11 |
 | C | hazard expression | full minus `emit` (baseline) | 3 |
 | D | hazard affinity | full (10 kinds) | 10 |
 | E | warden present (actor-vs-actor incl. 2-delver+warden stress) | hand-picked | 3 |
@@ -252,13 +254,17 @@ being written up as a finding.
 G2's out-of-bounds hazard is left in the matrix deliberately as a standing regression probe for #148
 — it should keep failing with a malformed message until that's fixed.
 
-**Results (re-run 2026-09-01 after widening axis D to 41 scenarios):**
+**Results (re-run 2026-09-01 after widening axis D and then axis B, 42 scenarios):**
 
 - `ak create --dry-run` only (authoring-layer validation, no artifacts written, no `ak run`):
-  **41/41 PASS.** No anomalies.
-- `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **40/41 PASS** on create,
-  **40/40 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple` —
+  **42/42 PASS.** No anomalies.
+- `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **41/42 PASS** on create,
+  **41/41 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple` —
   see finding 6. All 10 axis-D hazard affinities passed clean on both create and run.
+  `B-delver-motivation-user_controlled` also passed clean on both: `create=PASS`, `run=PASS`,
+  `actions=0, effects=5` — inert at the run layer as expected (player-controlled actors need
+  streamed simulation playback per the Actor persona README; a plain `ak_run` pass has no player
+  input to stream), informational only, not a failure.
 
 **Informational note, not a finding:** the run pass recorded `acceptedActions`/`emittedEffects` counts
 per scenario as metadata only, never as a pass/fail signal — treating "an actor did nothing" as

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -1,0 +1,160 @@
+# MCP harness run-through — friction log
+
+**Status (2026-09-01):** first pass. The maintainer asked to drive `agent-kernel` end-to-end through
+the `agent-kernel-cli` MCP server from inside a Claude Code harness (Bash + Browser-pane tools) and
+have results display back in that harness, logging any friction as it's hit.
+**Audience:** an agent with no memory of the session that produced it.
+**Source of evidence:** live MCP tool calls (`ak_create`, `ak_run`, `ak_push_to_ui`, `ak_show_state`,
+`ak_tick_forward`, `ak_show`, `ak_runs_list`) against `packages/adapters-cli/src/mcp/server.mjs` on
+branch `chore/mcp-session-run-through` (parent `main` @ `9611ad7`), plus reads of
+`packages/adapters-cli/src/tick-session.mjs` and `packages/adapters-cli/src/mcp/README.md`.
+
+**Session goal, restated:** run the app via MCP tools only (no shelling out to `ak.mjs` directly for
+the app-driving steps), get a visual/state result rendered inside the Claude Code harness (Browser
+pane or an inline image), and log each piece of friction as a standalone `gh issue` per
+`AGENTS.md → Working agreement`, back-linked to this file.
+
+---
+
+## Reproduction baseline
+
+```
+ak_create   text="A fire dungeon with one fire delver exploring past a fire hazard."
+            room=["size=small;count=1"]
+            delver=["count=1;affinity=fire;motivation=exploring;goals=max_mana,mana_regen"]
+            hazard=["x=3;y=3;affinity=fire;expression=emit;stacks=1"]
+            budgetTokens=1000  runId=run_mcp_session_demo2
+            outDir=artifacts/runs/run_mcp_session_demo2/create
+
+ak_run      simConfig=.../create/sim-config.json  initialState=.../create/initial-state.json
+            ticks=5  seed=0  runId=run_mcp_session_demo2
+            outDir=artifacts/runs/run_mcp_session_demo2/run
+```
+
+Both succeeded (`ok: true`). Everything below was hit while trying to *see* and *step through* the
+result of that run through MCP tools alone.
+
+---
+
+## 1. `ak_push_to_ui`'s WebSocket bridge is unreachable from the harness that is meant to host it
+
+**What's failing:** `ak_push_to_ui` starts a sandbox bridge WebSocket server on a port it picks
+(`38487` in this run) inside the MCP server's own process, and the browser UI (`packages/ui-web`,
+served via `serve:c`) connects to that port directly (`packages/ui-web/src/main.js:520-521`,
+`AK_BRIDGE_PORT = globalThis.__ak_sandboxBridgePort ?? 38487`). In this Claude Code harness:
+
+- `curl http://127.0.0.1:38487/` from the harness's own Bash tool: **connection refused**, and the
+  port doesn't appear in `lsof -i :38487` at all.
+- The harness's Browser pane (opened via `preview_start`, which *did* successfully reach the
+  `serve:c` dev server on `:8001` through the harness's own tunnel) logs repeated
+  `WebSocket connection to 'ws://127.0.0.1:38487/ak-sandbox' failed` — the UI loads, but never
+  receives the pushed bundle.
+
+**Why:** the MCP server process and the harness's Bash/Browser-pane tools do not share a network
+namespace here. Only ports the harness itself provisions (via `preview_start`) get tunneled through
+to the Browser pane; a raw port opened directly by a tool the MCP server spawns is invisible to both
+`curl` from Bash and the Browser pane. `openBrowser: true` on `ak_push_to_ui` would fare no better —
+it opens the *host's* default browser, which is a different surface than the harness's Browser pane
+and isn't what "display in the Claude harness" means for this task.
+
+**Impact:** the entire live "push a run to the gameplay UI and watch it play" path that
+`ak_push_to_ui` exists for is unusable end-to-end when the MCP server and the driving harness are
+this kind of sandboxed pair — not a fixture/data problem, an environment-reachability one.
+
+**Workaround used this session:** `ak_show_state` / `ak_tick_forward` / `ak_tick_backward` return
+state inline over the MCP response itself (ASCII or a PNG data URI) — no second network hop needed.
+That's the channel that actually works here; see finding 3 for its own limitation.
+
+## 2. `ak_show_state` / `ak_tick_forward` / `ak_tick_backward` resolve runs from a different root than `ak_create` / `ak_run` / `ak_show` / `ak_runs_list`
+
+**What's failing:** after a clean `ak_create` → `ak_run` with `outDir` omitted (the default —
+"MCP server uses a writable temp folder and remembers it"), `ak_show_state` returns:
+
+```
+{"ok":false,"command":"tick","action":"state","runId":"run_mcp_session_demo","error":"run directory not found: run_mcp_session_demo"}
+```
+
+even though `ak_show` and `ak_runs_list`, called with the same `runId` right after, both report the
+run indexed and `status: "success"` — because they read from the MCP server's own remembered temp
+root (`/var/folders/.../agent-kernel-mcp-<id>/<runId>/...`).
+
+**Root cause:** `resolveRunDir()` in
+[`packages/adapters-cli/src/tick-session.mjs:9-14`](packages/adapters-cli/src/tick-session.mjs#L9-L14)
+is hardcoded to `process.env.AK_ARTIFACTS_DIR ?? join(process.cwd(), "artifacts")` + `runs/<runId>` —
+it never consults the MCP server's "remembered outDir per runId" mechanism that every other run-aware
+tool in this same server (`ak_show`, `ak_runs_list`, and `ak_create`/`ak_run`'s own follow-up calls)
+uses. `packages/adapters-cli/src/mcp/tools/tick.mjs` calls `resolveRunDir(runId)` directly.
+
+**Impact:** the documented "most common agent loop" in `packages/adapters-cli/src/mcp/README.md`
+(`ak_create` or `ak_llm_plan` → `ak_run` → `ak_show`/`ak_inspect` → `ak_narrate` or `ak_diff`) works
+fine end-to-end with default temp `outDir`s — but the moment you want to *step through or visualize*
+that same run with `ak_show_state`/`ak_tick_forward`/`ak_tick_backward`, it silently can't find it,
+with no hint that the fix is "pass `outDir=artifacts/runs/<runId>/<command>` explicitly on every call
+instead." Confirmed as the fix: re-running `ak_create`/`ak_run` with `outDir` pinned under
+`<repo>/artifacts/runs/<runId>/{create,run}` made `ak_show_state`/`ak_tick_forward` work immediately.
+
+## 3. `ak_show_state`'s `image` visualization mode blows the MCP tool-result size limit
+
+**What's failing:** `ak_show_state({runId, visualization: "image"})` on the same run that answered
+fine in `ascii` mode returned a 443,790-character JSON payload (a `visualizationDataUri` PNG,
+base64-inlined) and hit this harness's tool-result token ceiling — the harness caught it and spilled
+the raw result to a scratch file rather than delivering it as a normal tool result.
+
+**Impact:** the `image` mode is the one most naturally suited to "show me what's happening" in a
+harness like this, and it's the one that doesn't fit through the channel. `ascii` mode worked cleanly
+at a fraction of the size and is what this session used to confirm tick-by-tick state. Two independent
+paths to a fix, not mutually exclusive: (a) MCP image results should use the protocol's native image
+content-block type instead of embedding a data URI inside the JSON text result, or (b) `ak_show_state`
+should support writing the PNG to a file and returning its path, the way every artifact-producing `ak_*`
+tool already does, instead of always inlining bytes.
+
+## 4. `ak_create`'s budget denial doesn't say what budget would have worked
+
+**What's failing:** `ak_create` with `budgetTokens=200` for one small room + one fire delver +
+one hazard was denied:
+
+```
+Budget receipt denied: status=denied; remaining=41; deniedLines=actor:actor_spawn:delvers,... (+8 more); deniedPools=delver:92/72
+```
+
+Re-running the identical spec with `budgetTokens=1000` succeeded with **`totalSpend: 159`** —
+well under the 200 that was rejected. The denial isn't driven by the total; `deniedPools=delver:92/72`
+shows a *per-category* pool (`delver`) was short even though total remaining (`41`) looked adequate,
+and the category split isn't derivable from the `budgetTokens` input alone.
+
+**Impact:** a caller who gets a `deniedPools` line has no way to compute the minimum `budgetTokens`
+that would clear it without trial and error — the error reports what was denied, not the shortfall
+size or the total that would resolve it. This is the same family of "comprehensive error message"
+work already tracked in `error-message-quality-sweep.md` (SM0–SM3, merged) but for a category that
+sweep's own scope note (`budget receipt denial` is a distinct code path from the `ak_create` field
+validators it audited) didn't cover.
+
+## 5. (open question, not yet root-caused) An authored delver took zero actions across a 5-tick plain `ak_run`
+
+**Observation:** `run_mcp_session_demo2` — one delver, `motivation=exploring`, run for 5 ticks via
+plain `ak_run` with no `--actions`/`actions` input (which the CLI help describes as being for
+"deterministic replay," i.e. optional, not a prerequisite for autonomous behavior) — produced:
+
+- `action-log.json`: `"actions": []`
+- `effects-log.json`: exactly 3 effects, all `status: "deferred"` (`missing_telemetry` /
+  `missing_logger`), i.e. harness-side bookkeeping, not gameplay effects
+- `ak_tick_forward` at tick 1, 2, and 3 all show the delver at the identical `{x:3,y:2}` with
+  identical vitals — no movement, no decisions, no state change of any kind
+
+**Why this is flagged rather than fixed inline:** this repo's own persona model gives the Actor
+persona an `observe, decide` tick phase specifically to propose actions, and `runtime` orchestrates
+that independently of any `--actions` replay file — so zero actions over 5 ticks for an
+`exploring`-motivated actor is either (a) a real regression in the autonomous decision path invoked
+by plain `ak_run`, or (b) expected behavior this session doesn't have context to judge (e.g. `ak_run`
+alone may intentionally not invoke actor decision-making, and only `ak_scenario` or a
+`--actions`-driven path does). The branch this session started from carries two same-day commits —
+`4112ac8 feat: complete persona-owned perception and solver policy` and
+`d47dfba refactor(runtime): restore allocator and configurator authority` — that are plausibly
+adjacent to whatever gates this, which is exactly the kind of thing that should be root-caused with
+Serena/`find_referencing_symbols` on the Actor persona's `advance()`, not guessed at from outside.
+
+---
+
+## Issues filed from this doc
+
+(filled in as `gh issue create` runs land — each issue links back here by path)

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -38,6 +38,7 @@ this file.
 | [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) | Open question: does plain `ak_run` ever invoke autonomous actor decision-making? | **Closed, not planned** | — | Superseded by #147; premise was wrong, see finding 5 |
 | [#147](https://github.com/KomplexMojo/agent-kernel/issues/147) | `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn position, single-frame overlay instead of cumulative replay | Open | No — top-level `ascii` field on `ak_show_state` (built by `renderAscii`) is a working substitute | Finding 5 |
 | [#148](https://github.com/KomplexMojo/agent-kernel/issues/148) | level-gen error formatter in `orchestrate-build.js` bakes literal `"undefined"` into messages for 4 of 5 error codes | Open | No — the underlying rejection is correct, only the message text is broken | Finding 6 |
+| [#149](https://github.com/KomplexMojo/agent-kernel/issues/149) | `ak run`'s `action-log.json`/`run-summary.json`/`world-state.json` use wall-clock meta stamps, breaking reproducibility the simulation itself has | Open | No — the simulation trace (tick-frames/effects-log/decision-captures) is unaffected; only these three artifacts' `meta.id`/`meta.createdAt` | Finding 7 |
 
 None of the open issues above block continued use of the MCP surface — every one has a stated
 workaround. Full repro steps, root-cause evidence, and code pointers for each are in the numbered
@@ -267,7 +268,7 @@ being written up as a finding.
 
 **Scripts (promoted into the repo 2026-09-01):**
 [`scripts/testing/configuration-permutation-matrix.mjs`](scripts/testing/configuration-permutation-matrix.mjs)
-(the 34-scenario matrix data) and
+(the 50-scenario matrix data) and
 [`scripts/testing/run-configuration-permutation-sweep.mjs`](scripts/testing/run-configuration-permutation-sweep.mjs)
 (the unified create+run runner, `--dry-run` for authoring-only). Wired up as `pnpm run config-sweep`
 (full) and `pnpm run config-sweep:dry-run`. Output goes to `artifacts/matrix-sweep/` (gitignored).
@@ -323,6 +324,57 @@ coverage (`tests/runtime/actor-motivation-combat.test.js`: "defending actor does
 is not adjacent" — no hostile exists in a single-actor scenario). None of this was investigated
 further; flagged here only so a future sweep doesn't have to re-derive that these are expected.
 
+**Hazard interaction — what this sweep found (2026-09-01).** The maintainer asked whether hazard
+interaction could be deterministically tested the same way. Short answer: not the way "interaction"
+initially reads — but the investigation into why led somewhere more useful.
+
+Empirical test first: a `stationary` actor placed via `--actor` override directly adjacent to, then
+directly on top of, a `stacks=3 fire/emit` hazard, run 5 ticks with `--world-state-checkpoints`
+capturing vitals every tick. Result: **zero change, bit-for-bit, at every tick, in both placements.**
+That sent the investigation into `core-ts`'s own test suite
+(`tests/core-ts/affinity-environment-effects.test.mts`, `tests/runtime/hazard-vitals-in-observation.test.js`),
+which settled why: hazards authored via `ak_create`/`ak_run` are wired through
+`core.armStaticHazardAt` into a **static affinity field**
+(`core.computeStaticHazardAffinityField`/`getAffinityFieldIntensityAt`) — a radius/intensity
+projection (with a documented zero-intensity buffer ring at distance 1 specifically for `emit`) that
+feeds an actor's **observation** (what it perceives, read by the Actor persona at decide-time), not an
+automatic vital-damage tick. That field is internal to `core-ts` and is never written to any file
+`ak_create`/`ak_run` produces, so its exact effect isn't assertable from this sweep's black-box
+vantage point without a `core-ts`-level test — a different tool than this one.
+
+What *is* assertable from here, and is the real prerequisite for any interaction-specific assertion to
+mean anything at all: **is the simulation reproducible, given the same inputs, at every layer this
+sweep can see.** That's the check that got built (see "Determinism/reproducibility check" below), and
+it answered its own question cleanly — while also surfacing a real, unrelated bug (#149) that would
+have made the check useless if left unhandled.
+
+**Determinism/reproducibility check.** `checkDeterminism()` in `run-configuration-permutation-sweep.mjs`
+re-runs `ak run` a second time against the exact same `sim-config.json`/`initial-state.json` (same
+`run-id`, a separate `--out-dir`) and deep-compares every artifact the first run produced. The clock
+`ak run` injects into the simulation is seeded from `sim-config.json`'s own `meta.createdAt`
+(`createDeterministicClock`/`resolveClockSeed` in `run-helpers.js`), not the wall clock, so a
+genuinely deterministic simulation should match exactly.
+
+First pass surfaced a real bug rather than confirming determinism: **all 49 scenarios mismatched**,
+every time in exactly the same three files (`action-log.json`, `run-summary.json`,
+`world-state.json`) and never in `tick-frames.json`/`effects-log.json`/`runtime-decision-captures.json`
+— which matched byte-for-byte, every scenario, every field. Root cause, filed as
+**[#149](https://github.com/KomplexMojo/agent-kernel/issues/149)**: those three artifacts stamp
+`meta.id`/`meta.createdAt` via the host's wall-clock `createMeta()`/`makeId()`
+(`packages/adapters-cli/src/cli/ak-impl.mjs:1597-1611`), completely bypassing the seeded clock the
+simulation itself uses — the same failure mode a `visualization-snapshot.js` comment (PX.3) already
+documents fixing at the render layer, unfixed here at the command layer. Confirmed as the *only*
+difference by inspecting the raw diffs (e.g. `action-log.json`'s `createdAt` and `id` differed between
+runs; every other field, including `runId`, matched).
+
+With that bug confirmed and filed (not fixed inline — out of scope for this sweep, per the working
+agreement), `checkDeterminism()` was narrowed to strip exactly `id`+`createdAt` when they co-occur on
+an object shaped like a `createMeta()` stamp — `runId`/`producedBy`/every other field still has to
+match, so a real regression there isn't masked, only the known #149 gap. Re-run after narrowing:
+**49/49 reproducible, 0 mismatched.** The simulation itself — including whatever the hazard
+affinity-field math actually does internally — is fully deterministic given the same seed and inputs;
+the only non-reproducibility in the whole matrix was #149's wall-clock metadata stamps.
+
 ## 6. `orchestrate-build.js`'s level-gen error formatter produces literal "undefined" text for 4 of 5 error codes
 
 **What's failing:** `G2-multi-hazard-triple` (3 hazards, one placed at a room-relative position
@@ -359,6 +411,19 @@ structured detail object computed by `level-layout.js`, then mangled by its call
 fix only patched the one code it was chasing; the generic formatter producing every *other* level-gen
 error was never made shape-aware, so the same failure mode is still reachable through hazard/element
 placement errors, which this sweep's axis G hit on its very first out-of-bounds scenario.
+
+## 7. `ak run`'s `action-log.json`/`run-summary.json`/`world-state.json` use wall-clock meta stamps, breaking reproducibility the simulation itself has
+
+Full writeup is in "Hazard interaction — what this sweep found" above (this is where the
+determinism/reproducibility check that found it lives). Summary: `ak run`'s actual simulation trace
+(`tick-frames.json`, `effects-log.json`, `runtime-decision-captures.json`) is fully deterministic —
+confirmed byte-for-byte across 49 scenarios given the same seed and inputs — but three other artifacts
+the same command writes (`action-log.json`, `run-summary.json`, `world-state.json`) stamp
+`meta.id`/`meta.createdAt` from the host's wall-clock `createMeta()`/`makeId()`
+([`ak-impl.mjs:1597-1611`](packages/adapters-cli/src/cli/ak-impl.mjs#L1597-L1611)) instead of the
+run's own seeded clock, so those two fields — and only those two fields — differ every time, even
+given byte-identical input. Filed as
+**[#149](https://github.com/KomplexMojo/agent-kernel/issues/149)**.
 
 ---
 

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -242,10 +242,14 @@ its own `outDir`, and on success feeds the resulting `sim-config.json`/`initial-
 anything not cleanly explained by a known, expected rejection pattern gets triaged by hand before
 being written up as a finding.
 
-**Scripts (currently scratchpad-only, not committed):**
-`permutation-matrix.mjs` (the 34-scenario matrix data) and `run-matrix-full.mjs` (the create+run
-runner) — not yet promoted into the repo; ask if/when this should become a permanent, committed tool
-rather than a one-off validation script.
+**Scripts (promoted into the repo 2026-09-01):**
+[`scripts/testing/configuration-permutation-matrix.mjs`](scripts/testing/configuration-permutation-matrix.mjs)
+(the 34-scenario matrix data) and
+[`scripts/testing/run-configuration-permutation-sweep.mjs`](scripts/testing/run-configuration-permutation-sweep.mjs)
+(the unified create+run runner, `--dry-run` for authoring-only). Wired up as `pnpm run config-sweep`
+(full) and `pnpm run config-sweep:dry-run`. Output goes to `artifacts/matrix-sweep/` (gitignored).
+G2's out-of-bounds hazard is left in the matrix deliberately as a standing regression probe for #148
+— it should keep failing with a malformed message until that's fixed.
 
 **Results:**
 

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -291,6 +291,26 @@ G2's out-of-bounds hazard is left in the matrix deliberately as a standing regre
   need streamed simulation playback per the Actor persona README; a plain `ak_run` pass has no
   player input to stream), informational only, not a failure.
 
+**Step-level assertions (added 2026-09-01).** Everything above only classified the *whole run* —
+exactly the gap a coverage review of this sweep surfaced: no automated check ever inspected a single
+tick in isolation, so a defect present at tick 2 and gone by tick 5 (#147's exact shape: correct in
+aggregate, wrong at every individual tick) would have been invisible to it. `stepLevelCheck()` in
+`run-configuration-permutation-sweep.mjs` closes that gap with zero extra CLI/MCP calls — it
+post-processes `tick-frames.json`/`initial-state.json`/`sim-config.json`, which the `run` step
+already writes, replaying `acceptedActions` cumulatively tick-by-tick (the same approach
+`ak_show_state`'s own correct `resolveActorPositionsAtTick()` uses) and asserting, at every tick:
+every accepted move landed in-bounds and off a wall tile, no two actors ever occupy the same tile
+after a tick's moves are applied, and every requested tick produced exactly one `apply` phase-frame
+(no skipped or duplicated ticks).
+
+Result: **49/49 checked scenarios clean, 0 violations**, across 245 total ticks (5 × 49). Verified the
+checker actually has teeth with a perturbation test — a hand-corrupted accepted move (destination
+`(99,99)`, deliberately out of a 9×9 grid) was caught immediately (`tick 1: accepted move put
+card_delver_1-1 out of grid bounds at (99,99)`) before being reverted; the real sweep run was
+unaffected. Console output and `results-full.json` now report a `step=OK(N)` / `step=VIOLATIONS(n)`
+per scenario and a `stepLevelSummary` aggregate, and a scenario with violations now fails the sweep's
+exit code the same way an `ANOMALY_*` create/run result does.
+
 **Informational note, not a finding:** the run pass recorded `acceptedActions`/`emittedEffects` counts
 per scenario as metadata only, never as a pass/fail signal — treating "an actor did nothing" as
 itself suspect is exactly the false-positive this session already hit once (issue #146, closed; see

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -1,18 +1,46 @@
-# MCP harness run-through — friction log
+# MCP harness run-through — open issues & handoff context
 
-**Status (2026-09-01):** first pass. The maintainer asked to drive `agent-kernel` end-to-end through
-the `agent-kernel-cli` MCP server from inside a Claude Code harness (Bash + Browser-pane tools) and
-have results display back in that harness, logging any friction as it's hit.
+**Status (2026-09-01):** first pass, actively growing. The maintainer asked to drive `agent-kernel`
+end-to-end through the `agent-kernel-cli` MCP server from inside a Claude Code harness (Bash +
+Browser-pane tools), have results display back in that harness, and file every piece of friction hit
+along the way as a standalone `gh issue`, immediately, as it's found — per
+`AGENTS.md → Working agreement`. This document is the handoff artifact: a running summary of every
+issue opened from this activity plus enough standalone context (repro steps, root cause, evidence,
+code locations) that **a different agent with no memory of this session can pick any one issue up and
+fix it without re-deriving anything above what's written here.**
+
+**This document does not itself fix anything.** Issues found here are filed to GitHub and logged below
+as they're identified; resolving them is explicitly out of scope for the session that finds them —
+that's separate work, for whoever (or whichever session) picks an issue off the list.
+
 **Audience:** an agent with no memory of the session that produced it.
 **Source of evidence:** live MCP tool calls (`ak_create`, `ak_run`, `ak_push_to_ui`, `ak_show_state`,
 `ak_tick_forward`, `ak_show`, `ak_runs_list`) against `packages/adapters-cli/src/mcp/server.mjs` on
 branch `chore/mcp-session-run-through` (parent `main` @ `9611ad7`), plus reads of
-`packages/adapters-cli/src/tick-session.mjs` and `packages/adapters-cli/src/mcp/README.md`.
+`packages/adapters-cli/src/tick-session.mjs` and `packages/adapters-cli/src/mcp/README.md`, and one
+root-cause pass with Serena's semantic tools (see finding 5).
 
 **Session goal, restated:** run the app via MCP tools only (no shelling out to `ak.mjs` directly for
 the app-driving steps), get a visual/state result rendered inside the Claude Code harness (Browser
-pane or an inline image), and log each piece of friction as a standalone `gh issue` per
-`AGENTS.md → Working agreement`, back-linked to this file.
+pane or an inline image), and file each piece of friction as a standalone `gh issue`, back-linked to
+this file.
+
+---
+
+## Open issues (start here)
+
+| # | Title | Status | Blocking? | Context |
+|---|---|---|---|---|
+| [#142](https://github.com/KomplexMojo/agent-kernel/issues/142) | `ak_push_to_ui`'s sandbox WebSocket bridge is unreachable from a sandboxed MCP-driving harness | Open | No — `ak_show_state`/`ak_tick_forward` are a working substitute | Finding 1 |
+| [#143](https://github.com/KomplexMojo/agent-kernel/issues/143) | `ak_show_state`/`ak_tick_forward`/`ak_tick_backward` resolve runs from a different root than `ak_create`/`ak_run`/`ak_show` | Open | No — workaround: pass `outDir=artifacts/runs/<runId>/<command>` explicitly | Finding 2 |
+| [#144](https://github.com/KomplexMojo/agent-kernel/issues/144) | `ak_show_state`'s `image` visualization mode blows the MCP tool-result size limit | Open | No — `ascii` mode works | Finding 3 |
+| [#145](https://github.com/KomplexMojo/agent-kernel/issues/145) | `ak_create` budget denial doesn't say what budget would have worked | Open | No — workaround: retry with a larger `budgetTokens` | Finding 4 |
+| [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) | Open question: does plain `ak_run` ever invoke autonomous actor decision-making? | **Closed, not planned** | — | Superseded by #147; premise was wrong, see finding 5 |
+| [#147](https://github.com/KomplexMojo/agent-kernel/issues/147) | `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn position, single-frame overlay instead of cumulative replay | Open | No — top-level `ascii` field on `ak_show_state` (built by `renderAscii`) is a working substitute | Finding 5 |
+
+None of the open issues above block continued use of the MCP surface — every one has a stated
+workaround. Full repro steps, root-cause evidence, and code pointers for each are in the numbered
+findings below.
 
 ---
 
@@ -177,22 +205,11 @@ visualization path.
 
 ---
 
-## Issues filed from this doc
+## Workflow for the rest of this activity
 
-- [#142](https://github.com/KomplexMojo/agent-kernel/issues/142) — `ak_push_to_ui`'s sandbox WebSocket bridge is unreachable from a sandboxed MCP-driving harness (finding 1)
-- [#143](https://github.com/KomplexMojo/agent-kernel/issues/143) — `ak_show_state`/`ak_tick_forward`/`ak_tick_backward` resolve runs from a different root than `ak_create`/`ak_run`/`ak_show` (finding 2)
-- [#144](https://github.com/KomplexMojo/agent-kernel/issues/144) — `ak_show_state`'s `image` visualization mode blows the MCP tool-result size limit (finding 3)
-- [#145](https://github.com/KomplexMojo/agent-kernel/issues/145) — `ak_create` budget denial doesn't say what budget would have worked (finding 4)
-- [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) — open question: does plain `ak_run` ever invoke autonomous actor decision-making? **CLOSED, not planned** — root-caused with Serena; premise was wrong, see #147
-- [#147](https://github.com/KomplexMojo/agent-kernel/issues/147) — `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn position, single-frame overlay instead of cumulative replay (finding 5, corrected)
-
----
-
-## Pending issue sweep (not yet filed)
-
-**Workflow change (maintainer, 2026-09-01):** non-blocking friction found from here on is logged in
-this section only, not filed as a `gh issue` immediately. #142-#147 above were filed one at a time;
-everything below waits for an explicit end-of-session sweep. "Blocking" (stops the current line of
-work outright) still gets surfaced immediately in chat rather than queued here.
-
-(none yet)
+**Corrected 2026-09-01** (see conversation): every issue found gets filed to GitHub immediately, as
+it's identified — not batched into an end-of-session sweep. What's deferred is *fixing* them: this
+session's job is to run the app, find friction, root-cause it enough to hand off cleanly, and file the
+issue with that context attached (repro, root cause, code pointers, evidence) — not to patch the code.
+The table at the top of this document is the running index; append a row there and a numbered finding
+section below for every new issue, in the same pattern as #142-#147 above.

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -185,3 +185,14 @@ visualization path.
 - [#145](https://github.com/KomplexMojo/agent-kernel/issues/145) — `ak_create` budget denial doesn't say what budget would have worked (finding 4)
 - [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) — open question: does plain `ak_run` ever invoke autonomous actor decision-making? **CLOSED, not planned** — root-caused with Serena; premise was wrong, see #147
 - [#147](https://github.com/KomplexMojo/agent-kernel/issues/147) — `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn position, single-frame overlay instead of cumulative replay (finding 5, corrected)
+
+---
+
+## Pending issue sweep (not yet filed)
+
+**Workflow change (maintainer, 2026-09-01):** non-blocking friction found from here on is logged in
+this section only, not filed as a `gh issue` immediately. #142-#147 above were filed one at a time;
+everything below waits for an explicit end-of-session sweep. "Blocking" (stops the current line of
+work outright) still gets surfaced immediately in chat rather than queued here.
+
+(none yet)

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -37,6 +37,7 @@ this file.
 | [#145](https://github.com/KomplexMojo/agent-kernel/issues/145) | `ak_create` budget denial doesn't say what budget would have worked | Open | No — workaround: retry with a larger `budgetTokens` | Finding 4 |
 | [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) | Open question: does plain `ak_run` ever invoke autonomous actor decision-making? | **Closed, not planned** | — | Superseded by #147; premise was wrong, see finding 5 |
 | [#147](https://github.com/KomplexMojo/agent-kernel/issues/147) | `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn position, single-frame overlay instead of cumulative replay | Open | No — top-level `ascii` field on `ak_show_state` (built by `renderAscii`) is a working substitute | Finding 5 |
+| [#148](https://github.com/KomplexMojo/agent-kernel/issues/148) | level-gen error formatter in `orchestrate-build.js` bakes literal `"undefined"` into messages for 4 of 5 error codes | Open | No — the underlying rejection is correct, only the message text is broken | Finding 6 |
 
 None of the open issues above block continued use of the MCP surface — every one has a stated
 workaround. Full repro steps, root-cause evidence, and code pointers for each are in the numbered
@@ -202,6 +203,106 @@ frozen. Two functions in the same package solve the identical problem; only one 
 whole run` (merged via #140) — a tick-cursor visualization reading a stale/wrong single frame instead
 of replaying accepted actions cumulatively. That fix apparently didn't extend to this MCP-side
 visualization path.
+
+---
+
+## Configuration-permutation sweep (2026-09-01)
+
+**Purpose:** automate the kind of manual poking that found findings 1-5 above, across a bounded
+matrix of delver/warden/hazard/resource configurations, rather than one hand-picked scenario at a
+time. "Every possible permutation" is not literally tractable — full Cartesian product of affinity
+(10) x expression (4) x motivation (11) x counts x entity-type combinations runs into the thousands —
+so this is a **one-axis-at-a-time sweep off a single known-good baseline** (room: 1 small room;
+delver: 1x fire/exploring; hazard: 1x fire/emit/stacks=1 at a room-relative position), varying one
+axis across its full domain (or a spot-check subset for the larger domains) while holding every other
+axis at baseline. `budgetTokens` is fixed at 2000 for every scenario — well above what any one
+scenario costs — specifically so budget denial doesn't confound the sweep; that fixed cap is also the
+"don't let generated configs grow unmanaged" rail the maintainer asked for.
+
+**Matrix — 34 scenarios across 7 axes:**
+
+| Axis | What it sweeps | Domain size | Count |
+|---|---|---|---|
+| A | delver affinity | full (10 kinds) | 10 |
+| B | delver motivation | full non-control domain minus `exploring` (baseline) | 10 |
+| C | hazard expression | full minus `emit` (baseline) | 3 |
+| D | hazard affinity | spot-check subset | 3 |
+| E | warden present (actor-vs-actor incl. 2-delver+warden stress) | hand-picked | 3 |
+| F | resource authoring (vital payload x2, affinity payload x1) | hand-picked | 3 |
+| G | multi-hazard stress (2 and 3 hazards) | hand-picked | 2 |
+
+**Methodology:** shells out to the real CLI (`node packages/adapters-cli/src/cli/ak.mjs`) directly
+rather than through MCP tool calls — this is scripted batch automation, which
+`packages/adapters-cli/src/mcp/README.md`'s own "Mental Model" section calls out as the right case for
+using the CLI directly ("ad hoc shell usage... scripting outside an MCP client"), not a departure from
+the MCP-first approach the rest of this doc uses. Each scenario runs `ak create` (no `--dry-run`) into
+its own `outDir`, and on success feeds the resulting `sim-config.json`/`initial-state.json` into
+`ak run --ticks 5 --seed 0`. Results are classified: `PASS`, `EXPECTED_BUDGET_DENIAL`,
+`VALIDATION_REJECTION`, or `ANOMALY_*` (crash / malformed output / unrecognized failure shape) —
+anything not cleanly explained by a known, expected rejection pattern gets triaged by hand before
+being written up as a finding.
+
+**Scripts (currently scratchpad-only, not committed):**
+`permutation-matrix.mjs` (the 34-scenario matrix data) and `run-matrix-full.mjs` (the create+run
+runner) — not yet promoted into the repo; ask if/when this should become a permanent, committed tool
+rather than a one-off validation script.
+
+**Results:**
+
+- First pass, `ak create --dry-run` only (authoring-layer validation, no artifacts written, no
+  `ak run`): **34/34 PASS.** No anomalies.
+- Second pass, `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **33/34 PASS**
+  on create, **33/33 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple`
+  — see finding 6.
+
+**Informational note, not a finding:** the run pass recorded `acceptedActions`/`emittedEffects` counts
+per scenario as metadata only, never as a pass/fail signal — treating "an actor did nothing" as
+itself suspect is exactly the false-positive this session already hit once (issue #146, closed; see
+finding 5). Axis B's cognition-only motivations (`reflexive`, `goal_oriented`, `strategy_focused`)
+and `stationary` all showed `actions=0`; per `packages/runtime/src/personas/actor/README.md`,
+cognition motivations compose with a *mobility* motivation rather than supplying one, so a
+cognition-only actor legitimately has no movement instruction — consistent with, not contradicting,
+documented behavior. `defending` showed `actions=0, effects=5`, also consistent with existing test
+coverage (`tests/runtime/actor-motivation-combat.test.js`: "defending actor does not move when hostile
+is not adjacent" — no hostile exists in a single-actor scenario). None of this was investigated
+further; flagged here only so a future sweep doesn't have to re-derive that these are expected.
+
+## 6. `orchestrate-build.js`'s level-gen error formatter produces literal "undefined" text for 4 of 5 error codes
+
+**What's failing:** `G2-multi-hazard-triple` (3 hazards, one placed at a room-relative position
+outside the room's bounds) failed `ak create` with:
+
+```
+{"ok":false,"command":"create","error":"level-gen input invalid: hazards[2].position:hazard_outside_room (requested undefined, need at least undefined for undefined rooms)"}
+```
+
+The underlying rejection is legitimate — hazard `x`/`y` in a `create`/`configure` spec are
+room-relative offsets into the target room's carved interior
+([`level-layout.js:1469-1476`](packages/runtime/src/personas/configurator/level-layout.js#L1469-L1476)),
+and this scenario's third hazard coordinate exceeded that room's bounds. The message text is what's
+broken.
+
+**Root cause:** [`orchestrate-build.js:397-406`](packages/runtime/src/build/orchestrate-build.js#L397-L406)
+formats every `level-layout.js` error with one hardcoded template —
+`` `(requested ${err.detail.target}, need at least ${err.detail.required} for ${err.detail.roomCount} rooms)` ``
+— written for exactly one error code's detail shape. `level-layout.js` raises five distinct codes;
+only `floor_tile_budget_insufficient` (the case `error-message-quality-sweep.md` SM3/SM4 already
+fixed) matches that shape. The other four —
+[`hazard_outside_room`](packages/runtime/src/personas/configurator/level-layout.js#L1492-L1502)
+(`{x, y, roomId, roomWidth, roomHeight}`),
+[`hazard_on_wall`](packages/runtime/src/personas/configurator/level-layout.js#L2659) (`{x, y, affinity}`),
+[`element_on_wall`](packages/runtime/src/personas/configurator/level-layout.js#L2686) (`{x, y, id}`), and
+[`target_mismatch`](packages/runtime/src/personas/configurator/level-layout.js#L2706) (`{target, walkableTiles}`)
+— all have incompatible shapes. Because `err.detail` is truthy in every case, the formatter's ternary
+always takes the "format it" branch rather than falling back to the plain `field:code` form, so all
+four silently degrade to `undefined`-polluted text instead of formatting correctly or omitting the
+parenthetical.
+
+**Impact:** same defect family as the already-tracked `error-message-quality-sweep.md` work (a rich
+structured detail object computed by `level-layout.js`, then mangled by its caller) — but that sweep's
+fix only patched the one code it was chasing; the generic formatter producing every *other* level-gen
+error was never made shape-aware, so the same failure mode is still reachable through hazard/element
+placement errors, which this sweep's axis G hit on its very first out-of-bounds scenario.
 
 ---
 

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -157,4 +157,8 @@ Serena/`find_referencing_symbols` on the Actor persona's `advance()`, not guesse
 
 ## Issues filed from this doc
 
-(filled in as `gh issue create` runs land — each issue links back here by path)
+- [#142](https://github.com/KomplexMojo/agent-kernel/issues/142) — `ak_push_to_ui`'s sandbox WebSocket bridge is unreachable from a sandboxed MCP-driving harness (finding 1)
+- [#143](https://github.com/KomplexMojo/agent-kernel/issues/143) — `ak_show_state`/`ak_tick_forward`/`ak_tick_backward` resolve runs from a different root than `ak_create`/`ak_run`/`ak_show` (finding 2)
+- [#144](https://github.com/KomplexMojo/agent-kernel/issues/144) — `ak_show_state`'s `image` visualization mode blows the MCP tool-result size limit (finding 3)
+- [#145](https://github.com/KomplexMojo/agent-kernel/issues/145) — `ak_create` budget denial doesn't say what budget would have worked (finding 4)
+- [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) — open question: does plain `ak_run` ever invoke autonomous actor decision-making? (finding 5)

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -219,20 +219,29 @@ axis at baseline. `budgetTokens` is fixed at 2000 for every scenario — well ab
 scenario costs — specifically so budget denial doesn't confound the sweep; that fixed cap is also the
 "don't let generated configs grow unmanaged" rail the maintainer asked for.
 
-**Matrix — 42 scenarios across 7 axes**, widened twice on 2026-09-01 (34 → 41 → 42): axis D went
-from a 3-affinity spot-check to the full 10-affinity domain, then axis B grew from the non-control
-motivation domain only to all 4 motivation families, including the control family's
-`user_controlled`:
+**Matrix — 46 scenarios across 7 axes**, widened three times on 2026-09-01 (34 → 41 → 42 → 46):
+axis D went from a 3-affinity spot-check to the full 10-affinity domain, axis B grew from the
+non-control motivation domain only to all 4 motivation families (including `user_controlled`), then
+axis C grew a position sub-sweep — the room's two diagonals (4 corners) — alongside its original
+expression sweep:
 
 | Axis | What it sweeps | Domain size | Count |
 |---|---|---|---|
 | A | delver affinity | full (10 kinds) | 10 |
 | B | delver motivation | full domain, all 4 families, minus `exploring` (baseline) | 11 |
-| C | hazard expression | full minus `emit` (baseline) | 3 |
+| C | hazard expression (3) + hazard position, room's two diagonals (4 corners) | full expression domain minus `emit`; diagonal corners of a 5x5 interior | 7 |
 | D | hazard affinity | full (10 kinds) | 10 |
 | E | warden present (actor-vs-actor incl. 2-delver+warden stress) | hand-picked | 3 |
 | F | resource authoring (vital payload x2, affinity payload x1) | hand-picked | 3 |
 | G | multi-hazard stress (2 and 3 hazards) | hand-picked | 2 |
+
+Axis C's diagonal-position sub-sweep exists because hazard x/y are room-relative offsets into the
+target room's carved interior, and a "small" room's interior is confirmed 5x5 (relative `0..4` on
+each axis — the underlying grid is `9x9` with a 1-tile border wall). The four corners are that
+interior's diagonal extremes; diagonal-adjacent-to-wall geometry (corner peeking, diagonal blocking)
+is called out elsewhere in this codebase (`packages/runtime/src/personas/actor/README.md`,
+line-of-sight section) as a distinct code path from cardinal placement, which the baseline's
+near-center `(3,3)` hazard never exercised.
 
 **Methodology:** shells out to the real CLI (`node packages/adapters-cli/src/cli/ak.mjs`) directly
 rather than through MCP tool calls — this is scripted batch automation, which
@@ -254,17 +263,17 @@ being written up as a finding.
 G2's out-of-bounds hazard is left in the matrix deliberately as a standing regression probe for #148
 — it should keep failing with a malformed message until that's fixed.
 
-**Results (re-run 2026-09-01 after widening axis D and then axis B, 42 scenarios):**
+**Results (re-run 2026-09-01 after widening axis D, then axis B, then axis C — 46 scenarios):**
 
 - `ak create --dry-run` only (authoring-layer validation, no artifacts written, no `ak run`):
-  **42/42 PASS.** No anomalies.
-- `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **41/42 PASS** on create,
-  **41/41 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple` —
-  see finding 6. All 10 axis-D hazard affinities passed clean on both create and run.
-  `B-delver-motivation-user_controlled` also passed clean on both: `create=PASS`, `run=PASS`,
-  `actions=0, effects=5` — inert at the run layer as expected (player-controlled actors need
-  streamed simulation playback per the Actor persona README; a plain `ak_run` pass has no player
-  input to stream), informational only, not a failure.
+  **46/46 PASS.** No anomalies.
+- `ak create` (real artifacts) + `ak run --ticks 5 --seed 0` per scenario: **45/46 PASS** on create,
+  **45/45 PASS** on run for every create that succeeded. One anomaly — `G2-multi-hazard-triple` —
+  see finding 6. All 10 axis-D hazard affinities and all 4 axis-C diagonal-corner positions passed
+  clean on both create and run. `B-delver-motivation-user_controlled` also passed clean on both:
+  `create=PASS`, `run=PASS`, `actions=0, effects=5` — inert at the run layer as expected
+  (player-controlled actors need streamed simulation playback per the Actor persona README; a plain
+  `ak_run` pass has no player input to stream), informational only, not a failure.
 
 **Informational note, not a finding:** the run pass recorded `acceptedActions`/`emittedEffects` counts
 per scenario as metadata only, never as a pass/fail signal — treating "an actor did nothing" as

--- a/mcp-harness-run-through.md
+++ b/mcp-harness-run-through.md
@@ -129,29 +129,51 @@ work already tracked in `error-message-quality-sweep.md` (SM0–SM3, merged) but
 sweep's own scope note (`budget receipt denial` is a distinct code path from the `ak_create` field
 validators it audited) didn't cover.
 
-## 5. (open question, not yet root-caused) An authored delver took zero actions across a 5-tick plain `ak_run`
+## 5. RESOLVED — root-caused with Serena: the actor did act; `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn
 
-**Observation:** `run_mcp_session_demo2` — one delver, `motivation=exploring`, run for 5 ticks via
-plain `ak_run` with no `--actions`/`actions` input (which the CLI help describes as being for
-"deterministic replay," i.e. optional, not a prerequisite for autonomous behavior) — produced:
+**Original observation (now known to be a misdiagnosis):** `run_mcp_session_demo2`'s `action-log.json`
+showed `"actions": []`, and `ak_tick_forward` at ticks 1, 2, 3 all showed the delver at the identical
+`{x:3,y:2}`, which read as "the actor never decided or moved." That premise was wrong on both counts:
 
-- `action-log.json`: `"actions": []`
-- `effects-log.json`: exactly 3 effects, all `status: "deferred"` (`missing_telemetry` /
-  `missing_logger`), i.e. harness-side bookkeeping, not gameplay effects
-- `ak_tick_forward` at tick 1, 2, and 3 all show the delver at the identical `{x:3,y:2}` with
-  identical vitals — no movement, no decisions, no state change of any kind
+- `action-log.json` is populated **only from the `--actions` input file** (deterministic-replay input),
+  never from what the runtime actually decided during the run —
+  [`packages/runtime/src/commands/kernel.js:1129-1148`](packages/runtime/src/commands/kernel.js#L1129-L1148).
+  An empty one says nothing about whether the Actor persona proposed anything.
+- `tick-frames.json` for the same run shows the Actor persona *did* propose and get accepted two moves:
+  tick 1 `move west (3,2)→(2,2)`, tick 2 `move northwest (2,2)→(1,1)` — landing exactly on the room's
+  exit tile (`E` at `(1,1)`). Zero further proposals from tick 3 onward is then the *correct* behavior
+  for an `exploring` motivation that has reached its goal, not a stall.
 
-**Why this is flagged rather than fixed inline:** this repo's own persona model gives the Actor
-persona an `observe, decide` tick phase specifically to propose actions, and `runtime` orchestrates
-that independently of any `--actions` replay file — so zero actions over 5 ticks for an
-`exploring`-motivated actor is either (a) a real regression in the autonomous decision path invoked
-by plain `ak_run`, or (b) expected behavior this session doesn't have context to judge (e.g. `ak_run`
-alone may intentionally not invoke actor decision-making, and only `ak_scenario` or a
-`--actions`-driven path does). The branch this session started from carries two same-day commits —
-`4112ac8 feat: complete persona-owned perception and solver policy` and
-`d47dfba refactor(runtime): restore allocator and configurator authority` — that are plausibly
-adjacent to whatever gates this, which is exactly the kind of thing that should be root-caused with
-Serena/`find_referencing_symbols` on the Actor persona's `advance()`, not guessed at from outside.
+**The real, confirmed bug:** `ak_tick_forward`/`ak_show_state`'s `visualization.ascii` /
+`visualization.visualizationDataUri` fields render every actor frozen at its `initial-state.json`
+spawn position for the entire run, regardless of tick or accepted moves. Root cause, traced with
+Serena (`find_referencing_symbols` on `createActorPersona`, then the `run` command in `kernel.js`,
+then the two tick-frame readers in `tick-session.mjs`):
+
+1. [`readTickFrame()`](packages/adapters-cli/src/tick-session.mjs#L72-L86) returns the **last**
+   phase-frame for a tick (`forTick[forTick.length - 1]`) — which is always the `summarize` phase.
+2. `summarize` phase-frames always carry `acceptedActions: []`; the actual accepted moves live only on
+   that tick's `apply` phase-frame (confirmed: tick 1 and 2's `apply` frames carry the moves above,
+   their `summarize` frames carry `[]`).
+3. [`computeActorPositions()`](packages/runtime/src/render/visualization-snapshot.js#L36-L49) (used by
+   `buildVisualizationSnapshot`, which is what `ak_tick_forward`/`ak_show_state`'s `visualization.*`
+   fields come from) starts from `initialState.actors[].position` and overlays only the **single**
+   passed-in `tickFrame.acceptedActions` — never a history. Fed an always-empty `summarize` frame, the
+   overlay never applies, so every actor renders at spawn forever.
+
+**Proof, same run, same call:** `ak_show_state({runId, visualization:"ascii"})` at cursor tick 3
+returns *both* renderings in one response — top-level `ascii` (built by the sibling function
+[`renderAscii()`](packages/adapters-cli/src/tick-session.mjs#L213-L262), via
+[`resolveActorPositionsAtTick()`](packages/adapters-cli/src/tick-session.mjs#L181-L202), which
+correctly *accumulates* every accepted move across ticks 1..N) shows `@` at `(1,1)` — the true,
+correct position. The same response's `visualization.ascii` shows `D` still at `(3,2)` — spawn,
+frozen. Two functions in the same package solve the identical problem; only one of them accumulates.
+
+**Family resemblance:** this is the same shape of defect as a bug already fixed on the UI side —
+`69330c4 fix(ui): gameplay tick playback was off by one, stuck on tick 0's stale position for the
+whole run` (merged via #140) — a tick-cursor visualization reading a stale/wrong single frame instead
+of replaying accepted actions cumulatively. That fix apparently didn't extend to this MCP-side
+visualization path.
 
 ---
 
@@ -161,4 +183,5 @@ Serena/`find_referencing_symbols` on the Actor persona's `advance()`, not guesse
 - [#143](https://github.com/KomplexMojo/agent-kernel/issues/143) — `ak_show_state`/`ak_tick_forward`/`ak_tick_backward` resolve runs from a different root than `ak_create`/`ak_run`/`ak_show` (finding 2)
 - [#144](https://github.com/KomplexMojo/agent-kernel/issues/144) — `ak_show_state`'s `image` visualization mode blows the MCP tool-result size limit (finding 3)
 - [#145](https://github.com/KomplexMojo/agent-kernel/issues/145) — `ak_create` budget denial doesn't say what budget would have worked (finding 4)
-- [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) — open question: does plain `ak_run` ever invoke autonomous actor decision-making? (finding 5)
+- [#146](https://github.com/KomplexMojo/agent-kernel/issues/146) — open question: does plain `ak_run` ever invoke autonomous actor decision-making? **CLOSED, not planned** — root-caused with Serena; premise was wrong, see #147
+- [#147](https://github.com/KomplexMojo/agent-kernel/issues/147) — `ak_tick_forward`/`ak_show_state` render every actor frozen at spawn position, single-frame overlay instead of cumulative replay (finding 5, corrected)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "typecheck:report": "node scripts/testing/typecheck-report.mjs",
     "benchmark:core-ts-affinity": "node scripts/testing/benchmark-compute-affinity-field.mjs",
+    "config-sweep": "node scripts/testing/run-configuration-permutation-sweep.mjs",
+    "config-sweep:dry-run": "node scripts/testing/run-configuration-permutation-sweep.mjs --dry-run",
     "serve:ui": "node scripts/serve-ui.mjs",
     "serve:c": "node scripts/serve-ui.mjs --entry index_c.html",
     "serve:l": "node scripts/serve-ui.mjs --entry index_l.html",

--- a/packages/adapters-cli/src/cli/ak-impl.mjs
+++ b/packages/adapters-cli/src/cli/ak-impl.mjs
@@ -6105,8 +6105,7 @@ async function tickCommand(argv) {
       maxTick,
     };
     if (vizMode) {
-      const tickFrame = await readTickFrame(runDir, newTick);
-      result.visualization = await buildVisualizationSnapshot(runDir, runId, newTick, tickFrame, vizMode);
+      result.visualization = await buildVisualizationSnapshot(runDir, runId, newTick, vizMode);
     }
     emitJsonStdout(result);
     return;
@@ -6137,8 +6136,7 @@ async function tickCommand(argv) {
       maxTick,
     };
     if (vizMode) {
-      const tickFrame = await readTickFrame(runDir, newTick);
-      result.visualization = await buildVisualizationSnapshot(runDir, runId, newTick, tickFrame, vizMode);
+      result.visualization = await buildVisualizationSnapshot(runDir, runId, newTick, vizMode);
     }
     emitJsonStdout(result);
     return;
@@ -6157,7 +6155,7 @@ async function tickCommand(argv) {
     tickFrame,
   };
   if (vizMode) {
-    stateResult.visualization = await buildVisualizationSnapshot(runDir, runId, currentTick, tickFrame, vizMode);
+    stateResult.visualization = await buildVisualizationSnapshot(runDir, runId, currentTick, vizMode);
   }
   emitJsonStdout(stateResult);
 }

--- a/packages/adapters-cli/src/mcp/server.mjs
+++ b/packages/adapters-cli/src/mcp/server.mjs
@@ -1,5 +1,5 @@
 import { mkdtempSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import os from "node:os";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -139,6 +139,25 @@ function resolveDefaultOutDir(tool, args) {
     return join(SESSION_TEMP_ROOT, runId, commandLabel);
   }
   return mkdtempSync(join(SESSION_TEMP_ROOT, `${commandLabel}-`));
+}
+
+// #143 — ak_show_state/ak_tick_forward/ak_tick_backward resolve a run's directory from the
+// canonical <cwd>/artifacts/runs/<runId> layout only (tick-session.mjs's resolveRunDir), never
+// consulting REMEMBERED_RUNS the way ak_show/ak_runs_list/maybeResolveRememberedInputs already do.
+// A run created via the documented default (outDir left unset, landing under SESSION_TEMP_ROOT)
+// was invisible to these three tools even though ak_show found it immediately. When a remembered
+// "run" command outDir exists for this runId, pass its parent through as an explicit override —
+// tick-session.mjs's functions all expect a base runDir and append "run/<file>.json" themselves,
+// matching the canonical layout, and the remembered "run" outDir already IS ".../run".
+const TICK_TOOL_NAMES = new Set(["ak_tick_forward", "ak_tick_backward", "ak_show_state"]);
+
+function resolveRememberedRunDirOverride(tool, args) {
+  if (!TICK_TOOL_NAMES.has(tool.name)) return null;
+  const runId = normalizeNonEmptyString(args?.runId);
+  if (!runId) return null;
+  const runOutDir = REMEMBERED_RUNS.get(runId)?.commands.get("run");
+  if (!runOutDir) return null;
+  return dirname(runOutDir);
 }
 
 async function maybeResolveRememberedInputs(tool, rawArgs) {
@@ -339,6 +358,10 @@ async function executeToolRequest(tool, requestedArgs) {
   const defaultedOutDir = resolveDefaultOutDir(tool, preparedArgs);
   if (defaultedOutDir) {
     preparedArgs.outDir = defaultedOutDir;
+  }
+  const runDirOverride = resolveRememberedRunDirOverride(tool, preparedArgs);
+  if (runDirOverride) {
+    preparedArgs.__runDirOverride = runDirOverride;
   }
 
   const result = await invokeCliTool(tool, preparedArgs);

--- a/packages/adapters-cli/src/mcp/tools/sandbox.mjs
+++ b/packages/adapters-cli/src/mcp/tools/sandbox.mjs
@@ -1331,7 +1331,18 @@ export const sandboxTools = [
       "(the shape ak_run writes after M7 stitching), or an inline bundle object. " +
       "Returns ok: false with bundleNotFound: true when no bundle is found at the resolved path, " +
       "SANDBOX_UI_NOT_CONNECTED when no browser UI is connected and requireClient is true, and " +
-      "SANDBOX_BRIDGE_START_FAILED when the bridge server failed to start.",
+      "SANDBOX_BRIDGE_START_FAILED when the bridge server failed to start. " +
+      "IMPORTANT (#142): the bridge is a raw WebSocket port opened directly by this MCP server " +
+      "process, and requires the browser loading the UI to reach that same port on the same " +
+      "machine. In a harness where the MCP server runs in a different network namespace/sandbox " +
+      "than the harness's own browser/preview surface, that port is unreachable even though the " +
+      "UI's own HTTP dev server may load fine -- confirmed via connection-refused from both a " +
+      "local curl and the browser's own WebSocket attempt in that kind of environment. " +
+      "openBrowser: true does not help there either -- it opens the HOST machine's default system " +
+      "browser, not the calling harness's own preview surface. If you cannot confirm the caller " +
+      "and this MCP server share a reachable network path, use ak_show_state / ak_tick_forward / " +
+      "ak_tick_backward with a visualization mode instead -- they return state over the MCP " +
+      "response itself (ascii inline, image as a file path since #144), with no second network hop.",
     inputSchema: {
       properties: {
         outDir: pathSchema(

--- a/packages/adapters-cli/src/mcp/tools/tick.mjs
+++ b/packages/adapters-cli/src/mcp/tools/tick.mjs
@@ -75,8 +75,7 @@ const tickForwardTool = createHandlerTool({
       maxTick,
     };
     if (visualization) {
-      const tickFrame = await readTickFrame(runDir, newTick);
-      result.visualization = await buildVisualizationSnapshot(runDir, runId, newTick, tickFrame, visualization);
+      result.visualization = await buildVisualizationSnapshot(runDir, runId, newTick, visualization);
     }
     return result;
   },
@@ -126,8 +125,7 @@ const tickBackwardTool = createHandlerTool({
       maxTick,
     };
     if (visualization) {
-      const tickFrame = await readTickFrame(runDir, newTick);
-      result.visualization = await buildVisualizationSnapshot(runDir, runId, newTick, tickFrame, visualization);
+      result.visualization = await buildVisualizationSnapshot(runDir, runId, newTick, visualization);
     }
     return result;
   },
@@ -157,7 +155,7 @@ const showStateTool = createHandlerTool({
     const [ascii, tickFrame] = await Promise.all([renderAscii(runDir, tick), readTickFrame(runDir, tick)]);
     const result = { ok: true, command: "tick", action: "state", runId, tick, maxTick, ascii, tickFrame };
     if (visualization) {
-      result.visualization = await buildVisualizationSnapshot(runDir, runId, tick, tickFrame, visualization);
+      result.visualization = await buildVisualizationSnapshot(runDir, runId, tick, visualization);
     }
     return result;
   },

--- a/packages/adapters-cli/src/mcp/tools/tick.mjs
+++ b/packages/adapters-cli/src/mcp/tools/tick.mjs
@@ -17,8 +17,8 @@ const visualizationSchema = {
   enum: ["ascii", "image"],
 };
 
-async function resolveTickState(runId) {
-  const runDir = resolveRunDir(runId);
+async function resolveTickState(runId, runDirOverride) {
+  const runDir = resolveRunDir(runId, runDirOverride);
   if (!existsSync(runDir)) {
     return { error: `run directory not found: ${runId}` };
   }
@@ -42,12 +42,12 @@ const tickForwardTool = createHandlerTool({
     },
     required: ["runId"],
   },
-  handler: async ({ runId, visualization }) => {
+  handler: async ({ runId, visualization, __runDirOverride }) => {
     if (visualization !== undefined) {
       const check = validateVisualizationMode(visualization);
       if (!check.ok) return { ok: false, command: "tick", action: "forward", runId, error: check.error };
     }
-    const state = await resolveTickState(runId);
+    const state = await resolveTickState(runId, __runDirOverride);
     if (state.error) {
       return { ok: false, command: "tick", action: "forward", runId, error: state.error };
     }
@@ -92,12 +92,12 @@ const tickBackwardTool = createHandlerTool({
     },
     required: ["runId"],
   },
-  handler: async ({ runId, visualization }) => {
+  handler: async ({ runId, visualization, __runDirOverride }) => {
     if (visualization !== undefined) {
       const check = validateVisualizationMode(visualization);
       if (!check.ok) return { ok: false, command: "tick", action: "backward", runId, error: check.error };
     }
-    const state = await resolveTickState(runId);
+    const state = await resolveTickState(runId, __runDirOverride);
     if (state.error) {
       return { ok: false, command: "tick", action: "backward", runId, error: state.error };
     }
@@ -142,12 +142,12 @@ const showStateTool = createHandlerTool({
     },
     required: ["runId"],
   },
-  handler: async ({ runId, visualization }) => {
+  handler: async ({ runId, visualization, __runDirOverride }) => {
     if (visualization !== undefined) {
       const check = validateVisualizationMode(visualization);
       if (!check.ok) return { ok: false, command: "tick", action: "state", runId, error: check.error };
     }
-    const state = await resolveTickState(runId);
+    const state = await resolveTickState(runId, __runDirOverride);
     if (state.error) {
       return { ok: false, command: "tick", action: "state", runId, error: state.error };
     }

--- a/packages/adapters-cli/src/tick-session.mjs
+++ b/packages/adapters-cli/src/tick-session.mjs
@@ -141,12 +141,30 @@ export async function buildVisualizationSnapshot(runDir, runId, tick, mode) {
     }
     const snap = await createVisualizationSnapshot({ mode, tick, runId, simConfig, initialState, frames });
     if (mode === "image" && snap) {
-      snap.visualizationDataUri = await buildPngDataUri(simConfig, initialState, frames, tick, runDir);
+      const dataUri = await buildPngDataUri(simConfig, initialState, frames, tick, runDir);
+      // #144 — a data URI this size (443,790 characters on a trivial one-room, one-actor run in
+      // the session that found this) inlined into the MCP tool result blows the caller's
+      // tool-result token limit; `ascii` mode worked at a fraction of the size because it never
+      // carries image bytes. Write the PNG to a file instead, the same convention every other
+      // artifact-producing ak_* tool already follows, and hand back the path — a caller reads the
+      // file directly rather than receiving its bytes inline.
+      snap.visualizationDataUri = null;
+      snap.visualizationPath = await writePngToFile(dataUri, runDir, tick);
     }
     return snap;
   } catch {
     return null;
   }
+}
+
+async function writePngToFile(dataUri, runDir, tick) {
+  if (!dataUri) return null;
+  const base64 = dataUri.replace(/^data:image\/png;base64,/, "");
+  const sessionDir = join(runDir, "session");
+  await mkdir(sessionDir, { recursive: true });
+  const path = join(sessionDir, `visualization-tick-${tick}.png`);
+  await writeFile(path, Buffer.from(base64, "base64"));
+  return path;
 }
 
 async function buildPngDataUri(simConfig, initialState, frames, tick, runDir) {

--- a/packages/adapters-cli/src/tick-session.mjs
+++ b/packages/adapters-cli/src/tick-session.mjs
@@ -102,7 +102,15 @@ function resolveBuildArtifact(runDir, filename) {
   return null;
 }
 
-export async function buildVisualizationSnapshot(runDir, runId, tick, tickFrame, mode) {
+// #147 — this used to accept a single `tickFrame` (the last phase-frame for the requested tick,
+// i.e. `summarize`, which always carries acceptedActions: [] by construction) and hand it straight
+// to createVisualizationSnapshot/buildPngDataUri, which only overlaid that one frame. The actual
+// accepted moves live on that tick's earlier `apply` phase-frame, so the overlay never applied and
+// every actor rendered frozen at spawn for the whole run. Reads the full frame history instead, so
+// both the ascii/actorDetails path (createVisualizationSnapshot) and the image path
+// (buildPngDataUri, via resolveActorPositionsAtTick — the same cumulative replay renderAscii()
+// already used correctly) can accumulate every accepted move up to the requested tick.
+export async function buildVisualizationSnapshot(runDir, runId, tick, mode) {
   const simConfigPath = resolveBuildArtifact(runDir, "sim-config.json");
   const initialStatePath = resolveBuildArtifact(runDir, "initial-state.json");
   if (!simConfigPath || !initialStatePath) return null;
@@ -111,9 +119,18 @@ export async function buildVisualizationSnapshot(runDir, runId, tick, tickFrame,
       readFile(simConfigPath, "utf8").then(JSON.parse),
       readFile(initialStatePath, "utf8").then(JSON.parse),
     ]);
-    const snap = await createVisualizationSnapshot({ mode, tick, runId, simConfig, initialState, tickFrame });
+    const framesPath = join(runDir, "run", "tick-frames.json");
+    let frames = null;
+    if (existsSync(framesPath)) {
+      try {
+        frames = JSON.parse(await readFile(framesPath, "utf8"));
+      } catch {
+        frames = null;
+      }
+    }
+    const snap = await createVisualizationSnapshot({ mode, tick, runId, simConfig, initialState, frames });
     if (mode === "image" && snap) {
-      snap.visualizationDataUri = await buildPngDataUri(simConfig, initialState, tickFrame, runDir);
+      snap.visualizationDataUri = await buildPngDataUri(simConfig, initialState, frames, tick, runDir);
     }
     return snap;
   } catch {
@@ -121,7 +138,7 @@ export async function buildVisualizationSnapshot(runDir, runId, tick, tickFrame,
   }
 }
 
-async function buildPngDataUri(simConfig, initialState, tickFrame, runDir) {
+async function buildPngDataUri(simConfig, initialState, frames, tick, runDir) {
   const { renderBoardWithResourceBundle, encodeRgbaToPng } = await import(
     "../../runtime/src/render/resource-bundle.js"
   );
@@ -140,13 +157,8 @@ async function buildPngDataUri(simConfig, initialState, tickFrame, runDir) {
     }
   }
 
-  // Apply move actions from tickFrame to get positions at this tick.
-  const posOverrides = new Map();
-  for (const action of (tickFrame?.acceptedActions || [])) {
-    if (action.kind === "move" && action.params?.to) {
-      posOverrides.set(action.actorId, { x: action.params.to.x, y: action.params.to.y });
-    }
-  }
+  // Cumulative replay of every accepted move up to `tick`, not just one frame's overlay.
+  const posOverrides = resolveActorPositionsAtTick(initialState, frames, tick);
   // Spread full actor data so renderBoardWithResourceBundle can resolve affinity/motivation sprites.
   const renderActors = (initialState.actors || []).map((actor) => {
     const pos = posOverrides.get(actor.id) || actor.position;

--- a/packages/adapters-cli/src/tick-session.mjs
+++ b/packages/adapters-cli/src/tick-session.mjs
@@ -6,7 +6,18 @@ import { TICK_CURSOR_SCHEMA } from "../../runtime/src/contracts/artifacts.ts";
 
 const DEFAULT_ARTIFACTS_DIR = "artifacts";
 
-export function resolveRunDir(runId) {
+// #143 — this always resolved to the canonical <cwd>/artifacts/runs/<runId> layout, ignoring the
+// MCP server's own "remembered outDir per runId" mechanism that ak_create/ak_run/ak_show/
+// ak_runs_list already use when outDir is left to default. A run created via that default (the
+// MCP README's own "most common agent loop") was invisible to ak_show_state/ak_tick_forward/
+// ak_tick_backward, which reported "run directory not found" even though ak_show/ak_runs_list
+// found the same run immediately. `runDirOverride`, when supplied, is used verbatim instead of
+// the canonical-layout guess -- the MCP server (server.mjs's resolveRememberedRunDirOverride)
+// passes one through when it has a remembered outDir for this runId; the plain CLI (`ak tick`,
+// which has no session/remembered-run concept at all) never supplies one, so its behavior is
+// unchanged.
+export function resolveRunDir(runId, runDirOverride) {
+  if (runDirOverride) return runDirOverride;
   const artifactsDir = process.env.AK_ARTIFACTS_DIR
     ? process.env.AK_ARTIFACTS_DIR
     : join(process.cwd(), DEFAULT_ARTIFACTS_DIR);

--- a/packages/runtime/src/build/orchestrate-build.js
+++ b/packages/runtime/src/build/orchestrate-build.js
@@ -116,10 +116,20 @@ function formatBudgetReceiptDenial(receipt) {
     const omitted = allDeniedItems.length - deniedLines.length;
     parts.push(`deniedLines=${deniedLines.join(",")}${omitted > 0 ? ` (+${omitted} more)` : ""}`);
   }
+  // #145 — the denial reported what was denied (id, spent, cap) but not the shortfall, so a
+  // caller had no way to compute the minimum budget that would clear it without trial and error.
+  // `short N` is the extra capacity this one pool alone needed; the total budgetTokens that would
+  // resolve it isn't computable from the receipt (capTokens' relationship to the overall budget
+  // isn't a simple proportion — see #145's own investigation), so this reports the one thing that
+  // is always correct: how far over this pool's own cap the spend landed.
   const deniedPools = Array.isArray(receipt?.poolStatuses)
     ? receipt.poolStatuses
       .filter((pool) => pool?.status !== "approved")
-      .map((pool) => `${pool.id}:${pool.spentTokens}/${pool.capTokens}`)
+      .map((pool) => {
+        const shortfall = Number(pool.spentTokens) - Number(pool.capTokens);
+        const shortfallText = Number.isFinite(shortfall) && shortfall > 0 ? ` (short ${shortfall})` : "";
+        return `${pool.id}:${pool.spentTokens}/${pool.capTokens}${shortfallText}`;
+      })
     : [];
   if (deniedPools.length > 0) {
     parts.push(`deniedPools=${deniedPools.join(",")}`);

--- a/packages/runtime/src/build/orchestrate-build.js
+++ b/packages/runtime/src/build/orchestrate-build.js
@@ -127,6 +127,50 @@ function formatBudgetReceiptDenial(receipt) {
   return `Budget receipt denied: ${parts.join("; ")}`;
 }
 
+// #148 — level-layout.js raises five distinct error codes, each with its own detail shape. This
+// used to be one hardcoded template (`requested X, need at least Y for Z rooms`) applied to every
+// code; only floor_tile_budget_insufficient's detail actually has {target, required, roomCount}, so
+// the other four silently formatted as "(requested undefined, need at least undefined for undefined
+// rooms)" — a real rejection with a broken message. Code-aware now: each code formats its own known
+// shape, and an error code with no formatter here (or a detail object missing the fields it expects)
+// falls back to no parenthetical rather than guessing wrong.
+const LEVEL_GEN_ERROR_DETAIL_FORMATTERS = {
+  floor_tile_budget_insufficient: (detail) => {
+    if (!Number.isFinite(detail?.target) || !Number.isFinite(detail?.required) || !Number.isFinite(detail?.roomCount)) {
+      return "";
+    }
+    return ` (requested ${detail.target}, need at least ${detail.required} for `
+      + `${detail.roomCount} room${detail.roomCount === 1 ? "" : "s"})`;
+  },
+  hazard_outside_room: (detail) => {
+    if (!Number.isFinite(detail?.x) || !Number.isFinite(detail?.y)) return "";
+    const bounds = Number.isFinite(detail?.roomWidth) && Number.isFinite(detail?.roomHeight)
+      ? ` — room ${detail.roomId ?? "?"}'s interior is ${detail.roomWidth}x${detail.roomHeight}`
+      : "";
+    return ` (position ${detail.x},${detail.y} is outside the target room${bounds})`;
+  },
+  hazard_on_wall: (detail) => {
+    if (!Number.isFinite(detail?.x) || !Number.isFinite(detail?.y)) return "";
+    const affinity = detail?.affinity ? ` (affinity ${detail.affinity})` : "";
+    return ` (position ${detail.x},${detail.y} is a wall tile${affinity})`;
+  },
+  element_on_wall: (detail) => {
+    if (!Number.isFinite(detail?.x) || !Number.isFinite(detail?.y)) return "";
+    const id = detail?.id ? ` (id ${detail.id})` : "";
+    return ` (position ${detail.x},${detail.y} is a wall tile${id})`;
+  },
+  target_mismatch: (detail) => {
+    if (!Number.isFinite(detail?.target) || !Number.isFinite(detail?.walkableTiles)) return "";
+    return ` (expected ${detail.target} walkable tiles, computed ${detail.walkableTiles})`;
+  },
+};
+
+function formatLevelGenErrorDetail(err) {
+  if (!err?.detail || typeof err.detail !== "object") return "";
+  const formatter = LEVEL_GEN_ERROR_DETAIL_FORMATTERS[err.code];
+  return formatter ? formatter(err.detail) : "";
+}
+
 function assertSchema(artifact, expectedSchema) {
   if (!artifact || typeof artifact !== "object") {
     throw new Error(`Expected ${expectedSchema} artifact.`);
@@ -396,11 +440,7 @@ export async function orchestrateBuild({
     });
     if (!layoutResult.ok) {
       const details = layoutResult.errors.map((err) => {
-        const detail = err.detail && typeof err.detail === "object"
-          ? ` (requested ${err.detail.target}, need at least ${err.detail.required} for `
-            + `${err.detail.roomCount} room${err.detail.roomCount === 1 ? "" : "s"})`
-          : "";
-        return `${err.field}:${err.code}${detail}`;
+        return `${err.field}:${err.code}${formatLevelGenErrorDetail(err)}`;
       }).join(", ");
       throw new Error(`level-gen input invalid: ${details}`);
     }

--- a/packages/runtime/src/commands/kernel.js
+++ b/packages/runtime/src/commands/kernel.js
@@ -1128,6 +1128,24 @@ export function createCommandKernel(host = {}) {
       assertSchema(affinityLoadouts, SCHEMAS.actorLoadout);
     }
 
+    // #149 — action-log.json/run-summary.json/world-state.json used to stamp meta.id/createdAt via
+    // createMeta()'s wall-clock (Date.now()/Math.random()), while every other artifact this command
+    // writes (tick-frames.json, effects-log.json, runtime-decision-captures.json) is timestamped by
+    // this same seeded clock. Two runs of byte-identical input then produced byte-identical
+    // simulation output but different meta stamps on these three files, breaking reproducibility the
+    // simulation itself already has. Constructed here (moved up from below) so it can seed all three.
+    const clock = createDeterministicClock(resolveClockSeed(simConfig, initialState));
+    function deterministicRunArtifactMeta(tag, producedBy) {
+      return {
+        id: `artifact_${runId}_${tag}`,
+        runId,
+        createdAt: clock(),
+        producedBy,
+        correlationId: undefined,
+        note: undefined,
+      };
+    }
+
     let actionLog = null;
     if (actionsPath) {
       actionLog = await readJson(actionsPath);
@@ -1136,14 +1154,14 @@ export function createCommandKernel(host = {}) {
       }
       actionLog.schema = actionLog.schema || ACTION_SEQUENCE_SCHEMA;
       actionLog.schemaVersion = actionLog.schemaVersion || 1;
-      actionLog.meta = actionLog.meta || createMeta({ producedBy: "cli-run", runId });
+      actionLog.meta = actionLog.meta || deterministicRunArtifactMeta("actionlog", "cli-run");
       actionLog.simConfigRef = actionLog.simConfigRef || toRef(simConfig);
       actionLog.initialStateRef = actionLog.initialStateRef || toRef(initialState);
     } else {
       actionLog = {
         schema: ACTION_SEQUENCE_SCHEMA,
         schemaVersion: 1,
-        meta: createMeta({ producedBy: "cli-run", runId }),
+        meta: deterministicRunArtifactMeta("actionlog", "cli-run"),
         simConfigRef: toRef(simConfig),
         initialStateRef: toRef(initialState),
         actions: [],
@@ -1195,7 +1213,6 @@ export function createCommandKernel(host = {}) {
       };
     }
 
-    const clock = createDeterministicClock(resolveClockSeed(simConfig, initialState));
     const core = createCommandRuntimeCore();
     const runtime = createRuntime({ core, adapters: {}, runId, clock });
     // AM.5/F13 — an actor's affinities must reach the OBSERVATION, or the Actor
@@ -1259,7 +1276,7 @@ export function createCommandKernel(host = {}) {
       tickFrames,
       effectLog,
       ticksRequested: ticks,
-      meta: createMeta({ producedBy: "annotator", runId }),
+      meta: deterministicRunArtifactMeta("runsummary", "annotator"),
       simConfigRef: toRef(simConfig),
     });
 
@@ -1284,7 +1301,7 @@ export function createCommandKernel(host = {}) {
     // the injected host `writeJson` like every other artifact, so the runtime
     // still performs no IO of its own.
     const worldState = runtime.captureWorldState({
-      meta: createMeta({ producedBy: "annotator", runId }),
+      meta: deterministicRunArtifactMeta("worldstate", "annotator"),
       simConfigRef,
     });
     await writeJson(join(outDir, "world-state.json"), worldState);

--- a/packages/runtime/src/contracts/artifacts.ts
+++ b/packages/runtime/src/contracts/artifacts.ts
@@ -508,7 +508,14 @@ export interface VisualizationSnapshotImageV1 {
   mode: "image";
   tick: number;
   runId: string;
+  /** #144 — always null from the adapters-cli image path; the PNG is written to visualizationPath
+   * instead of inlined, since a data URI this size reliably exceeds an MCP tool-result token
+   * budget. Stays `string | null` (not dropped) so a caller that still wants inline bytes for some
+   * other producer of this artifact isn't structurally prevented from supplying them. */
   visualizationDataUri: string | null;
+  /** Absolute path to the rendered PNG on disk. Set by adapters-cli's image path; absent for
+   * ascii mode and for any producer of this artifact that doesn't write to disk. */
+  visualizationPath?: string;
   actorDetails: VisualizationActorDetail[];
 }
 

--- a/packages/runtime/src/render/visualization-snapshot.js
+++ b/packages/runtime/src/render/visualization-snapshot.js
@@ -155,11 +155,20 @@ export async function createVisualizationSnapshot({
   const delverRows = buildBlankGrid(width, height);
   const wardenRows = buildBlankGrid(width, height);
 
-  for (const hazard of (simConfig.hazards || [])) {
+  // #153 — a real ak_create sim-config never populates the top-level simConfig.hazards/
+  // .resources; the actual data lives at simConfig.layout.data.hazards/.resources (confirmed:
+  // a real 2-hazard, 2-resource level had hazards: null, resources: null at the top level and
+  // both arrays, length 2 each, under layout.data). So the `|| []` fallback always fired and
+  // these loops never ran. buildPngDataUri() (tick-session.mjs, the image path) already has the
+  // correct fallback -- this brings the ascii path in line with it.
+  const hazards = simConfig.hazards ?? simConfig.layout?.data?.hazards ?? [];
+  const resources = simConfig.resources ?? simConfig.layout?.data?.resources ?? [];
+
+  for (const hazard of hazards) {
     markPosition(hazardRows, hazard.x, hazard.y, "H");
   }
 
-  for (const resource of (simConfig.resources || [])) {
+  for (const resource of resources) {
     markPosition(resourceRows, resource.x, resource.y, "R");
   }
 

--- a/packages/runtime/src/render/visualization-snapshot.js
+++ b/packages/runtime/src/render/visualization-snapshot.js
@@ -34,16 +34,26 @@ function markPosition(rows, x, y, char) {
   rows[y] = row.slice(0, x) + char + row.slice(x + 1);
 }
 
-function computeActorPositions(initialState, tickFrame) {
+// #147 — this used to take a single `tickFrame` and overlay only that one frame's
+// `acceptedActions`. The frame callers had on hand (readTickFrame's "last phase-frame for this
+// tick", i.e. `summarize`) always carries `acceptedActions: []` by construction — the actual moves
+// land on that tick's earlier `apply` phase-frame — so the overlay never applied and every actor
+// rendered frozen at its initial-state.json spawn position for the whole run. Fixed by replaying
+// every accepted move from every frame up to and including the requested tick, cumulatively — the
+// same approach adapters-cli's own resolveActorPositionsAtTick() (tick-session.mjs) already used
+// correctly; this was the one caller of this data that didn't.
+function computeActorPositions(initialState, frames, tick) {
   const positions = new Map();
   for (const actor of initialState.actors) {
     positions.set(actor.id, { x: actor.position.x, y: actor.position.y });
   }
-  if (tickFrame) {
-    for (const action of tickFrame.acceptedActions) {
-      if (action.kind === "move" && action.params && action.params.to) {
-        positions.set(action.actorId, { x: action.params.to.x, y: action.params.to.y });
-      }
+  if (!Array.isArray(frames)) return positions;
+  const limit = Number.isFinite(tick) ? tick : Infinity;
+  for (const frame of frames) {
+    if (Number.isFinite(frame?.tick) && frame.tick > limit) break;
+    for (const action of frame?.acceptedActions || []) {
+      if (action?.kind !== "move" || !action.params?.to) continue;
+      positions.set(action.actorId, { x: action.params.to.x, y: action.params.to.y });
     }
   }
   return positions;
@@ -96,7 +106,7 @@ export async function createVisualizationSnapshot({
   runId,
   simConfig,
   initialState,
-  tickFrame,
+  frames,
   clock = null,
 }) {
   // PX.3 extended to the render layer. This used to read the wall clock twice —
@@ -119,7 +129,7 @@ export async function createVisualizationSnapshot({
     meta.createdAt = clock();
   }
 
-  const actorPositions = computeActorPositions(initialState, tickFrame);
+  const actorPositions = computeActorPositions(initialState, frames, tick);
   const actorDetails = buildActorDetails(initialState, actorPositions);
 
   if (mode === "image") {

--- a/scripts/testing/configuration-permutation-matrix.mjs
+++ b/scripts/testing/configuration-permutation-matrix.mjs
@@ -58,9 +58,10 @@ export const MATRIX = [
       hazard: [`x=3;y=3;affinity=fire;expression=${e};stacks=1`],
     })),
 
-  // Axis D — hazard affinity, spot-check subset (not full 10 — a candidate for widening later).
-  // Delver held at baseline.
-  ...["water", "dark", "decay"].map((a) =>
+  // Axis D — hazard affinity, full domain (10), matching axis A's pattern of sweeping the full
+  // domain inclusive of the baseline value (fire) rather than excluding it. Delver held at
+  // baseline. Widened from a 3-affinity spot-check (water, dark, decay) 2026-09-01.
+  ...AFFINITIES.map((a) =>
     scenario(`D-hazard-affinity-${a}`, "D", `hazard affinity=${a}`, {
       hazard: [`x=3;y=3;affinity=${a};expression=emit;stacks=1`],
     })),

--- a/scripts/testing/configuration-permutation-matrix.mjs
+++ b/scripts/testing/configuration-permutation-matrix.mjs
@@ -66,6 +66,26 @@ export const MATRIX = [
       hazard: [`x=3;y=3;affinity=fire;expression=${e};stacks=1`],
     })),
 
+  // Axis C (continued) — hazard position, the room's two diagonals. Hazard x/y are
+  // room-relative offsets into the target room's carved interior (level-layout.js), and a
+  // "small" room's interior is confirmed 5x5 (relative 0..4 each axis: sim-config.json grid is
+  // 9x9 with a 1-tile border wall on every side). The four corners are the diagonal extremes of
+  // that interior — main diagonal (0,0)/(4,4) and anti-diagonal (0,4)/(4,0) — chosen because
+  // diagonal-adjacent-to-wall geometry (corner peeking, diagonal blocking) is called out
+  // elsewhere in this codebase (Actor persona README, line-of-sight) as a distinct code path
+  // from cardinal placement, which the baseline's near-center (3,3) hazard never exercises.
+  // Expression/affinity held at baseline ("emit"/"fire"); only position varies. Widened in
+  // 2026-09-01.
+  ...[
+    { id: "topleft", x: 0, y: 0 },
+    { id: "bottomright", x: 4, y: 4 },
+    { id: "topright", x: 4, y: 0 },
+    { id: "bottomleft", x: 0, y: 4 },
+  ].map(({ id, x, y }) =>
+    scenario(`C-hazard-position-diagonal-${id}`, "C", `hazard position=diagonal-${id} (${x},${y})`, {
+      hazard: [`x=${x};y=${y};affinity=fire;expression=emit;stacks=1`],
+    })),
+
   // Axis D — hazard affinity, full domain (10), matching axis A's pattern of sweeping the full
   // domain inclusive of the baseline value (fire) rather than excluding it. Delver held at
   // baseline. Widened from a 3-affinity spot-check (water, dark, decay) 2026-09-01.

--- a/scripts/testing/configuration-permutation-matrix.mjs
+++ b/scripts/testing/configuration-permutation-matrix.mjs
@@ -21,6 +21,13 @@ export const NON_CONTROL_MOTIVATIONS = [
   "attacking", "defending", "stealthy", "friendly",
   "reflexive", "goal_oriented", "strategy_focused",
 ];
+// The control family (packages/runtime/src/contracts/game-elements.js GAME_MOTIVATION_FAMILIES)
+// has exactly one kind. Player-controlled actors are documented (Actor persona README, "Player-
+// controlled dynamic actors") as needing streamed simulation playback to actually be driven, so a
+// plain ak_run pass over this axis is expected to authoring-validate cleanly but act as an inert
+// actor at the run layer — informational, not a failure signal, same caveat as the axis-B
+// cognition-only motivations already noted in mcp-harness-run-through.md.
+export const CONTROL_MOTIVATIONS = ["user_controlled"];
 
 const BASELINE = {
   room: ["size=small;count=1"],
@@ -45,9 +52,10 @@ export const MATRIX = [
       delver: [`count=1;affinity=${a};motivation=exploring`],
     })),
 
-  // Axis B — delver motivation, full non-control domain minus "exploring" (already covered by
-  // baseline in axis A). Affinity/hazard held at baseline.
-  ...NON_CONTROL_MOTIVATIONS.filter((m) => m !== "exploring").map((m) =>
+  // Axis B — delver motivation, full domain (all 4 families) minus "exploring" (already covered
+  // by baseline in axis A). Includes the control family's "user_controlled", widened in from a
+  // non-control-only sweep 2026-09-01. Affinity/hazard held at baseline.
+  ...[...NON_CONTROL_MOTIVATIONS, ...CONTROL_MOTIVATIONS].filter((m) => m !== "exploring").map((m) =>
     scenario(`B-delver-motivation-${m}`, "B", `delver motivation=${m}`, {
       delver: [`count=1;affinity=fire;motivation=${m}`],
     })),

--- a/scripts/testing/configuration-permutation-matrix.mjs
+++ b/scripts/testing/configuration-permutation-matrix.mjs
@@ -1,0 +1,114 @@
+// Bounded configuration-permutation matrix for `ak create` (dry-run or full) plus an optional
+// `ak run` follow-on, driven by run-configuration-permutation-sweep.mjs.
+//
+// Not a full Cartesian product (10 affinities x 4 expressions x 11 motivations x counts x
+// warden/resource combos would run into the thousands) — this is a one-axis-at-a-time sweep off a
+// single known-good baseline, plus a handful of multi-entity stress scenarios. Each axis holds
+// every other axis at baseline and varies one dimension across its full domain (or a spot-check
+// subset for the larger domains), so a failure localizes to one axis immediately.
+//
+// budgetTokens is fixed for every scenario at a level well above what any one scenario costs, so
+// budget denial doesn't confound the sweep. That fixed cap is also the "don't let generated configs
+// grow unmanaged" rail this tool was built to satisfy.
+//
+// See mcp-harness-run-through.md ("Configuration-permutation sweep") for the sweep this matrix
+// backs, its results, and the issue (#148) its first full run found.
+
+export const AFFINITIES = ["fire", "water", "earth", "wind", "life", "decay", "corrode", "fortify", "light", "dark"];
+export const EXPRESSIONS = ["push", "pull", "emit", "draw"];
+export const NON_CONTROL_MOTIVATIONS = [
+  "random", "stationary", "exploring", "patrolling",
+  "attacking", "defending", "stealthy", "friendly",
+  "reflexive", "goal_oriented", "strategy_focused",
+];
+
+const BASELINE = {
+  room: ["size=small;count=1"],
+  delver: ["count=1;affinity=fire;motivation=exploring"],
+  hazard: ["x=3;y=3;affinity=fire;expression=emit;stacks=1"],
+  budgetTokens: 2000,
+};
+
+function scenario(id, axis, description, overrides) {
+  return {
+    id,
+    axis,
+    description,
+    args: { ...BASELINE, ...overrides },
+  };
+}
+
+export const MATRIX = [
+  // Axis A — delver affinity, full domain (10). Motivation/hazard held at baseline.
+  ...AFFINITIES.map((a) =>
+    scenario(`A-delver-affinity-${a}`, "A", `delver affinity=${a}`, {
+      delver: [`count=1;affinity=${a};motivation=exploring`],
+    })),
+
+  // Axis B — delver motivation, full non-control domain minus "exploring" (already covered by
+  // baseline in axis A). Affinity/hazard held at baseline.
+  ...NON_CONTROL_MOTIVATIONS.filter((m) => m !== "exploring").map((m) =>
+    scenario(`B-delver-motivation-${m}`, "B", `delver motivation=${m}`, {
+      delver: [`count=1;affinity=fire;motivation=${m}`],
+    })),
+
+  // Axis C — hazard expression, full domain minus "emit" (baseline). Delver held at baseline.
+  ...EXPRESSIONS.filter((e) => e !== "emit").map((e) =>
+    scenario(`C-hazard-expression-${e}`, "C", `hazard expression=${e}`, {
+      hazard: [`x=3;y=3;affinity=fire;expression=${e};stacks=1`],
+    })),
+
+  // Axis D — hazard affinity, spot-check subset (not full 10 — a candidate for widening later).
+  // Delver held at baseline.
+  ...["water", "dark", "decay"].map((a) =>
+    scenario(`D-hazard-affinity-${a}`, "D", `hazard affinity=${a}`, {
+      hazard: [`x=3;y=3;affinity=${a};expression=emit;stacks=1`],
+    })),
+
+  // Axis E — warden present, actor-vs-actor interaction.
+  scenario("E1-warden-basic", "E", "delver(fire/exploring) + warden(dark/defending)", {
+    warden: ["count=1;affinity=dark;motivation=defending"],
+  }),
+  scenario("E2-warden-same-affinity-opposed-roles", "E", "delver(fire/attacking) + warden(fire/defending), same affinity", {
+    delver: ["count=1;affinity=fire;motivation=attacking"],
+    warden: ["count=1;affinity=fire;motivation=defending"],
+  }),
+  scenario("E3-multi-actor-stress", "E", "2 delvers + 1 warden, mixed affinities/motivations", {
+    delver: [
+      "count=1;affinity=fire;motivation=exploring",
+      "count=1;affinity=water;motivation=attacking",
+    ],
+    warden: ["count=1;affinity=earth;motivation=defending"],
+  }),
+
+  // Axis F — resource authoring (V3 spec: vital payload, affinity payload, and both).
+  scenario("F1-resource-vital-consumable", "F", "resource vital payload, consumable mana", {
+    resource: ["permanenceMode=consumable;vital=mana;delta=5"],
+  }),
+  scenario("F2-resource-vital-permanent", "F", "resource vital payload, permanent health", {
+    resource: ["permanenceMode=permanent;vital=health;delta=2"],
+  }),
+  scenario("F3-resource-affinity-payload", "F", "resource affinity payload with manaRegen", {
+    resource: ["affinity=water;expression=draw;stacks=1;mana=10;manaRegen=2"],
+  }),
+
+  // Axis G — multi-hazard stress (id/index collision surface distinct from axis E's multi-actor).
+  // G2's third hazard is deliberately placed outside the room's bounds — this is the exact repro
+  // for #148 (level-gen error formatter bakes literal "undefined" into hazard_outside_room
+  // messages) and is left in place on purpose as a regression probe: it should keep reporting
+  // ANOMALY_UNEXPECTED (bad message text) until #148 is fixed, not VALIDATION_REJECTION (which
+  // would require the message to actually say what's wrong).
+  scenario("G1-multi-hazard", "G", "2 hazards, distinct affinity/expression/stacks", {
+    hazard: [
+      "x=3;y=3;affinity=fire;expression=emit;stacks=1",
+      "x=1;y=4;affinity=water;expression=pull;stacks=2",
+    ],
+  }),
+  scenario("G2-multi-hazard-triple", "G", "3 hazards, full variety", {
+    hazard: [
+      "x=3;y=3;affinity=fire;expression=emit;stacks=1",
+      "x=1;y=4;affinity=water;expression=pull;stacks=2",
+      "x=5;y=1;affinity=dark;expression=push;stacks=3",
+    ],
+  }),
+];

--- a/scripts/testing/configuration-permutation-matrix.mjs
+++ b/scripts/testing/configuration-permutation-matrix.mjs
@@ -110,6 +110,26 @@ export const MATRIX = [
     warden: ["count=1;affinity=earth;motivation=defending"],
   }),
 
+  // Axis E (continued) — diagonal warden placement, the room's two diagonals (4 corners), same
+  // rationale as axis C's diagonal hazard positions but for an actor rather than a static hazard.
+  // create/configure has no x/y field for delver/warden (level-gen auto-places actors), so this
+  // reuses E1's exact authored config and repositions the auto-placed warden at RUN time via
+  // `ak run --actor <id>,<x>,<y>` (run-configuration-permutation-sweep.mjs's actorOverride hook)
+  // — id "card_warden_1-1" confirmed from E1's own initial-state.json (single warden, count=1).
+  // Corners are absolute grid coordinates: the room's walkable interior is confirmed absolute
+  // 1..5 on each axis (9x9 grid, 1-tile border wall, room origin at (1,1) — see axis C's comment
+  // for the room-relative 0..4 that these are offset by +1 from).
+  ...[
+    { id: "topleft", x: 1, y: 1 },
+    { id: "bottomright", x: 5, y: 5 },
+    { id: "topright", x: 5, y: 1 },
+    { id: "bottomleft", x: 1, y: 5 },
+  ].map(({ id, x, y }) =>
+    scenario(`E-warden-diagonal-${id}`, "E", `warden repositioned to diagonal-${id} (${x},${y})`, {
+      warden: ["count=1;affinity=dark;motivation=defending"],
+      actorOverride: [`card_warden_1-1,${x},${y}`],
+    })),
+
   // Axis F — resource authoring (V3 spec: vital payload, affinity payload, and both).
   scenario("F1-resource-vital-consumable", "F", "resource vital payload, consumable mana", {
     resource: ["permanenceMode=consumable;vital=mana;delta=5"],

--- a/scripts/testing/run-configuration-permutation-sweep.mjs
+++ b/scripts/testing/run-configuration-permutation-sweep.mjs
@@ -56,7 +56,7 @@ function buildCreateArgv(scenario, outDir) {
 }
 
 function buildRunArgv(scenario, createOutDir, runOutDir) {
-  return [
+  const argv = [
     "run",
     "--sim-config", `${createOutDir}/sim-config.json`,
     "--initial-state", `${createOutDir}/initial-state.json`,
@@ -65,6 +65,12 @@ function buildRunArgv(scenario, createOutDir, runOutDir) {
     "--run-id", scenario.id,
     "--out-dir", runOutDir,
   ];
+  // Run-time-only override, not an authoring input: `--actor id,x,y[,kind]` repositions an
+  // already-created actor (create/configure has no x/y field for delver/warden — placement is
+  // level-gen's job). Used by axis E's diagonal-warden-placement scenarios to move the
+  // auto-placed warden onto a specific corner before ticking, without changing what was authored.
+  for (const spec of scenario.args.actorOverride || []) argv.push("--actor", spec);
+  return argv;
 }
 
 function classify(combinedText, status, parsed) {

--- a/scripts/testing/run-configuration-permutation-sweep.mjs
+++ b/scripts/testing/run-configuration-permutation-sweep.mjs
@@ -1,0 +1,190 @@
+// Runs the configuration-permutation-matrix.mjs scenarios through the real CLI and classifies
+// each result. Shells out to `node packages/adapters-cli/src/cli/ak.mjs` directly rather than
+// through MCP tool calls — this is scripted batch automation, which
+// packages/adapters-cli/src/mcp/README.md's own "Mental Model" section calls out as the right
+// case for using the CLI directly ("ad hoc shell usage... scripting outside an MCP client").
+//
+// Two modes:
+//   --dry-run    `ak create --dry-run` only (authoring-layer validation, no artifacts written,
+//                no `ak run` follow-on). Fast; good for a quick check after touching authoring
+//                code.
+//   (default)    `ak create` (real artifacts) + `ak run --ticks <N> --seed <N>` per scenario that
+//                created successfully. Reaches the layer where the real bugs this matrix has found
+//                so far actually live (see mcp-harness-run-through.md, "Configuration-permutation
+//                sweep").
+//
+// Usage:
+//   node scripts/testing/run-configuration-permutation-sweep.mjs [--dry-run] [--ticks N] [--seed N]
+//
+// acceptedActions/emittedEffects counts are recorded as INFORMATIONAL metadata only, never as a
+// pass/fail signal — treating "an actor did nothing" as itself suspect is exactly the
+// false-positive this matrix's own history already hit once (issue #146, closed: the actor had in
+// fact acted correctly — see mcp-harness-run-through.md finding 5). This sweep looks for crashes
+// and malformed output, not for "did the actor do something the axis under test doesn't actually
+// motivate it to do."
+
+import { spawnSync } from "node:child_process";
+import { writeFileSync, mkdirSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { MATRIX } from "./configuration-permutation-matrix.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "../..");
+const CLI = resolve(ROOT, "packages/adapters-cli/src/cli/ak.mjs");
+const OUT_ROOT = resolve(ROOT, "artifacts/matrix-sweep");
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const TICKS = Number(args[args.indexOf("--ticks") + 1] ?? 5) || 5;
+const SEED = Number(args[args.indexOf("--seed") + 1] ?? 0) || 0;
+
+function buildCreateArgv(scenario, outDir) {
+  const { args: a } = scenario;
+  const argv = ["create", "--run-id", scenario.id, "--budget-tokens", String(a.budgetTokens)];
+  if (DRY_RUN) {
+    argv.push("--dry-run");
+  } else {
+    argv.push("--out-dir", outDir);
+  }
+  for (const r of a.room || []) argv.push("--room", r);
+  for (const d of a.delver || []) argv.push("--delver", d);
+  for (const w of a.warden || []) argv.push("--warden", w);
+  for (const h of a.hazard || []) argv.push("--hazard", h);
+  for (const r of a.resource || []) argv.push("--resource", r);
+  return argv;
+}
+
+function buildRunArgv(scenario, createOutDir, runOutDir) {
+  return [
+    "run",
+    "--sim-config", `${createOutDir}/sim-config.json`,
+    "--initial-state", `${createOutDir}/initial-state.json`,
+    "--ticks", String(TICKS),
+    "--seed", String(SEED),
+    "--run-id", scenario.id,
+    "--out-dir", runOutDir,
+  ];
+}
+
+function classify(combinedText, status, parsed) {
+  if (status === 0 && parsed?.ok === true) return { verdict: "PASS", detail: null };
+  if (/Budget receipt denied/.test(combinedText)) {
+    return { verdict: "EXPECTED_BUDGET_DENIAL", detail: combinedText.trim().slice(0, 500) };
+  }
+  // Recognized validation-rejection phrasing. Every scenario in the matrix uses values pulled
+  // directly from the domain-constants enums, so a validation rejection here is still worth a
+  // look (it would mean the matrix itself has an invalid combo) but is a cheaper triage bucket
+  // than a raw crash or a malformed message (see #148 — a real "rejection" that still lands in
+  // ANOMALY_UNEXPECTED below because its text is broken, not because the rejection is wrong).
+  if (/must be one of|is required|is not supported|invalid;? expected/.test(combinedText)) {
+    return { verdict: "VALIDATION_REJECTION", detail: combinedText.trim().slice(0, 500) };
+  }
+  if (status === 0 && parsed?.ok === false) {
+    return { verdict: "ANOMALY_OK_FALSE", detail: combinedText.trim().slice(0, 500) };
+  }
+  return { verdict: "ANOMALY_UNEXPECTED", detail: combinedText.trim().slice(0, 1000) };
+}
+
+function runStep(argv) {
+  const proc = spawnSync(process.execPath, [CLI, ...argv], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  const stdout = proc.stdout || "";
+  const stderr = proc.stderr || "";
+  let parsed = null;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    // not JSON
+  }
+  const { verdict, detail } = classify(`${stdout}\n${stderr}`, proc.status, parsed);
+  return { verdict, detail, parsed };
+}
+
+function summarizeTickFrames(runOutDir) {
+  const framesPath = `${runOutDir}/tick-frames.json`;
+  if (!existsSync(framesPath)) return null;
+  try {
+    const frames = JSON.parse(readFileSync(framesPath, "utf8"));
+    let actionsAccepted = 0;
+    let effectsEmitted = 0;
+    for (const f of frames) {
+      actionsAccepted += (f.acceptedActions || []).length;
+      effectsEmitted += (f.emittedEffects || []).length;
+    }
+    return { actionsAccepted, effectsEmitted, frameCount: frames.length };
+  } catch {
+    return null;
+  }
+}
+
+rmSync(OUT_ROOT, { recursive: true, force: true });
+mkdirSync(OUT_ROOT, { recursive: true });
+
+const results = [];
+for (const scenario of MATRIX) {
+  const base = resolve(OUT_ROOT, "runs", scenario.id);
+  const createOutDir = resolve(base, "create");
+  const runOutDir = resolve(base, "run");
+
+  const create = runStep(buildCreateArgv(scenario, createOutDir));
+
+  let run = { verdict: DRY_RUN ? "SKIPPED_DRY_RUN" : "SKIPPED_CREATE_FAILED", detail: null };
+  let runInfo = null;
+  if (!DRY_RUN && create.verdict === "PASS") {
+    run = runStep(buildRunArgv(scenario, createOutDir, runOutDir));
+    if (run.verdict === "PASS") {
+      runInfo = summarizeTickFrames(runOutDir);
+    }
+  }
+
+  results.push({
+    id: scenario.id,
+    axis: scenario.axis,
+    description: scenario.description,
+    createVerdict: create.verdict,
+    createDetail: create.verdict === "PASS" ? null : create.detail,
+    runVerdict: run.verdict,
+    runDetail: ["PASS", "SKIPPED_CREATE_FAILED", "SKIPPED_DRY_RUN"].includes(run.verdict) ? null : run.detail,
+    runInfo,
+  });
+
+  const runInfoText = runInfo ? `actions=${runInfo.actionsAccepted} effects=${runInfo.effectsEmitted}` : "";
+  process.stdout.write(
+    `${scenario.id.padEnd(45)} create=${create.verdict.padEnd(24)} run=${run.verdict.padEnd(24)} ${runInfoText}\n`,
+  );
+}
+
+const createSummary = results.reduce((acc, r) => {
+  acc[r.createVerdict] = (acc[r.createVerdict] || 0) + 1;
+  return acc;
+}, {});
+const runSummary = results.reduce((acc, r) => {
+  acc[r.runVerdict] = (acc[r.runVerdict] || 0) + 1;
+  return acc;
+}, {});
+
+const resultsPath = resolve(OUT_ROOT, `results-${DRY_RUN ? "dry-run" : "full"}.json`);
+writeFileSync(resultsPath, JSON.stringify({ mode: DRY_RUN ? "dry-run" : "full", ticks: TICKS, seed: SEED, total: results.length, createSummary, runSummary, results }, null, 2));
+
+console.log("\n--- create summary ---");
+console.log(JSON.stringify(createSummary, null, 2));
+if (!DRY_RUN) {
+  console.log("\n--- run summary ---");
+  console.log(JSON.stringify(runSummary, null, 2));
+}
+console.log(`\nfull results: ${resultsPath}`);
+
+const anomalies = results.filter((r) => r.createVerdict.startsWith("ANOMALY") || r.runVerdict.startsWith("ANOMALY"));
+if (anomalies.length > 0) {
+  console.log(`\n--- ${anomalies.length} anomalies ---`);
+  for (const a of anomalies) {
+    console.log(`\n${a.id} (${a.description}):`);
+    if (a.createDetail) console.log(`  create: ${a.createDetail}`);
+    if (a.runDetail) console.log(`  run: ${a.runDetail}`);
+  }
+  process.exitCode = 1;
+}

--- a/scripts/testing/run-configuration-permutation-sweep.mjs
+++ b/scripts/testing/run-configuration-permutation-sweep.mjs
@@ -34,6 +34,26 @@
 // tick's moves are applied, and every requested tick actually produced exactly one `apply`
 // phase-frame (no skipped or duplicated ticks). No extra CLI/MCP calls — it's pure post-processing
 // of files the `run` step already writes, so it costs nothing extra at 50-scenario scale.
+//
+// Determinism/reproducibility check (added investigating whether hazard interaction could be
+// tested this way — see mcp-harness-run-through.md, "Hazard interaction — what this sweep found").
+// Hazards authored via ak_create/ak_run turned out to be wired through a static affinity FIELD
+// (core.armStaticHazardAt / computeStaticHazardAffinityField) that feeds an actor's OBSERVATION —
+// internal to core-ts, never written to any file this sweep reads, so its exact effect isn't
+// assertable from outside without a core-ts-level test (a different layer than this sweep). What
+// *is* assertable from here, and is the real prerequisite for any interaction-specific assertion
+// to mean anything: is the simulation reproducible at all. checkDeterminism() re-runs `ak run`
+// a second time against the SAME create output (same sim-config.json/initial-state.json, same
+// run-id, a separate --out-dir) and deep-compares every artifact the first run produced. The clock
+// is seeded from sim-config's own meta.createdAt (createDeterministicClock/resolveClockSeed in
+// run-helpers.js), not the wall clock, so the SIMULATION should match exactly — and it does: the
+// first run of this check found tick-frames.json/effects-log.json/runtime-decision-captures.json
+// byte-identical across all 49 scenarios. It also found three OTHER artifacts
+// (action-log.json/run-summary.json/world-state.json) were never reproducible, for a confirmed,
+// unrelated reason — their meta.id/meta.createdAt are stamped by the host's wall-clock
+// createMeta()/makeId(), not the seeded clock (filed as #149). stripKnownNondeterministicMeta()
+// below excludes exactly that field pair so this check measures what it actually set out to
+// measure; see #149 for the harness gap itself, tracked and fixed separately.
 
 import { spawnSync } from "node:child_process";
 import { writeFileSync, mkdirSync, readFileSync, existsSync, rmSync } from "node:fs";
@@ -211,6 +231,91 @@ function stepLevelCheck(createOutDir, runOutDir, ticksRequested) {
   return { checked: true, ticksChecked: applyFrames.length, violations };
 }
 
+const DETERMINISM_FILES = [
+  "tick-frames.json",
+  "effects-log.json",
+  "runtime-decision-captures.json",
+  "run-summary.json",
+  "action-log.json",
+  "world-state.json",
+];
+
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  if (aKeys.length !== bKeys.length || aKeys.some((k, i) => k !== bKeys[i])) return false;
+  return aKeys.every((k) => deepEqual(a[k], b[k]));
+}
+
+// #149: action-log.json/run-summary.json/world-state.json stamp meta.id/meta.createdAt from the
+// host's wall-clock createMeta()/makeId() (ak-impl.mjs:1597-1611) instead of the run's own seeded
+// clock, so those two fields legitimately differ between two runs of identical input — confirmed
+// as the ONLY thing that ever differs; every other field, including every field in tick-frames.json/
+// effects-log.json/runtime-decision-captures.json (which use the seeded clock throughout), matched
+// exactly. Stripped here, narrowly: only `id`+`createdAt` when they co-occur on an object shaped
+// like a createMeta() stamp (so `runId`/`producedBy`/every other field still has to match — a real
+// regression there is not masked). Once #149 is fixed this function becomes a no-op and can be
+// deleted along with this whole exclusion.
+function stripKnownNondeterministicMeta(value) {
+  if (Array.isArray(value)) return value.map(stripKnownNondeterministicMeta);
+  if (value && typeof value === "object") {
+    const isMetaStamp = "id" in value && "createdAt" in value;
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (isMetaStamp && (k === "id" || k === "createdAt")) continue;
+      out[k] = stripKnownNondeterministicMeta(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+// Re-runs `ak run` a second time against the SAME create output (see the file-header comment for
+// why this is the meaningful reproducibility boundary) and deep-compares every artifact it wrote
+// the first time, after stripping the one known-nondeterministic field pair (see #149 above) — so
+// this checks what it's meant to check, whether the SIMULATION is reproducible, without a known,
+// separately-tracked harness gap drowning every result in noise.
+function checkDeterminism(scenario, createOutDir, runOutDir, repeatOutDir) {
+  const repeat = runStep(buildRunArgv(scenario, createOutDir, repeatOutDir));
+  if (repeat.verdict !== "PASS") {
+    return { checked: true, match: false, mismatches: [`repeat run did not pass: ${repeat.verdict} — ${repeat.detail}`] };
+  }
+  const mismatches = [];
+  for (const file of DETERMINISM_FILES) {
+    const originalPath = `${runOutDir}/${file}`;
+    const repeatPath = `${repeatOutDir}/${file}`;
+    const originalExists = existsSync(originalPath);
+    const repeatExists = existsSync(repeatPath);
+    if (originalExists !== repeatExists) {
+      mismatches.push(`${file}: present in one run but not the other (original=${originalExists}, repeat=${repeatExists})`);
+      continue;
+    }
+    if (!originalExists) continue;
+    let original;
+    let repeated;
+    try {
+      original = stripKnownNondeterministicMeta(JSON.parse(readFileSync(originalPath, "utf8")));
+      repeated = stripKnownNondeterministicMeta(JSON.parse(readFileSync(repeatPath, "utf8")));
+    } catch (err) {
+      mismatches.push(`${file}: could not parse for comparison: ${err.message}`);
+      continue;
+    }
+    if (!deepEqual(original, repeated)) {
+      mismatches.push(`${file}: differs between the two runs (beyond the known #149 meta.id/createdAt gap)`);
+    }
+  }
+  return { checked: true, match: mismatches.length === 0, mismatches };
+}
+
 rmSync(OUT_ROOT, { recursive: true, force: true });
 mkdirSync(OUT_ROOT, { recursive: true });
 
@@ -219,17 +324,20 @@ for (const scenario of MATRIX) {
   const base = resolve(OUT_ROOT, "runs", scenario.id);
   const createOutDir = resolve(base, "create");
   const runOutDir = resolve(base, "run");
+  const repeatOutDir = resolve(base, "run-repeat");
 
   const create = runStep(buildCreateArgv(scenario, createOutDir));
 
   let run = { verdict: DRY_RUN ? "SKIPPED_DRY_RUN" : "SKIPPED_CREATE_FAILED", detail: null };
   let runInfo = null;
   let stepLevel = { checked: false, ticksChecked: 0, violations: [] };
+  let determinism = { checked: false, match: null, mismatches: [] };
   if (!DRY_RUN && create.verdict === "PASS") {
     run = runStep(buildRunArgv(scenario, createOutDir, runOutDir));
     if (run.verdict === "PASS") {
       runInfo = summarizeTickFrames(runOutDir);
       stepLevel = stepLevelCheck(createOutDir, runOutDir, TICKS);
+      determinism = checkDeterminism(scenario, createOutDir, runOutDir, repeatOutDir);
     }
   }
 
@@ -243,14 +351,18 @@ for (const scenario of MATRIX) {
     runDetail: ["PASS", "SKIPPED_CREATE_FAILED", "SKIPPED_DRY_RUN"].includes(run.verdict) ? null : run.detail,
     runInfo,
     stepLevel,
+    determinism,
   });
 
   const runInfoText = runInfo ? `actions=${runInfo.actionsAccepted} effects=${runInfo.effectsEmitted}` : "";
   const stepLevelText = stepLevel.checked
     ? (stepLevel.violations.length > 0 ? `step=VIOLATIONS(${stepLevel.violations.length})` : `step=OK(${stepLevel.ticksChecked})`)
     : "";
+  const determinismText = determinism.checked
+    ? (determinism.match ? "det=OK" : `det=MISMATCH(${determinism.mismatches.length})`)
+    : "";
   process.stdout.write(
-    `${scenario.id.padEnd(45)} create=${create.verdict.padEnd(24)} run=${run.verdict.padEnd(24)} ${runInfoText} ${stepLevelText}\n`,
+    `${scenario.id.padEnd(45)} create=${create.verdict.padEnd(24)} run=${run.verdict.padEnd(24)} ${runInfoText} ${stepLevelText} ${determinismText}\n`,
   );
 }
 
@@ -268,9 +380,15 @@ const stepLevelSummary = {
   clean: stepLevelChecked.filter((r) => r.stepLevel.violations.length === 0).length,
   withViolations: stepLevelChecked.filter((r) => r.stepLevel.violations.length > 0).length,
 };
+const determinismChecked = results.filter((r) => r.determinism.checked);
+const determinismSummary = {
+  checked: determinismChecked.length,
+  reproducible: determinismChecked.filter((r) => r.determinism.match).length,
+  mismatched: determinismChecked.filter((r) => !r.determinism.match).length,
+};
 
 const resultsPath = resolve(OUT_ROOT, `results-${DRY_RUN ? "dry-run" : "full"}.json`);
-writeFileSync(resultsPath, JSON.stringify({ mode: DRY_RUN ? "dry-run" : "full", ticks: TICKS, seed: SEED, total: results.length, createSummary, runSummary, stepLevelSummary, results }, null, 2));
+writeFileSync(resultsPath, JSON.stringify({ mode: DRY_RUN ? "dry-run" : "full", ticks: TICKS, seed: SEED, total: results.length, createSummary, runSummary, stepLevelSummary, determinismSummary, results }, null, 2));
 
 console.log("\n--- create summary ---");
 console.log(JSON.stringify(createSummary, null, 2));
@@ -279,11 +397,14 @@ if (!DRY_RUN) {
   console.log(JSON.stringify(runSummary, null, 2));
   console.log("\n--- step-level summary ---");
   console.log(JSON.stringify(stepLevelSummary, null, 2));
+  console.log("\n--- determinism summary ---");
+  console.log(JSON.stringify(determinismSummary, null, 2));
 }
 console.log(`\nfull results: ${resultsPath}`);
 
 const anomalies = results.filter((r) => r.createVerdict.startsWith("ANOMALY") || r.runVerdict.startsWith("ANOMALY"));
 const stepLevelFailures = results.filter((r) => r.stepLevel.violations.length > 0);
+const determinismFailures = results.filter((r) => r.determinism.checked && !r.determinism.match);
 if (anomalies.length > 0) {
   console.log(`\n--- ${anomalies.length} anomalies ---`);
   for (const a of anomalies) {
@@ -298,6 +419,14 @@ if (stepLevelFailures.length > 0) {
   for (const s of stepLevelFailures) {
     console.log(`\n${s.id} (${s.description}):`);
     for (const v of s.stepLevel.violations) console.log(`  ${v}`);
+  }
+  process.exitCode = 1;
+}
+if (determinismFailures.length > 0) {
+  console.log(`\n--- ${determinismFailures.length} scenarios with non-reproducible output ---`);
+  for (const s of determinismFailures) {
+    console.log(`\n${s.id} (${s.description}):`);
+    for (const m of s.determinism.mismatches) console.log(`  ${m}`);
   }
   process.exitCode = 1;
 }

--- a/scripts/testing/run-configuration-permutation-sweep.mjs
+++ b/scripts/testing/run-configuration-permutation-sweep.mjs
@@ -22,6 +22,18 @@
 // fact acted correctly — see mcp-harness-run-through.md finding 5). This sweep looks for crashes
 // and malformed output, not for "did the actor do something the axis under test doesn't actually
 // motivate it to do."
+//
+// Step-level assertions (added after the sweep's first coverage review — see
+// mcp-harness-run-through.md, "Testing depth"): the whole-run classification above only asks
+// "did the run complete." It cannot see a defect present at tick 2 and gone by tick 5 — which is
+// exactly the shape #147 was (every tick individually wrong, in a way no aggregate summary would
+// ever flag). stepLevelCheck() replays acceptedActions cumulatively tick-by-tick against
+// initial-state.json/sim-config.json — the same data ak_show_state's own (correct)
+// resolveActorPositionsAtTick() replay is built on — and asserts, at every tick: every accepted
+// move landed in-bounds and off a wall tile, no two actors ever occupy the same tile after a
+// tick's moves are applied, and every requested tick actually produced exactly one `apply`
+// phase-frame (no skipped or duplicated ticks). No extra CLI/MCP calls — it's pure post-processing
+// of files the `run` step already writes, so it costs nothing extra at 50-scenario scale.
 
 import { spawnSync } from "node:child_process";
 import { writeFileSync, mkdirSync, readFileSync, existsSync, rmSync } from "node:fs";
@@ -127,6 +139,78 @@ function summarizeTickFrames(runOutDir) {
   }
 }
 
+// Per-tick assertions, replayed from files the `run` step already wrote — no extra CLI/MCP calls.
+// See the file-header comment for what this checks and why (mirrors #147's shape: correct in
+// aggregate, wrong at individual ticks).
+function stepLevelCheck(createOutDir, runOutDir, ticksRequested) {
+  let initialState;
+  let simConfig;
+  let frames;
+  try {
+    initialState = JSON.parse(readFileSync(`${createOutDir}/initial-state.json`, "utf8"));
+    simConfig = JSON.parse(readFileSync(`${createOutDir}/sim-config.json`, "utf8"));
+    frames = JSON.parse(readFileSync(`${runOutDir}/tick-frames.json`, "utf8"));
+  } catch (err) {
+    return { checked: false, ticksChecked: 0, violations: [`could not load step-level inputs: ${err.message}`] };
+  }
+  if (!Array.isArray(frames)) {
+    return { checked: false, ticksChecked: 0, violations: ["tick-frames.json is not an array"] };
+  }
+
+  const violations = [];
+
+  const tiles = Array.isArray(simConfig?.layout?.data?.tiles) ? simConfig.layout.data.tiles.map(String) : null;
+  const height = tiles ? tiles.length : 0;
+  const width = tiles && height > 0 ? tiles[0].length : 0;
+
+  // Tick continuity: exactly one "apply" phase-frame per requested tick, 1..N, no gaps or dupes —
+  // catches a tick silently dropped or replayed twice, which no aggregate count would surface.
+  const applyFrames = frames.filter((f) => f.phaseDetail === "apply").sort((a, b) => a.tick - b.tick);
+  const applyTicks = applyFrames.map((f) => f.tick);
+  const expectedTicks = Array.from({ length: ticksRequested }, (_, i) => i + 1);
+  if (JSON.stringify(applyTicks) !== JSON.stringify(expectedTicks)) {
+    violations.push(`tick continuity: expected apply phases [${expectedTicks.join(",")}], got [${applyTicks.join(",")}]`);
+  }
+
+  // Cumulative position replay, tick by tick — the same approach ak_show_state's own (correct)
+  // resolveActorPositionsAtTick() uses, applied here as an assertion instead of a rendering.
+  const positions = new Map();
+  for (const actor of initialState?.actors || []) {
+    if (actor?.id && Number.isFinite(actor?.position?.x) && Number.isFinite(actor?.position?.y)) {
+      positions.set(actor.id, { x: actor.position.x, y: actor.position.y });
+    }
+  }
+
+  for (const frame of applyFrames) {
+    for (const action of frame.acceptedActions || []) {
+      if (action.kind !== "move") continue;
+      const to = action.params?.to;
+      if (!to || !Number.isFinite(to.x) || !Number.isFinite(to.y)) {
+        violations.push(`tick ${frame.tick}: accepted move for ${action.actorId} has a malformed destination`);
+        continue;
+      }
+      if (tiles && (to.x < 0 || to.y < 0 || to.x >= width || to.y >= height)) {
+        violations.push(`tick ${frame.tick}: accepted move put ${action.actorId} out of grid bounds at (${to.x},${to.y})`);
+      } else if (tiles && tiles[to.y][to.x] === "#") {
+        violations.push(`tick ${frame.tick}: accepted move put ${action.actorId} on a wall tile at (${to.x},${to.y})`);
+      }
+      positions.set(action.actorId, { x: to.x, y: to.y });
+    }
+    // Collision check, after this tick's moves are applied — two solid actors on one tile.
+    const occupied = new Map();
+    for (const [actorId, pos] of positions) {
+      const key = `${pos.x},${pos.y}`;
+      if (occupied.has(key)) {
+        violations.push(`tick ${frame.tick}: ${actorId} and ${occupied.get(key)} both occupy (${key}) after accepted moves`);
+      } else {
+        occupied.set(key, actorId);
+      }
+    }
+  }
+
+  return { checked: true, ticksChecked: applyFrames.length, violations };
+}
+
 rmSync(OUT_ROOT, { recursive: true, force: true });
 mkdirSync(OUT_ROOT, { recursive: true });
 
@@ -140,10 +224,12 @@ for (const scenario of MATRIX) {
 
   let run = { verdict: DRY_RUN ? "SKIPPED_DRY_RUN" : "SKIPPED_CREATE_FAILED", detail: null };
   let runInfo = null;
+  let stepLevel = { checked: false, ticksChecked: 0, violations: [] };
   if (!DRY_RUN && create.verdict === "PASS") {
     run = runStep(buildRunArgv(scenario, createOutDir, runOutDir));
     if (run.verdict === "PASS") {
       runInfo = summarizeTickFrames(runOutDir);
+      stepLevel = stepLevelCheck(createOutDir, runOutDir, TICKS);
     }
   }
 
@@ -156,11 +242,15 @@ for (const scenario of MATRIX) {
     runVerdict: run.verdict,
     runDetail: ["PASS", "SKIPPED_CREATE_FAILED", "SKIPPED_DRY_RUN"].includes(run.verdict) ? null : run.detail,
     runInfo,
+    stepLevel,
   });
 
   const runInfoText = runInfo ? `actions=${runInfo.actionsAccepted} effects=${runInfo.effectsEmitted}` : "";
+  const stepLevelText = stepLevel.checked
+    ? (stepLevel.violations.length > 0 ? `step=VIOLATIONS(${stepLevel.violations.length})` : `step=OK(${stepLevel.ticksChecked})`)
+    : "";
   process.stdout.write(
-    `${scenario.id.padEnd(45)} create=${create.verdict.padEnd(24)} run=${run.verdict.padEnd(24)} ${runInfoText}\n`,
+    `${scenario.id.padEnd(45)} create=${create.verdict.padEnd(24)} run=${run.verdict.padEnd(24)} ${runInfoText} ${stepLevelText}\n`,
   );
 }
 
@@ -172,25 +262,42 @@ const runSummary = results.reduce((acc, r) => {
   acc[r.runVerdict] = (acc[r.runVerdict] || 0) + 1;
   return acc;
 }, {});
+const stepLevelChecked = results.filter((r) => r.stepLevel.checked);
+const stepLevelSummary = {
+  checked: stepLevelChecked.length,
+  clean: stepLevelChecked.filter((r) => r.stepLevel.violations.length === 0).length,
+  withViolations: stepLevelChecked.filter((r) => r.stepLevel.violations.length > 0).length,
+};
 
 const resultsPath = resolve(OUT_ROOT, `results-${DRY_RUN ? "dry-run" : "full"}.json`);
-writeFileSync(resultsPath, JSON.stringify({ mode: DRY_RUN ? "dry-run" : "full", ticks: TICKS, seed: SEED, total: results.length, createSummary, runSummary, results }, null, 2));
+writeFileSync(resultsPath, JSON.stringify({ mode: DRY_RUN ? "dry-run" : "full", ticks: TICKS, seed: SEED, total: results.length, createSummary, runSummary, stepLevelSummary, results }, null, 2));
 
 console.log("\n--- create summary ---");
 console.log(JSON.stringify(createSummary, null, 2));
 if (!DRY_RUN) {
   console.log("\n--- run summary ---");
   console.log(JSON.stringify(runSummary, null, 2));
+  console.log("\n--- step-level summary ---");
+  console.log(JSON.stringify(stepLevelSummary, null, 2));
 }
 console.log(`\nfull results: ${resultsPath}`);
 
 const anomalies = results.filter((r) => r.createVerdict.startsWith("ANOMALY") || r.runVerdict.startsWith("ANOMALY"));
+const stepLevelFailures = results.filter((r) => r.stepLevel.violations.length > 0);
 if (anomalies.length > 0) {
   console.log(`\n--- ${anomalies.length} anomalies ---`);
   for (const a of anomalies) {
     console.log(`\n${a.id} (${a.description}):`);
     if (a.createDetail) console.log(`  create: ${a.createDetail}`);
     if (a.runDetail) console.log(`  run: ${a.runDetail}`);
+  }
+  process.exitCode = 1;
+}
+if (stepLevelFailures.length > 0) {
+  console.log(`\n--- ${stepLevelFailures.length} scenarios with step-level violations ---`);
+  for (const s of stepLevelFailures) {
+    console.log(`\n${s.id} (${s.description}):`);
+    for (const v of s.stepLevel.violations) console.log(`  ${v}`);
   }
   process.exitCode = 1;
 }

--- a/tests/adapters-cli/ak-hazard-placement.test.js
+++ b/tests/adapters-cli/ak-hazard-placement.test.js
@@ -350,6 +350,28 @@ test("hazard with room-relative coords exceeding the room interior is rejected w
   );
 });
 
+test("#148: hazard_outside_room's rejection message reports real numbers, not \"undefined\"", () => {
+  // Regression guard for #148: orchestrate-build.js formatted every level-gen error with a
+  // template written for floor_tile_budget_insufficient's {target, required, roomCount} shape.
+  // hazard_outside_room's actual detail shape is {x, y, roomId, roomWidth, roomHeight}, so every
+  // interpolated field came out literally as the string "undefined". The rejection itself was
+  // always correct — this guards the MESSAGE, not the rejection decision above.
+  const result = runCli([
+    "create",
+    "--room", "size=medium;count=1",
+    "--hazard", "x=8;y=8;affinity=fire;expression=emit;stacks=1",
+    "--delver", "count=1;affinity=fire;motivation=attacking",
+    "--budget-tokens", "1000",
+    "--budget", BUDGET,
+    "--price-list", PRICE_LIST,
+    "--out-dir", mkdtempSync(join(os.tmpdir(), "ak-hazard-placement-message-")),
+  ]);
+  assert.notEqual(result.status, 0);
+  const combined = `${result.stdout}\n${result.stderr}`;
+  assert.doesNotMatch(combined, /undefined/, `error message must not contain "undefined": ${combined}`);
+  assert.match(combined, /8,8/, `error message should report the actual out-of-bounds position: ${combined}`);
+});
+
 test("hazard x or y supplied as a string token is rejected at parse time", () => {
   const result = runCli([
     "create",

--- a/tests/adapters-cli/ak-tick-visualization.test.js
+++ b/tests/adapters-cli/ak-tick-visualization.test.js
@@ -8,7 +8,7 @@
 
 const assert = require("node:assert/strict");
 const { spawnSync } = require("node:child_process");
-const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs");
+const { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } = require("node:fs");
 const { resolve, join, dirname } = require("node:path");
 const os = require("node:os");
 
@@ -213,7 +213,11 @@ test("tick backward --visualization ascii includes visualization at the rewound 
 // FAILING: --visualization image not yet implemented (M4)
 // ---------------------------------------------------------------------------
 
-test("tick state --visualization image returns visualizationDataUri as PNG data URI", () => {
+test("tick state --visualization image writes a PNG file and returns its path (#144)", () => {
+  // #144 -- an inlined data URI reliably blows an MCP tool-result token budget (443,790
+  // characters on a trivial one-room, one-actor real run). Image mode now writes the PNG to disk
+  // and returns visualizationPath instead, the same convention every other artifact-producing
+  // ak_* command already follows.
   const workDir = mkdtempSync(join(os.tmpdir(), "ak-viz-img-"));
   const runId = "run_viz_img";
   scaffoldRun(workDir, runId, { maxTick: 3 });
@@ -223,14 +227,12 @@ test("tick state --visualization image returns visualizationDataUri as PNG data 
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal(output.ok, true);
-  // FAILS until M4
   assert.ok(output.visualization !== undefined, "visualization must be present with --visualization image");
   assert.equal(output.visualization.mode, "image");
-  assert.ok(typeof output.visualization.visualizationDataUri === "string" &&
-    output.visualization.visualizationDataUri.startsWith("data:image/png;base64,"),
-    "visualizationDataUri must be a PNG data URI");
-  const base64 = output.visualization.visualizationDataUri.replace("data:image/png;base64,", "");
-  const bytes = Buffer.from(base64, "base64");
+  assert.equal(output.visualization.visualizationDataUri, null, "visualizationDataUri must be null -- the bytes are on disk");
+  assert.equal(typeof output.visualization.visualizationPath, "string", "visualizationPath must be a string path");
+  assert.ok(existsSync(output.visualization.visualizationPath), "the PNG file must actually exist");
+  const bytes = readFileSync(output.visualization.visualizationPath);
   assert.equal(bytes[0], 0x89, "PNG magic byte 0 must be 0x89");
   assert.equal(bytes[1], 0x50, "PNG magic byte 1 must be 0x50 (P)");
   assert.equal(bytes[2], 0x4e, "PNG magic byte 2 must be 0x4e (N)");

--- a/tests/architecture/ak-create-error-detail-allowlist.json
+++ b/tests/architecture/ak-create-error-detail-allowlist.json
@@ -1,28 +1,28 @@
 [
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 310,
-    "reason": "assignPositionedLayoutObjects -- multi-line concatenated template literal (M4 fix); already reports candidates.length/objects.length/index. Flagged needs-manual-read only because the classifier can't parse `...` + `...` concatenation as one interpolated literal. Line shifted by #148's formatLevelGenErrorDetail() addition."
+    "line": 320,
+    "reason": "assignPositionedLayoutObjects -- multi-line concatenated template literal (M4 fix); already reports candidates.length/objects.length/index. Flagged needs-manual-read only because the classifier can't parse `...` + `...` concatenation as one interpolated literal. Line shifted by #148's formatLevelGenErrorDetail() and #145's per-pool shortfall additions."
   },
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 369,
-    "reason": "orchestrateBuild top-level `!spec` guard -- spec is an internal BuildSpec artifact, not raw model input; nothing else to say when it's simply absent. Line shifted by #148's formatLevelGenErrorDetail() addition."
+    "line": 379,
+    "reason": "orchestrateBuild top-level `!spec` guard -- spec is an internal BuildSpec artifact, not raw model input; nothing else to say when it's simply absent. Line shifted by #148's formatLevelGenErrorDetail() and #145's per-pool shortfall additions."
   },
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 424,
-    "reason": "levelGen actors-presence guard (SM2 fix) -- concatenated template literal reports the received kind. Same classifier limitation as line 266 (now 310). Line shifted by #148's formatLevelGenErrorDetail() addition."
+    "line": 434,
+    "reason": "levelGen actors-presence guard (SM2 fix) -- concatenated template literal reports the received kind. Same classifier limitation as line 266 (now 320). Line shifted by #148's formatLevelGenErrorDetail() and #145's per-pool shortfall additions."
   },
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 648,
-    "reason": "throw new Error(formatBudgetReceiptDenial(budgetReceipt)) -- a function call, not a literal, so the classifier can't inspect it. formatBudgetReceiptDenial() is already rich (status/remaining/deniedLines/deniedPools). Line shifted by #148's formatLevelGenErrorDetail() addition."
+    "line": 658,
+    "reason": "throw new Error(formatBudgetReceiptDenial(budgetReceipt)) -- a function call, not a literal, so the classifier can't inspect it. formatBudgetReceiptDenial() is already rich (status/remaining/deniedLines/deniedPools/per-pool shortfall). Line shifted by #148's formatLevelGenErrorDetail() and #145's per-pool shortfall additions."
   },
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 652,
-    "reason": "Second call site of formatBudgetReceiptDenial() -- same as line 648. Line shifted by #148's formatLevelGenErrorDetail() addition."
+    "line": 662,
+    "reason": "Second call site of formatBudgetReceiptDenial() -- same as line 658. Line shifted by #148's formatLevelGenErrorDetail() and #145's per-pool shortfall additions."
   },
   {
     "file": "packages/runtime/src/personas/allocator/budget-fulfillment.js",

--- a/tests/architecture/ak-create-error-detail-allowlist.json
+++ b/tests/architecture/ak-create-error-detail-allowlist.json
@@ -1,28 +1,28 @@
 [
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 266,
-    "reason": "assignPositionedLayoutObjects -- multi-line concatenated template literal (M4 fix); already reports candidates.length/objects.length/index. Flagged needs-manual-read only because the classifier can't parse `...` + `...` concatenation as one interpolated literal."
+    "line": 310,
+    "reason": "assignPositionedLayoutObjects -- multi-line concatenated template literal (M4 fix); already reports candidates.length/objects.length/index. Flagged needs-manual-read only because the classifier can't parse `...` + `...` concatenation as one interpolated literal. Line shifted by #148's formatLevelGenErrorDetail() addition."
   },
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 325,
-    "reason": "orchestrateBuild top-level `!spec` guard -- spec is an internal BuildSpec artifact, not raw model input; nothing else to say when it's simply absent."
+    "line": 369,
+    "reason": "orchestrateBuild top-level `!spec` guard -- spec is an internal BuildSpec artifact, not raw model input; nothing else to say when it's simply absent. Line shifted by #148's formatLevelGenErrorDetail() addition."
   },
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 380,
-    "reason": "levelGen actors-presence guard (SM2 fix) -- concatenated template literal reports the received kind. Same classifier limitation as line 266."
+    "line": 424,
+    "reason": "levelGen actors-presence guard (SM2 fix) -- concatenated template literal reports the received kind. Same classifier limitation as line 266 (now 310). Line shifted by #148's formatLevelGenErrorDetail() addition."
   },
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 608,
-    "reason": "throw new Error(formatBudgetReceiptDenial(budgetReceipt)) -- a function call, not a literal, so the classifier can't inspect it. formatBudgetReceiptDenial() is already rich (status/remaining/deniedLines/deniedPools)."
+    "line": 648,
+    "reason": "throw new Error(formatBudgetReceiptDenial(budgetReceipt)) -- a function call, not a literal, so the classifier can't inspect it. formatBudgetReceiptDenial() is already rich (status/remaining/deniedLines/deniedPools). Line shifted by #148's formatLevelGenErrorDetail() addition."
   },
   {
     "file": "packages/runtime/src/build/orchestrate-build.js",
-    "line": 612,
-    "reason": "Second call site of formatBudgetReceiptDenial() -- same as line 608."
+    "line": 652,
+    "reason": "Second call site of formatBudgetReceiptDenial() -- same as line 648. Line shifted by #148's formatLevelGenErrorDetail() addition."
   },
   {
     "file": "packages/runtime/src/personas/allocator/budget-fulfillment.js",

--- a/tests/contracts/visualization-snapshot-artifact.test.js
+++ b/tests/contracts/visualization-snapshot-artifact.test.js
@@ -40,8 +40,18 @@ function validateAsciiSnapshot(snap) {
 function validateImageSnapshot(snap) {
   validateBase(snap);
   assert.equal(snap.mode, "image");
-  assert.equal(typeof snap.visualizationDataUri, "string", "visualizationDataUri must be a string");
-  assert.match(snap.visualizationDataUri, /^data:image\/png;base64,/, "must be a PNG data URI");
+  // #144 -- a producer either inlines a data URI (visualizationDataUri) or writes the PNG to disk
+  // and points at it (visualizationPath: adapters-cli's own image path does this now, since an
+  // inlined data URI reliably blows an MCP tool-result token budget). Never both, never neither.
+  const hasDataUri = typeof snap.visualizationDataUri === "string";
+  const hasPath = typeof snap.visualizationPath === "string" && snap.visualizationPath.length > 0;
+  assert.ok(hasDataUri || hasPath, "must have either visualizationDataUri (string) or visualizationPath (string)");
+  if (hasDataUri) {
+    assert.match(snap.visualizationDataUri, /^data:image\/png;base64,/, "visualizationDataUri, when a string, must be a PNG data URI");
+  }
+  if (hasPath) {
+    assert.equal(snap.visualizationDataUri, null, "visualizationDataUri must be null when visualizationPath is used instead");
+  }
   assert.ok(Array.isArray(snap.actorDetails), "actorDetails must be an array");
 }
 
@@ -113,6 +123,22 @@ test("VisualizationSnapshot image shape satisfies contract", () => {
   };
   validateImageSnapshot(snap);
 });
+
+test("VisualizationSnapshot image shape also satisfies contract via visualizationPath (#144)", () => {
+  const snap = {
+    schema: "agent-kernel/VisualizationSnapshot",
+    schemaVersion: 1,
+    meta: { id: "vs2b", runId: "run1", createdAt: "2026-01-01T00:00:00.000Z", producedBy: "ak-tick" },
+    mode: "image",
+    tick: 2,
+    runId: "run1",
+    visualizationDataUri: null,
+    visualizationPath: "/artifacts/runs/run1/session/visualization-tick-2.png",
+    actorDetails: [],
+  };
+  validateImageSnapshot(snap);
+});
+
 
 test("VisualizationSnapshot rejects unknown mode", () => {
   const snap = {

--- a/tests/integration/mcp/tick-visualization.test.js
+++ b/tests/integration/mcp/tick-visualization.test.js
@@ -8,7 +8,7 @@
 
 const assert = require("node:assert/strict");
 const { spawn, spawnSync } = require("node:child_process");
-const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs");
+const { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } = require("node:fs");
 const { resolve, join, dirname } = require("node:path");
 const os = require("node:os");
 
@@ -205,7 +205,12 @@ test("ak_show_state with visualization:ascii returns visualization object", asyn
   }
 });
 
-test("ak_show_state with visualization:image returns visualizationDataUri PNG data URI", async () => {
+test("ak_show_state with visualization:image writes a PNG file and returns its path (#144)", async () => {
+  // #144 — a data URI this size (443,790 characters on a trivial one-room, one-actor real run)
+  // reliably blows an MCP tool-result token budget; ascii mode never carries image bytes and
+  // stayed well under it. Image mode now writes the PNG to disk and returns visualizationPath
+  // instead of inlining the bytes, the same convention every other artifact-producing ak_* tool
+  // already follows.
   const workDir      = mkdtempSync(join(os.tmpdir(), "ak-mcp-viz-img-"));
   const artifactsDir = join(workDir, "artifacts");
   const runId        = "run_mcp_viz_img";
@@ -216,15 +221,28 @@ test("ak_show_state with visualization:image returns visualizationDataUri PNG da
   const harness = new McpServerHarness({ AK_ARTIFACTS_DIR: artifactsDir });
   try {
     await harness.initialize();
-    // FAILS until M4
     const result = await harness.callToolRaw("ak_show_state", { runId, visualization: "image" });
     assert.equal(result.ok, true);
     assert.ok(result.visualization !== undefined, "visualization must be present");
     assert.equal(result.visualization.mode, "image");
-    assert.ok(
-      typeof result.visualization.visualizationDataUri === "string" &&
-      result.visualization.visualizationDataUri.startsWith("data:image/png;base64,"),
-      "visualizationDataUri must be a PNG data URI",
+    assert.equal(
+      result.visualization.visualizationDataUri,
+      null,
+      "visualizationDataUri must be null -- the bytes are on disk, not inlined",
+    );
+    assert.equal(
+      typeof result.visualization.visualizationPath,
+      "string",
+      "visualizationPath must be a string path",
+    );
+    assert.ok(existsSync(result.visualization.visualizationPath), "the PNG file must actually exist");
+    const pngBytes = readFileSync(result.visualization.visualizationPath);
+    assert.ok(pngBytes.length > 0, "the PNG file must not be empty");
+    // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+    assert.deepEqual(
+      [...pngBytes.subarray(0, 8)],
+      [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+      "the file must be a valid PNG (correct signature bytes)",
     );
   } finally {
     await harness.close();

--- a/tests/personas/allocator/allocator-per-pool-denial.test.js
+++ b/tests/personas/allocator/allocator-per-pool-denial.test.js
@@ -54,6 +54,9 @@ test("allocator denies one token below a warden pool boundary while total budget
     assert.match(result.stderr, /Budget receipt denied: status=denied; remaining=188/);
     assert.match(result.stderr, /deniedLines=actor:actor_spawn:wardens/);
     assert.match(result.stderr, /deniedPools=wardens:186\/176/);
+    // #145 — the shortfall (how many more tokens this one pool alone needed) used to be
+    // uncomputable from the denial message; 186 spent against a 176 cap is short by 10.
+    assert.match(result.stderr, /deniedPools=wardens:186\/176 \(short 10\)/);
   } finally {
     rmSync(outDir, { recursive: true, force: true });
   }

--- a/tests/runtime/visualization-state-detail.test.js
+++ b/tests/runtime/visualization-state-detail.test.js
@@ -157,6 +157,46 @@ test("ascii detail renderer marks resource position in resources layer", async (
   assert.notEqual(resourceRow[4], " ", "resources layer must mark resource position at x=4");
 });
 
+// #153 regression: a real ak_create sim-config never populates the top-level simConfig.hazards/
+// .resources -- the actual data lives at simConfig.layout.data.hazards/.resources. The shared
+// SIM_CONFIG fixture above puts hazards/resources at the top level, which is NOT how ak_create
+// actually shapes them, so it never exercised this bug. This fixture reproduces the real shape
+// (hazards/resources nested under layout.data, absent at the top level) instead.
+const NESTED_ONLY_SIM_CONFIG = {
+  schema: "agent-kernel/SimConfigArtifact",
+  schemaVersion: 1,
+  meta: { id: "sc-nested", runId: "run_viz_nested", createdAt: "2026-01-01T00:00:00.000Z", producedBy: "fixture" },
+  layout: {
+    kind: "grid",
+    width: 7,
+    height: 3,
+    data: {
+      width: 7,
+      height: 3,
+      tiles: ["#######", "#.....#", "#######"],
+      legend: { "#": { tile: "wall" }, ".": { tile: "floor" } },
+      hazards: [{ id: "hazard_1", x: 2, y: 1, affinity: { kind: "fire", expression: "emit", stacks: 3 }, blocking: false }],
+      resources: [{ id: "resource_1", x: 4, y: 1, permanenceMode: "consumable", affinity: { kind: "water", expression: "draw", stacks: 1, mana: 5 } }],
+    },
+  },
+};
+
+test("ascii hazards/resources layers populate from simConfig.layout.data, not just top-level fields (#153)", async () => {
+  const { createVisualizationSnapshot } = await loadVisualizationModule();
+  const snap = await createVisualizationSnapshot({
+    mode: "ascii",
+    tick: 1,
+    runId: "run_viz_nested",
+    simConfig: NESTED_ONLY_SIM_CONFIG,
+    initialState: INITIAL_STATE,
+    frames: [TICK_FRAME],
+  });
+  const hazardRow = snap.layers.hazards.split("\n")[1];
+  assert.notEqual(hazardRow[2], " ", "hazards layer must mark hazard position at x=2 even when hazards live only under layout.data");
+  const resourceRow = snap.layers.resources.split("\n")[1];
+  assert.notEqual(resourceRow[4], " ", "resources layer must mark resource position at x=4 even when resources live only under layout.data");
+});
+
 test("ascii detail renderer marks delver position in delvers layer", async () => {
   const { createVisualizationSnapshot } = await loadVisualizationModule();
   const snap = await createVisualizationSnapshot({

--- a/tests/runtime/visualization-state-detail.test.js
+++ b/tests/runtime/visualization-state-detail.test.js
@@ -100,7 +100,7 @@ test("createVisualizationSnapshot in ascii mode returns a valid snapshot object"
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   assert.equal(snap.schema, "agent-kernel/VisualizationSnapshot");
   assert.equal(snap.schemaVersion, 1);
@@ -119,7 +119,7 @@ test("ascii detail renderer includes layout layer matching sim-config grid", asy
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   const rows = snap.layers.layout.split("\n");
   assert.equal(rows.length, SIM_CONFIG.layout.data.height, "layout row count must match map height");
@@ -135,7 +135,7 @@ test("ascii detail renderer marks hazard position in hazards layer", async () =>
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   // hazard at x=2, y=1 in a 7-wide grid; hazard row is row index 1 (y=1)
   const hazardRow = snap.layers.hazards.split("\n")[1];
@@ -150,7 +150,7 @@ test("ascii detail renderer marks resource position in resources layer", async (
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   // resource at x=4, y=1
   const resourceRow = snap.layers.resources.split("\n")[1];
@@ -165,7 +165,7 @@ test("ascii detail renderer marks delver position in delvers layer", async () =>
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   // delver starts at x=1,y=1; after move action ends at x=2,y=1
   const delverRow = snap.layers.delvers.split("\n")[1];
@@ -181,7 +181,7 @@ test("ascii detail renderer marks warden position in wardens layer", async () =>
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   // warden at x=5, y=1
   const wardenRow = snap.layers.wardens.split("\n")[1];
@@ -196,7 +196,7 @@ test("actorDetails includes affinities, vitals, and motivation for each actor", 
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   assert.ok(Array.isArray(snap.actorDetails) && snap.actorDetails.length === 2,
     "actorDetails must contain all actors");
@@ -218,7 +218,7 @@ test("createVisualizationSnapshot at tick 0 returns ascii with initial positions
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: null,
+    frames: null,
   });
   assert.equal(snap.tick, 0);
   assert.equal(snap.mode, "ascii");
@@ -233,7 +233,7 @@ test("createVisualizationSnapshot with no hazards produces empty hazards layer",
     runId: "run_viz",
     simConfig: { ...SIM_CONFIG, hazards: [] },
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   assert.doesNotMatch(snap.layers.hazards, /H/);
   assert.equal(snap.layers.hazards.replace(/\n/g, "").trim(), "");
@@ -247,13 +247,13 @@ test("createVisualizationSnapshot with no resources produces empty resources lay
     runId: "run_viz",
     simConfig: { ...SIM_CONFIG, resources: [] },
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   assert.doesNotMatch(snap.layers.resources, /R/);
   assert.equal(snap.layers.resources.replace(/\n/g, "").trim(), "");
 });
 
-test("createVisualizationSnapshot with null tickFrame at tick greater than zero uses initial positions", async () => {
+test("createVisualizationSnapshot with no frame history at tick greater than zero uses initial positions", async () => {
   const { createVisualizationSnapshot } = await loadVisualizationModule();
   const snap = await createVisualizationSnapshot({
     mode: "ascii",
@@ -261,11 +261,69 @@ test("createVisualizationSnapshot with null tickFrame at tick greater than zero 
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: null,
+    frames: null,
   });
   const delverRow = snap.layers.delvers.split("\n")[1];
   assert.notEqual(delverRow[1], " ", "delver should remain at initial x=1");
-  assert.equal(delverRow[2], " ", "delver should not use tick-frame x=2 without a tickFrame");
+  assert.equal(delverRow[2], " ", "delver should not use tick-frame x=2 without any frame history");
+});
+
+// #147 regression: computeActorPositions() used to take a single tickFrame and overlay only that
+// one frame's acceptedActions. In real runs the frame callers actually had (readTickFrame's "last
+// phase-frame for this tick", i.e. `summarize`) always carries acceptedActions: [] by construction
+// -- the accepted moves live on that tick's earlier `apply` phase-frame -- so the overlay never
+// applied and every actor rendered frozen at spawn for the whole run. This fixture reproduces that
+// exact real shape (apply frame WITH the move, summarize frame WITHOUT it) rather than the
+// simplified single-frame TICK_FRAME fixture above, which never exercised the bug.
+function applyAndSummarizeFrames(tick, moves) {
+  return [
+    {
+      schema: "agent-kernel/TickFrame",
+      schemaVersion: 1,
+      meta: { id: `tf${tick}a`, runId: "run_viz", createdAt: "2026-01-01T00:00:00.000Z", producedBy: "fixture" },
+      tick,
+      phase: "execute",
+      phaseDetail: "apply",
+      acceptedActions: moves,
+    },
+    {
+      schema: "agent-kernel/TickFrame",
+      schemaVersion: 1,
+      meta: { id: `tf${tick}s`, runId: "run_viz", createdAt: "2026-01-01T00:00:00.000Z", producedBy: "fixture" },
+      tick,
+      phase: "execute",
+      phaseDetail: "summarize",
+      acceptedActions: [],
+    },
+  ];
+}
+
+function moveAction(actorId, tick, to) {
+  return { schema: "agent-kernel/Action", schemaVersion: 1, actorId, tick, kind: "move", params: { to } };
+}
+
+test("createVisualizationSnapshot accumulates moves across apply-phase frames from multiple ticks (regression #147)", async () => {
+  const { createVisualizationSnapshot } = await loadVisualizationModule();
+  const frames = [
+    ...applyAndSummarizeFrames(1, [moveAction("actor_delver_1", 1, { x: 2, y: 1 })]),
+    ...applyAndSummarizeFrames(2, [moveAction("actor_delver_1", 2, { x: 3, y: 1 })]),
+  ];
+
+  // Requesting tick 1: only tick 1's apply-phase move has happened yet.
+  const tick1 = await createVisualizationSnapshot({
+    mode: "ascii", tick: 1, runId: "run_viz", simConfig: SIM_CONFIG, initialState: INITIAL_STATE, frames,
+  });
+  assert.equal(tick1.actorDetails.find((a) => a.id === "actor_delver_1").position.x, 2);
+
+  // Requesting tick 2: tick 2's own apply-phase move has also happened, cumulatively.
+  const tick2 = await createVisualizationSnapshot({
+    mode: "ascii", tick: 2, runId: "run_viz", simConfig: SIM_CONFIG, initialState: INITIAL_STATE, frames,
+  });
+  assert.equal(
+    tick2.actorDetails.find((a) => a.id === "actor_delver_1").position.x,
+    3,
+    "position must reflect BOTH ticks' accepted moves, not just the single (always-empty) summarize frame",
+  );
 });
 
 test("createVisualizationSnapshot in image mode returns visualizationDataUri field and no layers", async () => {
@@ -276,7 +334,7 @@ test("createVisualizationSnapshot in image mode returns visualizationDataUri fie
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   assert.equal(snap.mode, "image");
   assert.ok(Object.prototype.hasOwnProperty.call(snap, "visualizationDataUri"));
@@ -291,7 +349,7 @@ test("actorDetails for stationary warden reflects motivation", async () => {
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   const warden = snap.actorDetails.find((actor) => actor.id === "actor_warden_1");
   assert.ok(warden, "warden actor detail must exist");
@@ -307,7 +365,7 @@ test("actorDetails affinities preserve stacks and expression fields", async () =
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   const delver = snap.actorDetails.find((actor) => actor.id === "actor_delver_1");
   assert.deepEqual(delver.affinities[0], { name: "fire", stacks: 2, expression: "emit" });
@@ -327,7 +385,7 @@ test("actorDetails vitals include stamina and mana when present", async () => {
     runId: "run_viz",
     simConfig: SIM_CONFIG,
     initialState,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   const delver = snap.actorDetails.find((actor) => actor.id === "actor_delver_1");
   assert.ok(delver.vitals.stamina, "stamina vital must be present");
@@ -343,7 +401,7 @@ test("createVisualizationSnapshot tolerates missing hazards and resources fields
     runId: "run_viz",
     simConfig,
     initialState: INITIAL_STATE,
-    tickFrame: TICK_FRAME,
+    frames: [TICK_FRAME],
   });
   assert.equal(snap.mode, "ascii");
   assert.equal(snap.layers.hazards.replace(/\n/g, "").trim(), "");


### PR DESCRIPTION
## Summary

Session goal: drive `agent-kernel` end-to-end through the `agent-kernel-cli` MCP server, get results
rendering in the driving harness, and log/fix friction along the way. Full narrative, repro steps,
root causes, and verification for every finding are in [`mcp-harness-run-through.md`](mcp-harness-run-through.md)
— this description is the short form.

- **Friction log** (findings 1-7): drove the app via MCP tools (`ak_create`/`ak_run`/`ak_show_state`/
  `ak_tick_forward`/`ak_push_to_ui`), captured every defect hit as a standalone `gh issue`, and
  root-caused one (#146→#147) with Serena rather than guessing from outside.
- **Configuration-permutation sweep**: a bounded, one-axis-at-a-time matrix (50 scenarios across 7
  axes — delver/hazard affinity, motivation, hazard/warden position, resource authoring, multi-hazard
  stress) automating the same kind of poking, promoted into the repo as
  `scripts/testing/run-configuration-permutation-sweep.mjs` (`pnpm run config-sweep[:dry-run]`). Grew
  step-level (per-tick) assertions and a determinism/reproducibility check on top of the original
  whole-run classification, which is what actually found #148 and #149.
- **All 7 issues found (#142-#145, #147-#149) are fixed, verified, and closed** — each against its
  original repro plus a full `pnpm run test` + `pnpm run typecheck` pass. Two new issues found *while*
  fixing the others are deliberately left open, out of scope for the fixes that found them: #150
  (same wall-clock-meta bug, two unconfirmed sites) and #151 (MCP README's Tool Index is stale).

## What changed, by issue

- **#142** — `ak_push_to_ui`'s WS bridge unreachable from a sandboxed harness: no code fix exists
  (environment constraint); tool description now states it and points to the working alternative.
- **#143** — `ak_show_state`/`ak_tick_forward`/`ak_tick_backward` couldn't find MCP-remembered runs:
  `resolveRunDir()` now accepts an override, supplied by `server.mjs`'s dispatch layer.
- **#144** — image-mode visualization blew the MCP tool-result token limit (443,790 chars): now
  written to disk, `visualizationPath` returned instead (1,716 chars).
- **#145** — budget denial didn't say the shortfall: `deniedPools` now reports `(short N)` per pool.
- **#147** — `ak_tick_forward`/`ak_show_state` rendered every actor frozen at spawn: fixed by
  replaying every accepted move cumulatively instead of one always-empty frame (found and fixed the
  same bug independently in the CLI's `ak tick` command too).
- **#148** — level-gen error formatter baked literal `"undefined"` into 4 of 5 error codes: replaced
  with a per-code formatter lookup.
- **#149** — `ak run`'s `action-log.json`/`run-summary.json`/`world-state.json` used wall-clock meta
  stamps, breaking reproducibility the simulation itself already had: routed through the run's seeded
  clock instead.

## Test plan

- [x] `pnpm run test` — 3546 passed, 0 failed, no new failures vs. the pre-session baseline
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run config-sweep` / `pnpm run config-sweep:dry-run` — 49/50 create+run pass (the one
      failure is a deliberate regression probe for the exact bug #148 fixed), 49/49 step-level clean,
      49/49 reproducible
- [x] Every fix verified individually against its exact original repro (see `mcp-harness-run-through.md`'s
      per-finding "Fix" notes for each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)