### PR TITLE
feat: patrolling patrols, and reaching the exit means leaving the level

### DIFF
--- a/packages/core-ts/src/index.ts
+++ b/packages/core-ts/src/index.ts
@@ -182,6 +182,7 @@ export const CORE_API_KEYS = [
   "getMotivatedActorAffinityStacksByIndex",
   "getMotivatedActorAffinityStacksForKind",
   "getMotivatedActorCount",
+  "getMotivatedActorExitDwellByIndex",
   "getMotivatedActorIdByIndex",
   "getMotivatedActorMovementCostByIndex",
   "getMotivatedActorVitalCurrentByIndex",
@@ -231,6 +232,7 @@ export const CORE_API_KEYS = [
   "grantMotivatedActorAffinity",
   "hasResourceAt",
   "init",
+  "isMotivatedActorExitedByIndex",
   "loadMvpBarrierScenario",
   "loadMvpScenario",
   "loadTilesFromBuffer",
@@ -549,6 +551,8 @@ export function createCore(): Record<(typeof CORE_API_KEYS)[number], CoreExport>
   core.loadTilesFromBuffer = world.loadTilesFromBuffer as CoreFunction;
   core.setTileAt = world.setTileAt as CoreFunction;
   core.setSpawnPosition = world.setSpawnPosition as CoreFunction;
+  core.getMotivatedActorExitDwellByIndex = world.getMotivatedActorExitDwellByIndex as CoreFunction;
+  core.isMotivatedActorExitedByIndex = world.isMotivatedActorExitedByIndex as CoreFunction;
   core.spawnActorAt = world.spawnActorAt as CoreFunction;
   core.loadMvpScenario = world.loadMvpScenario.bind(world) as CoreFunction;
   core.loadMvpBarrierScenario = world.loadMvpBarrierScenario.bind(world) as CoreFunction;

--- a/packages/core-ts/src/state/world.ts
+++ b/packages/core-ts/src/state/world.ts
@@ -15,6 +15,14 @@ import { VitalKind } from "./vitals.ts";
 
 // ── Tile codes ──
 
+/**
+ * Ticks an actor must END on the exit tile before it has left the level.
+ *
+ * Two, by maintainer ruling (2026-09-05). One would retire an actor that merely passes
+ * across the exit on its way somewhere else, which is a different event.
+ */
+export const EXIT_DWELL_TICKS = 2;
+
 export const Tile = {
   Wall: 0,
   Floor: 1,
@@ -146,6 +154,10 @@ export function createWorldState() {
   let motivatedActorVitalCurrent = new Int32Array(0);
   let motivatedActorVitalMax = new Int32Array(0);
   let motivatedActorVitalRegen = new Int32Array(0);
+  // Leaving the level (maintainer ruling, 2026-09-05). Consecutive ticks ENDED on the
+  // exit tile, and the resulting flag. Two ticks means the actor has left.
+  let motivatedActorExitDwellArr = new Int32Array(0);
+  let motivatedActorExitedArr = new Int32Array(0);
   let motivatedActorMovementCostArr = new Int32Array(0);
   let motivatedActorActionCostManaArr = new Int32Array(0);
   let motivatedActorActionCostStaminaArr = new Int32Array(0);
@@ -230,6 +242,8 @@ export function createWorldState() {
     motivatedActorVitalCurrent = new Int32Array(maxMotivatedActors * VITAL_COUNT);
     motivatedActorVitalMax = new Int32Array(maxMotivatedActors * VITAL_COUNT);
     motivatedActorVitalRegen = new Int32Array(maxMotivatedActors * VITAL_COUNT);
+    motivatedActorExitDwellArr = new Int32Array(maxMotivatedActors);
+    motivatedActorExitedArr = new Int32Array(maxMotivatedActors);
     motivatedActorMovementCostArr = new Int32Array(maxMotivatedActors);
     motivatedActorActionCostManaArr = new Int32Array(maxMotivatedActors);
     motivatedActorActionCostStaminaArr = new Int32Array(maxMotivatedActors);
@@ -386,6 +400,9 @@ export function createWorldState() {
     clearMotivatedOccupancy();
     if (motivatedActorCount > 0) {
       for (let i = 0; i < motivatedActorCount; i++) {
+        // An actor that has left the level occupies nothing. Re-seeding its body here
+        // would silently undo the vacate in `applyExitDwell` on the next rebuild.
+        if (motivatedActorExitedArr[i] !== 0) continue;
         const mx = motivatedActorXArr[i];
         const my = motivatedActorYArr[i];
         setMotivatedOccupancyAt(mx, my, i + 1);
@@ -489,6 +506,8 @@ export function createWorldState() {
     resetActorVitals();
     resetActorCapabilities();
     clearActorAffinities();
+    motivatedActorExitDwellArr.fill(0);
+    motivatedActorExitedArr.fill(0);
   }
 
   function syncActorMirrorFromMotivatedIndex(index: number): void {
@@ -763,6 +782,38 @@ export function createWorldState() {
       const current = motivatedActorGrantManaArr[offset];
       if (current < max) {
         motivatedActorGrantManaArr[offset] = Math.min(max, current + regen);
+      }
+    }
+  }
+
+  /**
+   * Advance the exit-dwell counter, and retire any actor that has now left.
+   *
+   * CONSECUTIVE ticks, which is why the else-branch resets rather than decays: without
+   * it an actor could bank a stray tick on the exit early in a run and leave much later
+   * from somewhere else entirely.
+   *
+   * Counted at END of tick, so an actor that steps onto the exit during tick N has dwelt
+   * ONE tick when N closes, and leaves when N+1 closes. That is what "two ticks" means
+   * here, and the arithmetic is pinned by `tests/core-ts/exit-dwell.test.mts`.
+   *
+   * ⚠️ EXITING MUST VACATE THE CELL. The flag alone would leave the actor's body sitting
+   * on the one tile every other actor paths toward — which is the defect this rule exists
+   * to end (#169: 579 ActorCollision rejections in a 100-tick run, three actors that never
+   * moved). Releasing occupancy is the observable half; a test asserts it directly.
+   */
+  function applyExitDwell(): void {
+    if (exitX < 0 || exitY < 0) return;
+    for (let i = 0; i < motivatedActorCount; i++) {
+      if (motivatedActorExitedArr[i] !== 0) continue;
+      if (motivatedActorXArr[i] === exitX && motivatedActorYArr[i] === exitY) {
+        motivatedActorExitDwellArr[i] += 1;
+        if (motivatedActorExitDwellArr[i] >= EXIT_DWELL_TICKS) {
+          motivatedActorExitedArr[i] = 1;
+          setMotivatedOccupancyAt(exitX, exitY, 0);
+        }
+      } else {
+        motivatedActorExitDwellArr[i] = 0;
       }
     }
   }
@@ -1269,6 +1320,14 @@ export function createWorldState() {
       return motivatedActorVitalRegen[vitalIndexFor(index, kind)];
     },
 
+    getMotivatedActorExitDwellByIndex(index: number): number {
+      return isValidMotivatedActorIndex(index) ? motivatedActorExitDwellArr[index] : 0;
+    },
+
+    isMotivatedActorExitedByIndex(index: number): boolean {
+      return isValidMotivatedActorIndex(index) && motivatedActorExitedArr[index] !== 0;
+    },
+
     getMotivatedActorMovementCostByIndex(index: number): number {
       return isValidMotivatedActorIndex(index) ? motivatedActorMovementCostArr[index] : 0;
     },
@@ -1295,6 +1354,7 @@ export function createWorldState() {
 
     advanceTick(): void {
       applyTickRegen();
+      applyExitDwell();
       currentTick++;
     },
 

--- a/packages/runtime/src/personas/actor/controller.js
+++ b/packages/runtime/src/personas/actor/controller.js
@@ -1413,6 +1413,107 @@ function buildMoveProposal({ observation, payload, simConfig }) {
   ];
 }
 
+/**
+ * PATROLLING: a clockwise circuit of the actor's own room.
+ *
+ * Before this, `patrolling` had no branch at all. Core's profile table gives it mobility
+ * 2 — the highest tier — and combat 0, so it cleared the holds-position guard, matched no
+ * combat branch, and fell through to `buildMoveProposal`: shortest path to the level
+ * exit. Every patrolling actor walked to the one exit tile alongside everybody else. In a
+ * measured 100-tick run that produced 579 `ActorCollision` rejections and three wardens
+ * that never moved (#169). The motivation named for patrolling left the fastest.
+ *
+ * ⚠️ STATELESS BY REQUIREMENT, NOT BY PREFERENCE. The next cell is a pure function of the
+ * current cell and the room rectangle. Persona context must stay serializable and the
+ * Actor carries nothing between ticks, so a patrol that remembered its next waypoint
+ * would need the runner to thread that state — the problem #162 is still open on. A
+ * circuit needs no memory because the ring itself encodes the order.
+ */
+function roomPerimeterRing(room, tileKinds, baseTiles) {
+  const x0 = room.x;
+  const y0 = room.y;
+  const x1 = room.x + room.width - 1;
+  const y1 = room.y + room.height - 1;
+  if (x1 <= x0 || y1 <= y0) return [];
+  const ring = [];
+  for (let x = x0; x <= x1; x += 1) ring.push({ x, y: y0 });
+  for (let y = y0 + 1; y <= y1; y += 1) ring.push({ x: x1, y });
+  for (let x = x1 - 1; x >= x0; x -= 1) ring.push({ x, y: y1 });
+  for (let y = y1 - 1; y >= y0 + 1; y -= 1) ring.push({ x: x0, y });
+  // A room may be carved so part of its rectangle is wall. Patrolling the walkable
+  // subset keeps the circuit legal rather than proposing moves core will refuse.
+  return ring.filter((cell) => isPassable(cell, tileKinds, baseTiles));
+}
+
+function roomContaining(position, rooms) {
+  if (!Array.isArray(rooms) || !position) return null;
+  for (const room of rooms) {
+    if (!isObject(room)) continue;
+    const { x, y, width, height } = room;
+    if (![x, y, width, height].every((v) => Number.isInteger(v))) continue;
+    if (position.x >= x && position.x <= x + width - 1
+      && position.y >= y && position.y <= y + height - 1) {
+      return room;
+    }
+  }
+  return null;
+}
+
+function resolveRooms(payload, view, simConfig) {
+  const fromConfig = simConfig?.layout?.data?.rooms;
+  if (Array.isArray(fromConfig)) return fromConfig;
+  const fromPayload = payload?.simConfig?.layout?.data?.rooms;
+  if (Array.isArray(fromPayload)) return fromPayload;
+  const fromView = view?.rooms;
+  return Array.isArray(fromView) ? fromView : [];
+}
+
+function buildPatrolProposals({ observation, payload, simConfig }) {
+  const view = resolveObservationView(observation);
+  if (!view) return [];
+  const actor = resolveActor(view, payload?.actorId, observation);
+  if (!actor?.position) return [];
+  const baseTiles = resolveBaseTiles(payload, view, simConfig);
+  const tileKinds = resolveTileKinds(view, payload);
+  const rooms = resolveRooms(payload, view, simConfig);
+  const room = roomContaining(actor.position, rooms);
+  if (!room) return [];
+  const ring = roomPerimeterRing(room, tileKinds, baseTiles);
+  if (ring.length < 2) return [];
+
+  const at = ring.findIndex((cell) => cell.x === actor.position.x && cell.y === actor.position.y);
+  // On the ring: take the next cell round. Inside the room: walk out to the nearest ring
+  // cell first, so an actor that spawned in the middle joins the patrol instead of
+  // standing still — which would look exactly like the defect this replaces.
+  const target = at >= 0 ? ring[(at + 1) % ring.length] : nearestRingCell(actor.position, ring);
+  if (!target) return [];
+
+  const path = findPath(actor.position, target, tileKinds, baseTiles);
+  if (!path || path.length < 2) return [];
+  const from = path[0];
+  const to = path[1];
+  const direction = DEFAULT_DELTAS.find(
+    (entry) => entry.dx === to.x - from.x && entry.dy === to.y - from.y,
+  )?.direction;
+  if (!direction) return [];
+  return [{ kind: "move", params: { direction, from, to } }];
+}
+
+function nearestRingCell(position, ring) {
+  let best = null;
+  let bestDistance = Infinity;
+  for (const cell of ring) {
+    const distance = chebyshevDistance(position, cell);
+    // Ties break on the ring's own order, which is deterministic — replay compares runs
+    // frame by frame, so "whichever came first" must mean the same thing every run.
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = cell;
+    }
+  }
+  return best;
+}
+
 // ── M5: Simple motivation helpers ──────────────────────────────────────────
 
 const DEFAULT_ATTACK_DAMAGE = 2; // M1 contract: fixed deterministic damage
@@ -1730,6 +1831,15 @@ function buildMotivatedProposals({ observation, payload, simConfig, personaSeed 
   // Random: seed-derived deterministic movement to a legal adjacent tile
   if (motivationKind === "random") {
     return buildRandomMoveProposals({ observation, payload, simConfig, personaSeed });
+  }
+
+  // Patrolling: circuit its own room. Placed before the hostile branch for readability
+  // only — `patrolling` has combat tier 0, so every branch inside `if (hostile)` is
+  // already unreachable for it. Falls through when the actor is in no declared room,
+  // which keeps a room-less layout behaving as it did rather than freezing the actor.
+  if (motivationKind === "patrolling") {
+    const patrol = buildPatrolProposals({ observation, payload, simConfig });
+    if (patrol.length > 0) return patrol;
   }
 
   const hostile = resolveNearestHostile(view, actorId);

--- a/packages/runtime/src/personas/annotator/world-state.js
+++ b/packages/runtime/src/personas/annotator/world-state.js
@@ -191,6 +191,10 @@ export function buildWorldState({ core, meta, simConfigRef = null, actorIdMap = 
       },
       vitals: readActorVitals(core, index),
       affinities: readActorAffinities(core, index),
+      // Has this actor LEFT the level? Reported rather than filtered: the run is a
+      // record of what happened, and silently dropping an actor from world state would
+      // make an exit indistinguishable from an actor that was never there.
+      exited: core.isMotivatedActorExitedByIndex?.(index) === true,
     });
   }
 

--- a/packages/runtime/src/runner/runtime-fsm.mjs
+++ b/packages/runtime/src/runner/runtime-fsm.mjs
@@ -1690,9 +1690,18 @@ export function createFsmRuntime({
       // alphabetically-sorted numeric-index order used for core observation
       // labeling above. Every tracked actor must get a chance to propose an
       // action each tick — see tests/runtime/multi-actor-orchestration.test.js.
+      // An actor that has LEFT THE LEVEL is not asked to decide (maintainer ruling,
+      // 2026-09-05). Core owns the rule — two ticks ended on the exit tile — and the
+      // runner only reads the verdict; recomputing "has it exited?" here would be a
+      // second authority on a core state transition.
+      const hasExited = (id) => {
+        if (typeof core.isMotivatedActorExitedByIndex !== "function") return false;
+        const oneBased = actorIdMap.get(id);
+        return Number.isInteger(oneBased) && core.isMotivatedActorExitedByIndex(oneBased - 1) === true;
+      };
       const decideActorIds = Array.isArray(initialState?.actors)
-        ? initialState.actors.map((a) => a?.id).filter((id) => id && actorIdMap.has(id))
-        : sortedActorIds;
+        ? initialState.actors.map((a) => a?.id).filter((id) => id && actorIdMap.has(id) && !hasExited(id))
+        : sortedActorIds.filter((id) => !hasExited(id));
       const observation = resolveObservation(core, primaryActorId, baseTiles, affinityEffects, layoutHazards, sortedActorIds, initialState);
       const observePersonaPayloads = buildPersonaPayloads({
         phase: TickPhases.OBSERVE,

--- a/tests/core-ts/exit-dwell.test.mts
+++ b/tests/core-ts/exit-dwell.test.mts
@@ -1,0 +1,182 @@
+/**
+ * Leaving the level: an actor that sits on the exit tile has EXITED.
+ *
+ * Maintainer ruling (2026-09-05): two ticks or more on the exit tile means the actor
+ * has left, and it stops being part of the actor inventory.
+ *
+ * WHY THIS IS CORE'S RULE AND NOT THE RUNTIME'S. It is a deterministic state transition
+ * over bounded inputs — a position, a counter, a threshold — which is exactly what core
+ * owns. The runtime deliberately holds no per-actor state across ticks (persona context
+ * must stay serializable), so a counter kept there would be domain logic in glue and
+ * would not survive replay.
+ *
+ * THE DEFECT THIS CLOSES (#169). Before it, an actor that reached the exit stood on it
+ * forever: `buildMoveProposal` returns [] when the path length is 1, so it proposed
+ * nothing again while its body kept occupying the one tile every other actor was pathing
+ * toward. A measured 100-tick run produced 579 `ActorCollision` rejections and three
+ * actors that never moved at all. Vacating the exit is not cosmetic — it is what unblocks
+ * everyone behind it, so a test drives that through the real move rule rather than
+ * inspecting an occupancy flag.
+ *
+ * Driven entirely through the PUBLIC core surface (`CORE_API_KEYS` + the exported move
+ * helpers). An earlier draft reached for `resizeGrid` / `setActorPosition` /
+ * `isMotivatedOccupied`, none of which core exposes — the narrow surface is deliberate,
+ * and a test that needs internals is testing something the runtime cannot reach either.
+ */
+import { describe, expect, test } from "vitest";
+
+import { applyMoveAction, createCore, packMoveAction, ValidationError } from "../../packages/core-ts/src/index.ts";
+import { VitalKind } from "../../packages/core-ts/src/state/vitals.ts";
+
+type Core = ReturnType<typeof createCore>;
+
+const FLOOR = 1;
+const EXIT = 3;
+const EXIT_AT = { x: 3, y: 1 };
+
+function call(fn: unknown, ...args: unknown[]): unknown {
+  if (typeof fn !== "function") throw new Error("expected callable core export");
+  return fn(...args);
+}
+
+/** Floors across the usable area, with the exit at (3,1). */
+function makeWorld(withExit = true): Core {
+  const core = createCore();
+  // `configureGrid` is what sizes the world AND allocates actor capacity. Without it a
+  // fresh core is 0x0 with room for zero actors, and `addActorPlacement` silently
+  // overflows — placement then reports success while seating nobody.
+  call(core.configureGrid, 6, 3);
+  for (let y = 0; y < 3; y++) {
+    for (let x = 0; x < 6; x++) call(core.setTileAt, x, y, FLOOR);
+  }
+  if (withExit) call(core.setTileAt, EXIT_AT.x, EXIT_AT.y, EXIT);
+  return core;
+}
+
+/**
+ * `true` seats on reserved tiles — the exit is one, so placement needs it.
+ *
+ * Stamina is granted deliberately: core refuses a move with `InsufficientStamina`
+ * without it, and the two tests that drive real moves would otherwise be asserting a
+ * vitals failure while claiming to measure occupancy.
+ */
+function seat(core: Core, actors: Array<[id: number, x: number, y: number]>): void {
+  call(core.clearActorPlacements);
+  for (const [id, x, y] of actors) call(core.addActorPlacement, id, x, y);
+  call(core.applyActorPlacements, true);
+  for (const [id] of actors) {
+    // ⚠️ BY ACTOR ID, NOT INDEX — and it RETURNS an error rather than throwing. Passing
+    // an index selects the actor whose id happens to equal it, or silently selects
+    // nobody, and `setActorVital` then writes to whoever was already active. That is how
+    // a first draft of this file gave actor 0 stamina twice and actor 1 none, and read
+    // back as a mysterious `InsufficientStamina` three calls later.
+    expect(call(core.setActiveMotivatedActor, id)).toBe(ValidationError.None);
+    call(core.setActorVital, VitalKind.Stamina, 8, 8, 8);
+  }
+}
+
+function activate(core: Core, actorId: number): void {
+  expect(call(core.setActiveMotivatedActor, actorId)).toBe(ValidationError.None);
+}
+
+/** Core accepts a move stamped for the tick it is ABOUT to apply, i.e. currentTick + 1. */
+const nextTick = (core: Core): number => Number(call(core.getCurrentTick)) + 1;
+
+const exited = (core: Core, i: number): boolean => call(core.isMotivatedActorExitedByIndex, i) === true;
+const dwell = (core: Core, i: number): number => Number(call(core.getMotivatedActorExitDwellByIndex, i));
+
+describe("core-ts exit dwell", () => {
+  test("an actor standing on the exit for two ticks has exited", () => {
+    const core = makeWorld();
+    seat(core, [[1, EXIT_AT.x, EXIT_AT.y]]);
+    expect(dwell(core, 0)).toBe(0);
+    expect(exited(core, 0)).toBe(false);
+
+    // Tick 1 ENDS with the actor on the exit: one tick there, not two.
+    call(core.advanceTick);
+    expect(dwell(core, 0)).toBe(1);
+    expect(exited(core, 0)).toBe(false);
+
+    // Tick 2 ends with it still there. Two ticks — it has left the level.
+    call(core.advanceTick);
+    expect(dwell(core, 0)).toBe(2);
+    expect(exited(core, 0)).toBe(true);
+  });
+
+  test("stepping off the exit before the second tick resets the dwell", () => {
+    // CONSECUTIVE ticks. Without the reset an actor could bank a stray tick on the exit
+    // early in a run and then leave from somewhere else entirely much later.
+    const core = makeWorld();
+    seat(core, [[1, EXIT_AT.x, EXIT_AT.y]]);
+    call(core.advanceTick);
+    expect(dwell(core, 0)).toBe(1);
+
+    activate(core, 1);
+    const off = applyMoveAction(core, packMoveAction({
+      actorId: 1, from: EXIT_AT, to: { x: 2, y: 1 }, direction: "west", tick: nextTick(core),
+    }));
+    expect(off).toBe(ValidationError.None);
+
+    call(core.advanceTick);
+    expect(dwell(core, 0)).toBe(0);
+    expect(exited(core, 0)).toBe(false);
+  });
+
+  test("an exited actor releases the exit tile so another actor can take it", () => {
+    // THE ASSERTION THAT WOULD HAVE CAUGHT #169, and the reason it goes through the real
+    // move rule: a rule that flagged the actor without vacating the cell would satisfy
+    // every other test here and change nothing whatsoever in a real run.
+    const core = makeWorld();
+    seat(core, [[1, EXIT_AT.x, EXIT_AT.y], [2, 2, 1]]);
+
+    activate(core, 2);
+    const blocked = applyMoveAction(core, packMoveAction({
+      actorId: 2, from: { x: 2, y: 1 }, to: EXIT_AT, direction: "east", tick: nextTick(core),
+    }));
+    expect(blocked).toBe(ValidationError.ActorCollision);
+
+    call(core.advanceTick);
+    call(core.advanceTick);
+    expect(exited(core, 0)).toBe(true);
+
+    activate(core, 2);
+    const allowed = applyMoveAction(core, packMoveAction({
+      actorId: 2, from: { x: 2, y: 1 }, to: EXIT_AT, direction: "east", tick: nextTick(core),
+    }));
+    expect(allowed).toBe(ValidationError.None);
+  });
+
+  test("an exited actor stays exited and stops accumulating dwell", () => {
+    const core = makeWorld();
+    seat(core, [[1, EXIT_AT.x, EXIT_AT.y]]);
+    call(core.advanceTick);
+    call(core.advanceTick);
+    expect(exited(core, 0)).toBe(true);
+    const settled = dwell(core, 0);
+
+    call(core.advanceTick);
+    call(core.advanceTick);
+    expect(exited(core, 0)).toBe(true);
+    expect(dwell(core, 0)).toBe(settled);
+  });
+
+  test("an actor that never reaches the exit never exits", () => {
+    // Anti-vacuity: a rule that simply retired everyone on tick 2 would pass the rest.
+    const core = makeWorld();
+    seat(core, [[1, 1, 1]]);
+    for (let i = 0; i < 10; i++) call(core.advanceTick);
+    expect(exited(core, 0)).toBe(false);
+    expect(dwell(core, 0)).toBe(0);
+  });
+
+  test("a world with no exit tile never exits anyone", () => {
+    const core = makeWorld(false);
+    seat(core, [[1, 1, 1]]);
+    for (let i = 0; i < 5; i++) call(core.advanceTick);
+    expect(exited(core, 0)).toBe(false);
+  });
+});
+
+// ## TODO: Test Permutations
+// - two actors reaching the exit on consecutive ticks
+// - an actor exiting while a hazard occupies an adjacent tile

--- a/tests/personas/actor/actor-patrol-behaviour.test.js
+++ b/tests/personas/actor/actor-patrol-behaviour.test.js
@@ -1,0 +1,171 @@
+/**
+ * `patrolling` patrols. It does not walk to the exit.
+ *
+ * Maintainer ruling (2026-09-05), closing the first half of #169.
+ *
+ * WHAT WAS WRONG. `patrolling` had no branch of its own in `buildMotivatedProposals`.
+ * Core's profile table gives it mobility 2 — the HIGHEST tier — and combat 0, so it
+ * cleared the holds-position guard, matched no combat branch, and fell through to
+ * `buildMoveProposal`: shortest path to the level exit. Every patrolling actor therefore
+ * beelined to the single exit tile alongside every other actor, and a measured 100-tick
+ * run produced 579 `ActorCollision` rejections with three wardens that never moved.
+ * The motivation named for patrolling was the one that left the fastest.
+ *
+ * THE SHAPE CHOSEN, and why it is stateless. A clockwise circuit of the actor's own
+ * room. The next cell is a function of the current cell and the room rectangle, so no
+ * memory is carried between ticks — which matters twice over: persona context must stay
+ * serializable, and a memory-carrying patrol would inherit the runner-threading problem
+ * that #162 is still open on. A waypoint patrol would have needed both.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+
+let modulesPromise;
+function loadModules() {
+  modulesPromise ??= Promise.all([
+    import("../../../packages/runtime/src/personas/actor/persona.js"),
+    import("../../../packages/runtime/src/personas/_shared/tick-state-machine.mts"),
+  ]);
+  return modulesPromise;
+}
+
+// A 7x7 room carved out of a wall border, with the level exit OUTSIDE it at (0,3).
+// The exit sits on the far side deliberately: a patrol that quietly still seeks the exit
+// would show up as a westward drift rather than a circuit.
+const BASE_TILES = [
+  "#########",
+  "#.......#",
+  "#.......#",
+  "E.......#",
+  "#.......#",
+  "#.......#",
+  "#########",
+];
+
+const ROOMS = [{ id: "R1", x: 1, y: 1, width: 7, height: 5 }];
+
+function simConfig() {
+  return {
+    schema: "agent-kernel/SimConfigArtifact",
+    schemaVersion: 1,
+    meta: { id: "patrol_sim", runId: "patrol", createdAt: "2026-01-01T00:00:00.000Z" },
+    seed: 0,
+    layout: {
+      kind: "grid",
+      data: {
+        width: 9,
+        height: 7,
+        tiles: BASE_TILES,
+        spawn: { x: 1, y: 1 },
+        exit: { x: 0, y: 3 },
+        rooms: ROOMS,
+        hazards: [],
+      },
+    },
+  };
+}
+
+async function proposeFrom(position, { motivation = { kind: "patrolling" }, others = [] } = {}) {
+  const [{ createActorPersona }, { TickPhases }] = await loadModules();
+  const persona = createActorPersona({ clock: () => "fixed" });
+  const self = { id: "warden_1", kind: 2, role: "warden", position, motivation };
+  const payload = {
+    actorId: self.id,
+    observation: { tick: 0, actors: [self, ...others], exit: { x: 0, y: 3 } },
+    baseTiles: BASE_TILES,
+    simConfig: simConfig(),
+    initialState: { actors: [{ id: self.id, role: "warden", kind: "motivated" }] },
+  };
+  persona.advance({ phase: TickPhases.OBSERVE, event: "observe", payload, tick: 0 });
+  persona.advance({ phase: TickPhases.DECIDE, event: "decide", payload, tick: 0 });
+  const result = persona.advance({ phase: TickPhases.DECIDE, event: "propose", payload, tick: 0 });
+  return (result.actions || []).find((a) => a.kind === "move") || null;
+}
+
+/** Walk the patrol by feeding each proposed destination back in as the next position. */
+async function walk(from, steps) {
+  const path = [{ ...from }];
+  let at = { ...from };
+  for (let i = 0; i < steps; i += 1) {
+    const move = await proposeFrom(at);
+    if (!move) break;
+    at = { x: move.params.to.x, y: move.params.to.y };
+    path.push({ ...at });
+  }
+  return path;
+}
+
+const onPerimeter = (p) => {
+  const r = ROOMS[0];
+  return p.x === r.x || p.x === r.x + r.width - 1 || p.y === r.y || p.y === r.y + r.height - 1;
+};
+
+test("a patrolling actor circuits its room instead of walking to the exit", async () => {
+  const path = await walk({ x: 1, y: 1 }, 20);
+
+  assert.ok(path.length > 8, `patrol stalled after ${path.length} steps: ${JSON.stringify(path)}`);
+  // THE LOAD-BEARING ASSERTION. The exit is at (0,3), due west. Exit-seeking — the old
+  // behaviour — reaches x=1,y=3 and then leaves the room. A circuit never does.
+  assert.ok(
+    path.every((p) => p.x >= 1),
+    `a patrolling actor left the room toward the exit: ${JSON.stringify(path)}`,
+  );
+  assert.ok(
+    path.every(onPerimeter),
+    `patrol left its room's perimeter: ${JSON.stringify(path)}`,
+  );
+});
+
+test("the circuit returns to where it started", async () => {
+  // A patrol that merely wanders along the perimeter would satisfy the test above. This
+  // is what makes it a CIRCUIT. The room is 7x5, so its perimeter is 2*(7+5)-4 = 20
+  // cells and exactly 20 steps close the loop.
+  const start = { x: 1, y: 1 };
+  const path = await walk(start, 20);
+  assert.deepEqual(path[path.length - 1], start, `circuit did not close: ${JSON.stringify(path)}`);
+});
+
+test("every step is to an adjacent tile", async () => {
+  const path = await walk({ x: 1, y: 1 }, 12);
+  for (let i = 1; i < path.length; i += 1) {
+    const dx = Math.abs(path[i].x - path[i - 1].x);
+    const dy = Math.abs(path[i].y - path[i - 1].y);
+    assert.ok(dx <= 1 && dy <= 1 && (dx || dy), `step ${i} is not one tile: ${JSON.stringify(path)}`);
+  }
+});
+
+test("an actor inside the room joins the perimeter rather than stalling", async () => {
+  const move = await proposeFrom({ x: 4, y: 3 });
+  assert.ok(move, "an actor away from the perimeter must still propose a move");
+  const to = move.params.to;
+  const r = ROOMS[0];
+  const before = Math.min(4 - r.x, r.x + r.width - 1 - 4, 3 - r.y, r.y + r.height - 1 - 3);
+  const after = Math.min(to.x - r.x, r.x + r.width - 1 - to.x, to.y - r.y, r.y + r.height - 1 - to.y);
+  assert.ok(after < before, `step did not approach the perimeter: ${JSON.stringify(to)}`);
+});
+
+test("the patrol is deterministic", async () => {
+  // `ak replay` compares runs frame by frame, so a patrol that varied between runs would
+  // break replay outright rather than degrade it.
+  const a = await walk({ x: 1, y: 1 }, 10);
+  const b = await walk({ x: 1, y: 1 }, 10);
+  assert.deepEqual(a, b);
+});
+
+test("a non-patrolling actor still heads for the exit", async () => {
+  // ANTI-VACUITY. Without this, deleting exit-seeking altogether would pass every test
+  // above — and the change under test is meant to give `patrolling` its OWN behaviour,
+  // not to remove exit-seeking from the actors that should have it.
+  const move = await proposeFrom({ x: 3, y: 3 }, { motivation: { kind: "exploring" } });
+  assert.ok(move, "an exploring actor must still propose a move");
+  assert.ok(
+    move.params.to.x < 3,
+    `exploring should close on the exit at (0,3), went to ${JSON.stringify(move.params.to)}`,
+  );
+});
+
+// ## TODO: Test Permutations
+// - a room whose perimeter is broken by an interior wall
+// - two patrolling actors on the same ring, one blocking the other
+// - an actor whose position lies outside every declared room


### PR DESCRIPTION
Closes #169. Two changes that only work as a pair: giving `patrolling` behaviour of its own, and letting an actor that reaches the exit actually leave.

## What was wrong

`patrolling` had **no branch** in `buildMotivatedProposals`. Core's profile table gives it mobility **2** — the *highest* tier — and combat **0**, so it cleared the holds-position guard, matched no combat branch, and fell through to `buildMoveProposal`: shortest path to the level exit.

So every patrolling actor beelined to the single exit tile alongside everyone else — and the first to arrive **stood on it forever**, because `buildMoveProposal` returns `[]` when the path length is 1. The motivation named for patrolling was the one that left the fastest, and then blocked the door.

Same gap `multi-actor-random-run.test.js` already documents for `random`: *"every 'random' actor falls back to buildMoveProposal(), which pathfinds toward the shared level exit."* That one was later special-cased; `patrolling` was not, and nothing noticed because no test asserted what patrolling **does** — only that it moved.

## The two changes

**`77f3626` — an actor on the exit for two ticks has left the level.** Core owns it: a position, a counter, a threshold is a deterministic state transition, and the runtime carries no per-actor state across ticks by design. The actor keeps its slot with an `exited` flag and is excluded from occupancy and the decide loop — rather than deleted, which would reindex every later actor and disturb both the core-index affinity tie-break (#163) and `ak replay`'s positional frame comparison. World state **reports** the flag rather than filtering the actor out: a run is a record of what happened, and dropping it would make an exit indistinguishable from an actor that was never there.

⚠️ **Exiting must vacate the cell, and that is the half worth reviewing.** The flag alone would leave the actor's body on the one tile everyone paths toward — the exact defect this exists to end. A test drives it through the real move rule (another actor refused with `ActorCollision` before, accepted after) and was perturbed by deleting the vacate line: that test alone fails.

**`3b10dbc` — patrolling circuits its own room.** Clockwise around the room perimeter. **Stateless by requirement, not preference:** the next cell is a pure function of the current cell and the room rectangle, so nothing is carried between ticks. Persona context must stay serializable, and a waypoint patrol would have needed the runner to thread per-actor state — the problem #162 is still open on.

Deliberate details: the ring is filtered to **walkable** cells (a room's rectangle may be carved through, and an unfiltered circuit proposes moves core refuses); an actor inside the room steps out to join the ring rather than standing still, which would have looked exactly like the defect replaced; and it falls through to the old behaviour when the actor is in no declared room.

## Measured, on the same 100-tick scenario that exposed it

3 rooms, 6 patrolling wardens, 2 attacking delvers, seed 7.

| actor | before acc/rej | after acc/rej | exited |
|---|---|---|---|
| delver_1-1 | 49/51 | 52/48 | |
| delver_1-2 | 19/81 | **49**/51 | |
| warden_1-1 | 1/0 | 1/1 | **true** |
| warden_1-2 | **0**/100 | **28**/72 | |
| warden_1-3 | 1/99 | **30**/70 | |
| warden_1-4 | **0**/100 | **29**/71 | |
| warden_1-5 | **0**/100 | **28**/72 | |
| warden_1-6 | 1/99 | **30**/70 | |

**Actors that move at all: 5 of 8 → 8 of 8.** `ActorCollision` rejections: **579 → 359**. One warden reached the exit and left the level.

The remaining 359 collisions are patrolling actors crossing each other's rings in a tight cluster — they still move ~30 times each, where three of them previously never moved at all.

## Three harness traps, recorded rather than worked around

Each produced a confident wrong signal before it was understood, and each is written into the test file:

- **`configureGrid` is what allocates actor capacity.** Without it a fresh core is 0×0 with room for zero actors, and `addActorPlacement` **silently overflows** while placement still reports success.
- **`setActiveMotivatedActor` takes an actor ID, not an index — and returns an error rather than throwing.** Passing an index gave actor 0 stamina twice and actor 1 none, surfacing as a mysterious `InsufficientStamina` three calls later.
- **Core accepts a move stamped `currentTick + 1`**, not `currentTick`.

## Gates

Suite **484 files / 3,760 passed / 199 skipped / 0 failed** · typecheck **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)