### PR TITLE
fix: a defending actor holds its ground; guard the motivation vocabulary

### DIFF
--- a/docs/architecture-charter.md
+++ b/docs/architecture-charter.md
@@ -459,7 +459,41 @@ Heavy level synthesis runs behind a builder adapter. UI code hands off summaries
 
 - Simple actor motivations are resolved deterministically in `packages/runtime/src/personas/actor/controller.js`.
 - `buildMotivatedProposals()` reads `motivation.kind` from the observation actor record or `payload.initialState.actors`. It uses `resolveNearestHostile()` to choose the closest other actor by Chebyshev distance.
-- Current simple motivation kinds are `attacking`, `defending`, `stationary`, and `random`: attacking actors attack adjacent hostiles or pursue distant hostiles, defending actors attack adjacent hostiles or hold position when distant, stationary actors emit no movement proposal, and random actors move to a seed-derived legal adjacent tile.
+- **Gating is on the PROFILE; a few specific behaviours are still selected by NAME.** The
+  questions "may this actor move?" and "does it fight?" are answered from core's mobility and
+  combat tiers, so a new kind inherits correct movement and combat from its profile row with no
+  branch to add — the earlier form tested `kind === "stationary"` and everything else fell
+  through to movement, behaviour living in the list of names someone remembered. But four kinds
+  still have name branches: `random`, `patrolling`, and the `attacking`/`defending` pair that
+  gates casting and striking. Those are the sites a thirteenth motivation would have to be
+  wired into by hand, and the honest statement of the current design rather than the one the
+  profile table implies.
+- **There are twelve kinds, and they produce five distinct behaviours** (audited 2026-09-06).
+  Behaviour collapsing is not automatically a defect: kinds sharing a profile *should* behave
+  alike, and the axis that separates several of them — cognition — is not yet consumed by the
+  Actor.
+
+  | behaviour | kinds |
+  |---|---|
+  | seed-derived move to a legal adjacent tile | `random` |
+  | clockwise circuit of the actor's own room | `patrolling` |
+  | shortest path to the level exit | `exploring`, `stealthy`, `friendly` |
+  | strike an adjacent hostile; else pursue (mobility 1) or hold (mobility 0) | `attacking`, `defending` |
+  | no movement proposal | `stationary`, `reflexive`, `goal_oriented`, `strategy_focused`, `user_controlled` |
+
+- **Mobility 0 means hold position, in BOTH directions an actor can walk away.** The rule is
+  pinned as a rule — every mobility-0 kind proposes no move, every mobility-bearing kind
+  proposes one — because covering only one direction is how it was wrong before: `defending`
+  (mobility 0, combat 2) skipped the holds-position guard, found no hostile, and fell through
+  to exit pathfinding, proposing moves byte-identical to `attacking`. Holding position
+  suppresses MOVEMENT, not every proposal: `defending` holds ground and still strikes what
+  comes to it (§382).
+- ⚠️ **This section previously named four kinds** — `attacking`, `defending`, `stationary`,
+  `random` — as "the current simple motivation kinds", which was true when written and had
+  stopped being true twice over: `patrolling` gained behaviour of its own, and the description
+  of `defending` as holding position when distant described a fix that had not landed yet.
+  A charter that lists behaviours by name goes stale silently every time one is added, which is
+  why the table above is anchored to the PROFILE the dispatch actually reads.
 - `random` movement is deterministic pseudo-random: the choice derives from `seed:actorId:tick` (FNV/mulberry), never `Math.random()`, and synthesizes a `wait` when no legal adjacent tile exists. Replays of the same seed produce identical movement.
 - Multi-actor ticks: `packages/runtime/src/runner/runtime-fsm.mjs` runs the DECIDE phase for every actor each tick and reserves proposed target tiles within the tick so two actors cannot move onto the same tile in the same tick.
 - Complex motivation is opt-in. Actors with runtime decisioning enabled, for example `runtimeDecisioning: { enabled: true, mode: "solver", preferred: "solver", targetAdapter: "z3" }`, emit a `solver_request` effect instead of directly returning a concrete action.

--- a/packages/runtime/src/personas/actor/controller.js
+++ b/packages/runtime/src/personas/actor/controller.js
@@ -1911,6 +1911,21 @@ function buildMotivatedProposals({ observation, payload, simConfig, personaSeed 
     }
   }
 
+  // ⚠️ HOLDS-POSITION APPLIES HERE TOO, and its absence was a real defect. The early
+  // return at the top of this function is gated on `!hasCombatRole`, so `defending`
+  // (mobility 0, combat 2) skipped it, found no hostile, and fell through to exit
+  // pathfinding — a defender walking to the exit. Measured across six positions,
+  // `defending` and `attacking` proposed byte-identical moves.
+  //
+  // The comment above the pursuit branch already claimed this was handled: "a combat
+  // motivation with mobility 0 holds its ground instead of pursuing, which is what
+  // separates defending from attacking". True of pursuit, never true of this line. The
+  // guard existed for one of the two ways an actor can walk away.
+  //
+  // Returning [] rather than a `wait` proposal keeps this identical to the other
+  // holds-position path at the top, so the two cannot drift into different silences.
+  if (holdsPosition) return [];
+
   // Fallback: existing exit pathfinding
   return buildMoveProposal({ observation, payload, simConfig });
 }

--- a/tests/architecture/motivation-vocabulary-single-origin.test.js
+++ b/tests/architecture/motivation-vocabulary-single-origin.test.js
@@ -1,0 +1,129 @@
+/**
+ * ONE motivation vocabulary, and every copy must agree with it.
+ *
+ * AUDIT, 2026-09-06. Twenty-six files across core-ts, runtime, adapters-cli and ui-web
+ * name motivation kinds as string literals, and FIVE of them enumerate all twelve:
+ *
+ *   core-ts/src/motivation-readers.ts                  the code→name authority
+ *   runtime/src/contracts/game-elements.js             the name authority
+ *   runtime/src/personas/configurator/motivation-rules.js
+ *   runtime/src/render/actor-medallion-composer.ts
+ *   runtime/src/render/actor-medallion-composer.js     (a second copy of the same file)
+ *
+ * TWO THINGS WERE UNGUARDED, and both are the repo's recurring defect rather than new
+ * mistakes.
+ *
+ * 1. THE TWO AUTHORITIES WERE NEVER COMPARED. `MOTIVATION_KIND_BY_CODE` (core) and
+ *    `GAME_MOTIVATION_KINDS` (contracts) are independent lists of the same twelve names
+ *    in different packages. Nothing asserted they agree, so adding a kind to one and not
+ *    the other would have produced a vocabulary that disagrees with itself, silently.
+ *
+ * 2. `single-origin.test.js` MATCHES DECLARATION NAMES, so it catches a re-declared
+ *    `const MOTIVATION_KINDS` and cannot see an ANONYMOUS inline array of the same twelve
+ *    strings — which is exactly what the medallion composer holds. That guard's own
+ *    header records this lesson from a previous occurrence: "the guard was scoped to the
+ *    spelling that existed when it was written rather than to the concept." It happened
+ *    again, one level down.
+ *
+ * This guard is about AGREEMENT, not about forbidding copies. A render layer mapping each
+ * kind to a token is legitimate; a render layer inventing a thirteenth kind, or missing
+ * one, is not.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+const { readdirSync, readFileSync, statSync } = require("node:fs");
+const { join, relative, resolve, sep } = require("node:path");
+
+const ROOT = resolve(__dirname, "../..");
+const PACKAGES = resolve(ROOT, "packages");
+const SOURCE_EXTENSIONS = new Set([".js", ".mjs", ".mts", ".ts"]);
+const SKIP_DIRECTORIES = new Set(["node_modules", "dist", "build", "graphify-out"]);
+
+function collect(directory, files = []) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRECTORIES.has(entry.name)) collect(join(directory, entry.name), files);
+    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(entry.name.slice(entry.name.lastIndexOf(".")))) {
+      files.push(join(directory, entry.name));
+    }
+  }
+  return files;
+}
+
+const repoPath = (p) => relative(ROOT, p).split(sep).join("/");
+
+async function authorities() {
+  const core = await import("../../packages/core-ts/src/index.ts");
+  const contracts = await import("../../packages/runtime/src/contracts/game-elements.js");
+  const fromCore = Object.entries(core.MOTIVATION_KIND_BY_CODE)
+    .filter(([code]) => Number(code) > 0)
+    .sort((a, b) => Number(a[0]) - Number(b[0]))
+    .map(([, name]) => name);
+  return { fromCore, fromContracts: Array.from(contracts.GAME_MOTIVATION_KINDS) };
+}
+
+test("core and contracts name the same motivation kinds", async () => {
+  const { fromCore, fromContracts } = await authorities();
+  assert.deepEqual(
+    [...fromContracts].sort(),
+    [...fromCore].sort(),
+    "core-ts `MOTIVATION_KIND_BY_CODE` and contracts `GAME_MOTIVATION_KINDS` are the two "
+      + "lists every other copy is derived from. They live in different packages and were "
+      + "never compared until this guard: a kind added to one alone gives the codebase a "
+      + "vocabulary that disagrees with itself, and nothing else would notice.",
+  );
+});
+
+test("a file that carries most of the vocabulary carries all of it", async () => {
+  const { fromCore } = await authorities();
+  const known = new Set(fromCore);
+  // A file naming two-thirds of the kinds is a CODEBOOK, whatever it calls itself, and the
+  // risk is that it falls one member behind when a kind is added — eleven of twelve, with
+  // nothing failing and one motivation quietly missing a price, an icon or a rule.
+  //
+  // The threshold is what makes this non-circular. Asserting completeness only on files
+  // that already name every kind would prove nothing; asserting it on files that name most
+  // of them is exactly the drift that has no other detector.
+  //
+  // ⚠️ THE THRESHOLD IS HIGH ON PURPOSE — two-thirds was tried first and produced a false
+  // positive that is itself worth knowing about. `configurator/motivation-evaluation-core.js`
+  // names 8 of 12, and every one is an AXIS TIER name rather than a motivation kind:
+  // MOBILITY_NAMES is ["stationary","exploring","patrolling"], COMBAT_NAMES is
+  // ["none","attacking","defending"]. Those strings are the names of tier VALUES, and they
+  // collide by spelling with motivation KINDS. Same token, two meanings, decided by
+  // context — no textual guard can separate them, so the threshold sits above where axis
+  // tables land and below where a codebook missing a member or two does.
+  const threshold = known.size - 2;
+  const incomplete = [];
+  for (const file of collect(PACKAGES)) {
+    const source = readFileSync(file, "utf8");
+    const named = new Set();
+    for (const [, token] of source.matchAll(/"([a-z][a-z_]{2,30})"/g)) {
+      if (known.has(token)) named.add(token);
+    }
+    if (named.size < threshold || named.size === known.size) continue;
+    const missing = fromCore.filter((kind) => !named.has(kind));
+    incomplete.push(`${repoPath(file)} names ${named.size}/${known.size}, missing: ${missing.join(", ")}`);
+  }
+  assert.deepEqual(
+    incomplete,
+    [],
+    "these files hold most of the motivation vocabulary but not all of it. Either they are "
+      + "codebooks that fell behind, or they should derive the list from "
+      + `contracts/game-elements.js instead of restating it:\n  ${incomplete.join("\n  ")}`,
+  );
+});
+
+// ⚠️ A THIRD GUARD WAS WRITTEN AND DELETED, and the reason is worth more than the guard.
+// It flagged any non-kind token appearing inside an array alongside three or more kinds,
+// intending to catch a typo or a retired name. It fired on four files immediately, and
+// every hit was legitimate: `defend`, `guard`, `patrol`, `sentry`, `warden` are role
+// aliases that share those arrays by design, and `combat`, `mobility`, `none` are axis
+// names. Without a spec of what else may legally sit beside a kind, the check cannot tell
+// a typo from a synonym — and a guard whose failures are usually false teaches people to
+// add exceptions to it, which is worse than not having it.
+
+// ## TODO: Test Permutations
+// - a file naming exactly two kinds is not treated as a codebook
+// - the guard survives a kind whose name is a substring of another

--- a/tests/personas/actor/actor-motivation-distinctness.test.js
+++ b/tests/personas/actor/actor-motivation-distinctness.test.js
@@ -1,0 +1,172 @@
+/**
+ * Every motivation must MEAN something, and mobility 0 must mean it.
+ *
+ * AUDIT, 2026-09-06: driving the Actor with all twelve motivation kinds across six
+ * positions, with and without an adjacent hostile, produced FIVE distinct behaviours:
+ *
+ *   random                                                              unique
+ *   patrolling                                                          unique
+ *   exploring · stealthy · friendly                                     identical
+ *   attacking · defending                                               identical
+ *   stationary · reflexive · goal_oriented · strategy_focused ·
+ *     user_controlled                                                   identical (silent)
+ *
+ * Collapsing is not automatically a defect — five of those have mobility 0 and combat 0,
+ * so holding position is the correct reading of their profile. `defending` is different:
+ * it collapsed onto `attacking` because of a real gap, and that is what this file pins.
+ */
+"use strict";
+
+const assert = require("node:assert/strict");
+
+let modulesPromise;
+function loadModules() {
+  modulesPromise ??= Promise.all([
+    import("../../../packages/runtime/src/personas/actor/persona.js"),
+    import("../../../packages/runtime/src/personas/_shared/tick-state-machine.mts"),
+  ]);
+  return modulesPromise;
+}
+
+const BASE_TILES = [
+  "#########",
+  "#.......#",
+  "#.......#",
+  "E.......#",
+  "#.......#",
+  "#.......#",
+  "#########",
+];
+
+function simConfig() {
+  return {
+    schema: "agent-kernel/SimConfigArtifact",
+    schemaVersion: 1,
+    meta: { id: "m", runId: "m", createdAt: "2026-01-01T00:00:00.000Z" },
+    seed: 0,
+    layout: {
+      kind: "grid",
+      data: {
+        width: 9,
+        height: 7,
+        tiles: BASE_TILES,
+        spawn: { x: 1, y: 1 },
+        exit: { x: 0, y: 3 },
+        rooms: [{ id: "R1", x: 1, y: 1, width: 7, height: 5 }],
+        hazards: [],
+      },
+    },
+  };
+}
+
+const vitals = () => ({
+  health: { current: 10, max: 10, regen: 1 },
+  stamina: { current: 8, max: 8, regen: 8 },
+  mana: { current: 10, max: 10, regen: 1 },
+});
+
+async function propose({ kind, position = { x: 4, y: 3 }, hostileAt = null }) {
+  const [{ createActorPersona }, { TickPhases }] = await loadModules();
+  const self = { id: "a1", kind: 2, role: "warden", position, motivation: { kind }, vitals: vitals() };
+  const others = hostileAt
+    ? [{ id: "d1", kind: 2, role: "delver", position: hostileAt, vitals: vitals() }]
+    : [];
+  const payload = {
+    actorId: self.id,
+    observation: { tick: 0, actors: [self, ...others], exit: { x: 0, y: 3 } },
+    baseTiles: BASE_TILES,
+    simConfig: simConfig(),
+    initialState: {
+      actors: [
+        { id: self.id, role: "warden", kind: "motivated" },
+        ...others.map((o) => ({ id: o.id, role: "delver", kind: "motivated" })),
+      ],
+    },
+  };
+  const persona = createActorPersona({ clock: () => "fixed", seed: 5 });
+  persona.advance({ phase: TickPhases.OBSERVE, event: "observe", payload, tick: 0 });
+  persona.advance({ phase: TickPhases.DECIDE, event: "decide", payload, tick: 0 });
+  const result = persona.advance({ phase: TickPhases.DECIDE, event: "propose", payload, tick: 0 });
+  return (result.actions || []).filter((a) => a.kind !== "emit_log" && a.kind !== "emit_telemetry");
+}
+
+test("a defending actor with no enemy in sight holds its ground", async () => {
+  // THE BUG. `defending` has mobility 0 — stationary — and combat 2. The holds-position
+  // early return is gated on `!hasCombatRole`, so a defender skips it, finds no hostile,
+  // and falls through to `buildMoveProposal`: shortest path to the level EXIT. Measured
+  // across six positions, `defending` and `attacking` proposed byte-identical moves.
+  //
+  // The code asserted the opposite in a comment three lines up — "a combat motivation
+  // with mobility 0 holds its ground instead of pursuing, which is what separates
+  // defending from attacking" — which is true of the PURSUIT branch and was never true
+  // of the fallback below it. A defender walking to the exit is not defending anything.
+  const actions = await propose({ kind: "defending" });
+  assert.deepEqual(
+    actions.filter((a) => a.kind === "move"),
+    [],
+    `a defending actor must not walk off: ${JSON.stringify(actions)}`,
+  );
+});
+
+test("a defending actor still strikes what comes to it", async () => {
+  // The other half, and the reason the fix cannot simply be an early return on
+  // holdsPosition: charter §382 says defending holds ground AND fights. Suppressing
+  // movement must not silence the actor, which is a mistake this file's ancestors
+  // already made once — three tests said so.
+  const actions = await propose({ kind: "defending", hostileAt: { x: 5, y: 3 } });
+  assert.ok(
+    actions.some((a) => a.kind === "attack" || a.kind === "cast_affinity"),
+    `a defending actor must fight an adjacent hostile: ${JSON.stringify(actions)}`,
+  );
+});
+
+test("attacking still closes on a distant hostile", async () => {
+  // ANTI-VACUITY. `attacking` has mobility 1, so the holds-position rule must not touch
+  // it. Without this, suppressing movement for every combat motivation would pass above.
+  const actions = await propose({ kind: "attacking", hostileAt: { x: 7, y: 3 } });
+  const move = actions.find((a) => a.kind === "move");
+  assert.ok(move, `an attacking actor must pursue: ${JSON.stringify(actions)}`);
+  assert.ok(move.params.to.x > 4, `pursuit should close the gap: ${JSON.stringify(move.params.to)}`);
+});
+
+test("every mobility-0 motivation holds position", async () => {
+  // The rule stated as a rule rather than one case: mobility 0 means stationary, and no
+  // motivation carrying it may propose a move when nothing is adjacent to fight.
+  const { MOTIVATION_KIND_BY_CODE, getMotivationMobilityTier } = await import(
+    "../../../packages/core-ts/src/index.ts"
+  );
+  const stationary = [];
+  for (let code = 1; code <= 12; code += 1) {
+    if (getMotivationMobilityTier(code) === 0) stationary.push(MOTIVATION_KIND_BY_CODE[code]);
+  }
+  assert.ok(stationary.length >= 5, `expected several stationary kinds, got ${stationary}`);
+
+  for (const kind of stationary) {
+    const actions = await propose({ kind });
+    assert.deepEqual(
+      actions.filter((a) => a.kind === "move"),
+      [],
+      `${kind} has mobility 0 but proposed a move`,
+    );
+  }
+});
+
+test("mobility-bearing motivations do propose movement", async () => {
+  // The mirror, so "hold everything" cannot pass. Anything core rates mobile must move.
+  const { MOTIVATION_KIND_BY_CODE, getMotivationMobilityTier } = await import(
+    "../../../packages/core-ts/src/index.ts"
+  );
+  for (let code = 1; code <= 12; code += 1) {
+    if (getMotivationMobilityTier(code) === 0) continue;
+    const kind = MOTIVATION_KIND_BY_CODE[code];
+    const actions = await propose({ kind });
+    assert.ok(
+      actions.some((a) => a.kind === "move"),
+      `${kind} is mobile (tier ${getMotivationMobilityTier(code)}) but proposed no move`,
+    );
+  }
+});
+
+// ## TODO: Test Permutations
+// - a defending actor with a hostile two tiles away (out of reach, still holds)
+// - stealthy vs exploring once stealth has behaviour of its own


### PR DESCRIPTION
An audit of all twelve motivation kinds — what each one **does**, and where motivation code **lives**.

## Behaviour: 5 distinct behaviours across 12 motivations

Driving the Actor with every kind, across six positions, with and without an adjacent hostile:

| behaviour | kinds |
|---|---|
| unique | `random` |
| unique | `patrolling` |
| **identical** | `exploring` · `stealthy` · `friendly` |
| **identical** | `attacking` · `defending` |
| **identical** (silent) | `stationary` · `reflexive` · `goal_oriented` · `strategy_focused` · `user_controlled` |

**Collapsing is not automatically wrong.** The five silent kinds all carry mobility 0 and combat 0, so holding position is the correct reading of their profile — they differ on the *cognition* axis, which nothing in the Actor consumes yet. Only one group is a defect, and this PR fixes that one. What `stealthy` and `friendly` should *do* is a gameplay ruling, reported below rather than invented.

## The defect: `defending` walked to the exit

`defending` has mobility **0** (stationary) and combat **2**. The holds-position early return is gated on `!hasCombatRole`, so a defender skipped it, found no hostile, and fell through to `buildMoveProposal` — shortest path to the level **exit**. Across six positions, `defending` and `attacking` proposed **byte-identical moves**.

The code claimed otherwise three lines above the fallback:

> *"a combat motivation with mobility 0 holds its ground instead of pursuing, which is what separates defending from attacking"*

True of the **pursuit** branch. Never true of the fallback below it. The guard covered one of the two ways an actor can walk away.

Now pinned as a rule rather than a case: **every mobility-0 kind must propose no move, and every mobility-bearing kind must propose one.** The mirror matters — "suppress everything" would satisfy the first half alone. A defender still strikes what comes to it (charter §382).

## Centralization: 26 files, 5 codebooks, 2 unguarded gaps

Motivation kinds are named as string literals in **26 files** across core-ts, runtime, adapters-cli and ui-web. **Five enumerate all twelve** — core's `motivation-readers.ts`, contracts' `game-elements.js`, `configurator/motivation-rules.js`, and `actor-medallion-composer` in both `.ts` and `.js`.

Two gaps, both the repo's recurring defect rather than new mistakes:

1. **The two authorities were never compared.** core's `MOTIVATION_KIND_BY_CODE` and contracts' `GAME_MOTIVATION_KINDS` are independent lists of the same twelve names in different packages. Nothing asserted they agree — add a kind to one alone and the codebase has a vocabulary that disagrees with itself, silently.
2. **`single-origin.test.js` matches declaration *names*.** It catches a re-declared `const MOTIVATION_KINDS` and cannot see an **anonymous inline array** of the same twelve strings — which is exactly what the medallion composer holds. That guard's own header records this lesson from a previous occurrence: it was *"scoped to the spelling that existed when it was written rather than to the concept."* It happened again, one level down.

Both now guarded, each perturbed against its own class: removing a kind from contracts fails the agreement test; removing one from the render codebook fails the drift test.

## Two things I chose not to ship

⚠️ **A third guard was written and deleted**, and the reason is in the file. It flagged non-kind tokens sharing an array with kinds, to catch typos and retired names. All four of its hits were legitimate — `defend`, `guard`, `patrol`, `sentry`, `warden` are role aliases; `combat`, `mobility`, `none` are axis names. Without a spec of what may legally sit beside a kind it cannot tell a typo from a synonym, and **a guard whose failures are usually false teaches people to add exceptions to it.**

⚠️ **Axis tier names collide with motivation kind names.** `MOBILITY_NAMES` is `["stationary","exploring","patrolling"]`; `COMBAT_NAMES` is `["none","attacking","defending"]`. The same token means a tier in one place and a kind in another, decided by context. That is why the drift threshold sits above where axis tables land — and it is a maintainability hazard worth a decision of its own.

## Charter corrected in the same diff (`810d92a6`)

`docs/architecture-charter.md` § Motivation And Action Flow said:

> *"Current simple motivation kinds are `attacking`, `defending`, `stationary`, and `random`"*

True when written, and stale **twice over** by the time it was read: `patrolling` gained behaviour of its own in `9273e5d7`, and the same sentence described `defending` as holding position when distant — a fix that had not landed, and which this branch is what makes true. A doc contradicting the code is a blocking defect fixed in the diff that made it wrong; this branch made it wrong.

It now carries the five behaviours the twelve kinds actually produce, as a table **anchored to the profile the dispatch reads** rather than a list of names — a charter that enumerates behaviours by name goes stale silently every time one is added.

⚠️ **A claim I nearly shipped false.** The first draft said dispatch is *"on the PROFILE, never on the name"*. It is not. Gating — may this actor move, does it fight — is profile-driven, but **four kinds still have name branches**: `random`, `patrolling`, and the `attacking`/`defending` pair that gates casting and striking. Caught before committing. The section now names those four as the sites a thirteenth motivation must be wired into by hand — the honest description of the current design rather than the one the profile table implies.

## Still open — a gameplay ruling, not a measurement

`stealthy`, `friendly` and `exploring` are behaviourally identical, and `stealthy` already carries a `PrefersStealth` flag the Actor's rank tuple reads but its proposal builder ignores. `friendly` has no flag at all. Giving each real behaviour is the same shape of decision `patrolling` just went through (#169) and wants the same explicit ruling.

## Gates

Suite **486 files / 3,767 passed / 199 skipped / 0 failed** · typecheck **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
