### PR TITLE
chore(policy): no change lands on main — branch, PR, then delete the branch

### DIFF
--- a/.cursor/rules/branch-policy.mdc
+++ b/.cursor/rules/branch-policy.mdc
@@ -1,0 +1,35 @@
+---
+description: No change ever lands on main. Every change — any size, any agent — goes on a feature branch, lands through a PR, and the branch is deleted locally and on origin when it merges.
+globs:
+alwaysApply: true
+---
+
+# Never commit on `main`
+
+**No commit lands on `main` directly, ever.** No exception for a one-line fix, a typo, a doc tweak,
+or "this is too small for a PR". No exception for which agent is driving — Cursor, Claude and Codex
+are bound identically. Size was never what made a direct commit safe; it only made it feel safe.
+
+```bash
+git switch -c <type>/<short-description>     # feat/ fix/ chore/ docs/ test/ refactor/
+# ... work, gates green ...
+git push -u origin HEAD
+gh pr create --fill
+gh pr merge --squash --delete-branch         # merges, deletes the branch here AND on origin
+git fetch --prune
+```
+
+`gh pr merge --delete-branch` is the entire cleanup step — remote and local in one command. A branch
+that outlives its merged PR reads as live work to the next agent scanning `git branch -a`.
+
+**If you are already on `main` with uncommitted work:** `git switch -c <branch>` carries the changes
+onto the new branch. Nothing is lost and nothing needs stashing.
+
+`.githooks/pre-commit` and `.githooks/pre-push` refuse this mechanically — the pre-push hook checks
+the *destination* ref, so `git push origin HEAD:main` from a feature branch is refused too. They are
+guards, not walls: `--no-verify` and the ruleset's admin bypass both get through. **A bypass is
+something you report to the maintainer, never something you use quietly to get unblocked.**
+
+The full policy, the naming convention, and the current `Protect Main` ruleset state live in
+`AGENTS.md → Branching — every change goes through a branch and a PR`. That file owns this rule;
+this one points at it.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Refuse a commit made directly on a protected branch. See .githooks/protected-branch.sh.
+set -uo pipefail
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# A detached HEAD is not a protected branch: rebases, bisects and worktree surgery all run there,
+# and refusing them would break ordinary git operations for no gain.
+branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+[ -n "$branch" ] || exit 0
+
+exec "$HOOK_DIR/protected-branch.sh" "$branch" commit

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Refuse a push whose DESTINATION is a protected branch.
+#
+# Checked against the remote ref, not the local branch name: `git push origin HEAD:main` from a
+# feature branch is still a direct write to main, and a hook that only looked at the local name
+# would wave it through. That is exactly the shape that put two commits on main by hand.
+set -uo pipefail
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# stdin: <local ref> <local sha> <remote ref> <remote sha>
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  [ -n "${remote_ref:-}" ] || continue
+  case "$remote_ref" in
+    refs/heads/*) target="${remote_ref#refs/heads/}" ;;
+    *) continue ;;
+  esac
+  "$HOOK_DIR/protected-branch.sh" "$target" push || exit 1
+done
+
+exit 0

--- a/.githooks/protected-branch.sh
+++ b/.githooks/protected-branch.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Is this branch one that must never receive a direct commit or push?
+#
+# The decision lives here, on its own, for two reasons: both hooks need the same answer, and a test
+# can call this directly with any branch name. A guard whose logic is only reachable by actually
+# committing to main is a guard nobody can prove works.
+#
+#   protected-branch.sh <branch-name> <commit|push>
+#
+# Exit 0 = allowed. Exit 1 = refused, with the reason and the way forward on stderr.
+set -uo pipefail
+
+BRANCH="${1:-}"
+ACTION="${2:-commit}"
+
+# master is included because a clone of this repo under an older default would otherwise be
+# unguarded, and the cost of listing it is nothing.
+case "$BRANCH" in
+  main|master) ;;
+  *) exit 0 ;;
+esac
+
+cat >&2 <<MSG
+
+  ✗ Refused: direct ${ACTION} on '${BRANCH}'.
+
+  Every change lands through a feature branch and a PR — no exception for a one-line fix,
+  a typo, or a doc tweak, and no exception for which agent is driving (Claude, Codex, Cursor).
+  See AGENTS.md → "Branching — every change goes through a branch and a PR".
+
+  From here:
+
+    git switch -c <type>/<short-description>     # feat/ fix/ chore/ docs/ test/ refactor/
+MSG
+
+if [ "$ACTION" = "commit" ]; then
+  cat >&2 <<'MSG'
+    git commit ...                               # your commit, now on the branch
+MSG
+else
+  cat >&2 <<'MSG'
+    git push -u origin HEAD                      # push the branch, not main
+MSG
+fi
+
+cat >&2 <<'MSG'
+    gh pr create --fill
+    gh pr merge --squash --delete-branch         # merges, then removes it here and on origin
+
+  This hook is a guard, not a wall: `--no-verify` bypasses it, as does any admin bypass on
+  the GitHub ruleset. It exists to stop the accident, not to defeat a deliberate override.
+
+MSG
+exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ Claude Sonnet/medium (write base tests + TODO permutation stubs)
     ↓
 Ollama (expand permutations in place via /local-test-gen)
     ↓
-Claude (docs in the SAME diff as the code — Sonnet/medium descriptive, Opus/high normative; then commit + PR)
+Claude (docs in the SAME diff as the code — Sonnet/medium descriptive, Opus/high normative;
+         then commit ON A BRANCH + PR — never on main, see "Branching")
 ```
 
 **Docs are not a trailing step.** The agent that changes behavior updates the affected docs in the same diff: it already holds the context, and a doc that contradicts the code is a live hazard, not cosmetic debt — 7 persona READMEs named `.mts` as the canonical source long after `.js` became it, so anyone following them would have edited a re-export shim and their change would silently never run.
@@ -93,11 +94,69 @@ Documentation moved from GitHub Copilot to Claude on 2026-07-27. Two tiers by st
 
 ---
 
+## Branching — every change goes through a branch and a PR
+
+**No commit ever lands on `main` directly. No exception for size, urgency, or which agent is
+driving** — Claude, Codex, Cursor and the maintainer are bound identically. A one-character typo fix
+takes a branch and a PR, the same as a milestone. Size was never the thing that made a direct commit
+safe; it only made it feel safe.
+
+```bash
+git switch -c <type>/<short-description>     # feat/ fix/ chore/ docs/ test/ refactor/
+# ... work, with the gates green ...
+git push -u origin HEAD
+gh pr create --fill
+gh pr merge --squash --delete-branch         # merges, deletes the branch here AND on origin
+git fetch --prune                            # drop any other remote-tracking refs already gone
+```
+
+**`gh pr merge --delete-branch` is the whole cleanup step.** It removes the remote branch and the
+local one in a single command, which is why it is written this way rather than as a merge followed
+by two deletes people forget. A branch that outlives its merged PR is not free: it is one more ref
+that looks like live work to the next agent reading `git branch -a`.
+
+**Branch naming:** `<type>/<short-description>`, lowercase, hyphenated — `fix/actor-motivation-drift`,
+`chore/forbid-direct-commits-to-main`. The type prefix matches the commit type.
+
+### What enforces this, and what does not
+
+| Layer | What it actually does |
+|---|---|
+| `.githooks/pre-commit` | refuses a commit made while `main` or `master` is checked out |
+| `.githooks/pre-push` | refuses a push whose **destination** is `main` — including `git push origin HEAD:main` from a feature branch, which a local-name check would wave through |
+| `Protect Main` ruleset | `deletion`, `non_fast_forward`, **and `pull_request`** (see below) |
+
+The hooks live in `.githooks/` and are activated by `core.hooksPath`, set by
+`scripts/setup/install-git-hooks.sh` and run from `session-refresh.sh` on every session.
+`.git/hooks` is **not** versioned, so a hook installed there would protect one clone and silently
+protect nothing on the next one — including every cloud agent VM, which is exactly where an
+unattended agent would commit to main with nothing to stop it.
+
+⚠️ **These are guards, not walls.** `git commit --no-verify` bypasses the hooks, and the ruleset
+carries a repository-role bypass that lets an admin push straight through — which is how two commits
+reached `main` by hand on 2026-09-06, each reporting `Bypassed rule violations`. The guard exists to
+stop the accident and to make the deliberate override *visible*. **A bypass is a thing you report,
+not a thing you quietly use.**
+
+### `main` requires a PR — verified 2026-09-06
+
+The `Protect Main` ruleset gained a `pull_request` rule at some point after the 2026-08-21 check, and
+this file continued to assert it had none. Current state, from
+`gh api repos/KomplexMojo/agent-kernel/rulesets/14943811`:
+
+- rules: `deletion`, `non_fast_forward`, `pull_request`
+- `required_approving_review_count: 0` — a PR is required, **an approval is not**
+- `bypass_actors`: repository role `5` (admin), `bypass_mode: always`
+
+So the PR requirement and the solo-project model are not in tension: open the PR, merge it yourself,
+no reviewer waits on anything. Re-check with the command above before restating any of this — the
+previous version of this claim was carried forward for two weeks after it stopped being true.
+
 ## Review — solo project, self-merge is the normal path
 
 **No human second reviewer exists, and none is coming.** Do not write, plan, or report as though a PR is waiting on one.
 
-- **`main` is not review-gated.** The `Protect Main` ruleset carries `deletion` and `non_fast_forward` only — no `pull_request` rule, no required approving reviews — plus a repository-role bypass. Re-verified 2026-08-21 via `gh api repos/KomplexMojo/agent-kernel/rulesets`.
+- **`main` requires a PR, but no reviewer.** The `Protect Main` ruleset carries `deletion`, `non_fast_forward` and `pull_request` with `required_approving_review_count: 0`, plus a repository-role bypass. Re-verified 2026-09-06 — the earlier note here claimed there was no `pull_request` rule, which had stopped being true. Details and the verification command: *Branching — every change goes through a branch and a PR* above.
 - **There is no CI test job.** `.github/workflows/` holds the `@claude` responder and `claude-code-review.yml`, an automated advisory review that comments on every PR. Advisory: it blocks nothing, and it does not run the suite. **The local gates are the only gates that run.**
 - A PR is still worth opening — it is the reviewable unit and where the reasoning is indexed — but it is a **record, not a gate**. Never block on, or ask the maintainer to arrange, a review.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Claude is the **orchestration, implementation, and documentation engine**. Codex
 
 **The persona model is enforced** (charter → "Persona Model — ENFORCED"): all domain logic lives in one of the seven personas; everything else is glue; external code imports persona controllers only. The Allocator alone owns pricing.
 
-**Which file owns what — neither file restates the other.** This one owns: reporting, session start, code navigation, commands, architecture summary, the enforcement checklist, escalation. `AGENTS.md` owns: the agent roster and tiers, the handoff workflow, per-agent scope, test and benchmark strategy, file placement, naming, the pre-handoff checklist. Change a rule in its owning file only; a rule copied into both will drift and one copy will be wrong.
+**Which file owns what — neither file restates the other.** This one owns: reporting, session start, code navigation, commands, architecture summary, the enforcement checklist, escalation. `AGENTS.md` owns: the agent roster and tiers, the handoff workflow, **the branching and PR policy**, per-agent scope, test and benchmark strategy, file placement, naming, the pre-handoff checklist. Change a rule in its owning file only; a rule copied into both will drift and one copy will be wrong.
 
 > **Model names, not versions.** Both files name model *tiers* (Opus, Sonnet, Haiku, GPT-5), never dated IDs — those churn and go stale while still looking authoritative. Use the latest release in each tier; pick the exact ID with `/model` or the API.
 
@@ -43,7 +43,7 @@ Not optional — a stale vault or an unpatched tool produces wrong structural an
 bash scripts/setup/session-refresh.sh
 ```
 
-It fetches and `git pull --ff-only` only when the branch tracks a remote *and* the tree is clean (never touches uncommitted work, never switches branches), runs `pnpm install --frozen-lockfile`, re-applies the Serena ignored-dirs patch, refreshes `local-codex/CodeContext.md`, and runs `pnpm run test`. Then report its `source` / `tools` / `tests` summary; a non-zero exit means deps or tests need attention **before** anything else. Skip parts only when asked: `--no-pull`, `--no-tools`, `--no-tests`. Same script on cloud agents, where `.cursor/install.sh` has already provisioned the VM at boot.
+It fetches and `git pull --ff-only` only when the branch tracks a remote *and* the tree is clean (never touches uncommitted work, never switches branches), runs `pnpm install --frozen-lockfile`, re-applies the Serena ignored-dirs patch, points `core.hooksPath` at `.githooks` so direct commits to `main` are refused, refreshes `local-codex/CodeContext.md`, and runs `pnpm run test`. Then report its `source` / `tools` / `tests` summary; a non-zero exit means deps or tests need attention **before** anything else. Skip parts only when asked: `--no-pull`, `--no-tools`, `--no-tests`. Same script on cloud agents, where `.cursor/install.sh` has already provisioned the VM at boot.
 
 1. Read `~/vault/plans/active/Plan.md` — the START HERE block is the last-session handoff; `~/vault/index.md` only if it is sparse
 2. `git pull --ff-only` — confirm on HEAD *(script)*
@@ -195,6 +195,8 @@ Run on every diff. **Fix failures — don't just flag them.** The guards in `tes
 **Types** — `pnpm run typecheck` stays at zero (gate: `tsconfig.typecheck.json`, enforced by `tests/architecture/typecheck-gate.test.js`). The gate covers **core-ts and its tests only** — the code genuinely clean under `strict`. Do not widen it casually: the five `_shared/*.mts` modules carry **180 errors** that leak into every scope importing them, so widening is a fix-first project, not a config change. ⚠️ `checkJs` is **off**, so an all-`.js` package reports 0 because there is nothing to check — read the file count the report prints alongside.
 
 **Tests** — failing tests written *before* production code · new behavior covered under `tests/` · anything a benchmark surfaced that a deterministic test could catch is landed as that test, not left to the next run · deterministic behavior uses fixtures · negative cases under `tests/fixtures/artifacts/invalid/` · no test hits live external services · base test file ends with `## TODO: Test Permutations` before Ollama handoff · persona behavior tests live in `tests/personas/<persona>/` named `<persona>-<behavior>.test.*` · label-only persona tests are legacy: replace with a behavior test, then remove — never before.
+
+**Branching** — the change is on a feature branch, never on `main`; it lands through a PR; the branch is deleted locally and on origin when the PR merges. No exception for a one-line fix. `.githooks/` refuses direct commits and pushes mechanically. Full rule and the cleanup command: `AGENTS.md → Branching`.
 
 **Code quality** — every changed line traces to the current milestone spec (no drive-by cleanup) · not over-engineered · assumptions stated before implementation · **clean-up found but not required by the task gets logged as a `gh issue`** — not fixed inline, and not left as a code comment or a plan-doc aside.
 

--- a/scripts/setup/install-git-hooks.sh
+++ b/scripts/setup/install-git-hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Point this clone's git hooks at the repo's own .githooks/ directory.
+#
+# .git/hooks is not versioned, so a hook that lives only there protects exactly one clone and
+# silently protects nothing on the next one — including every cloud agent VM. core.hooksPath moves
+# the hooks into the tree, where they are reviewed, tested, and present for whoever clones next.
+#
+# Idempotent; safe to run on every session. Run by scripts/setup/session-refresh.sh.
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+current="$(git config --local --get core.hooksPath || true)"
+if [ "$current" = ".githooks" ]; then
+  echo "git hooks: already pointed at .githooks"
+  exit 0
+fi
+
+if [ -n "$current" ] && [ "$current" != ".githooks" ]; then
+  echo "git hooks: core.hooksPath was '$current' — repointing to .githooks" >&2
+fi
+
+git config --local core.hooksPath .githooks
+echo "git hooks: core.hooksPath set to .githooks (direct commits and pushes to main are now refused)"

--- a/scripts/setup/session-refresh.sh
+++ b/scripts/setup/session-refresh.sh
@@ -115,6 +115,16 @@ if [ "$RUN_TOOLS" = 1 ]; then
     python3 scripts/setup/patch-serena-ignored-dirs.py || true
   fi
 
+  # Branch guard. .git/hooks is not versioned, so without this every fresh clone and every
+  # cloud agent VM starts with no guard at all — which is precisely when a direct commit to
+  # main happens, because nothing is there to refuse it.
+  if bash scripts/setup/install-git-hooks.sh; then
+    :
+  else
+    echo "git hooks: install FAILED (direct commits to main would not be refused)"
+    fails=$((fails + 1))
+  fi
+
   # Agent context snapshot (local-codex/CodeContext.md + vault mirror). Best
   # effort: it needs no external indexer, so a failure here is not fatal.
   if bash scripts/setup/agent-context.sh >/dev/null 2>&1; then

--- a/tests/architecture/branch-policy.test.js
+++ b/tests/architecture/branch-policy.test.js
@@ -1,0 +1,123 @@
+const assert = require('node:assert/strict');
+const { execFileSync, spawnSync } = require('node:child_process');
+const { readFileSync, existsSync, statSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+
+const ROOT = resolve(__dirname, '../..');
+const HOOKS = join(ROOT, '.githooks');
+const DECIDER = join(HOOKS, 'protected-branch.sh');
+
+const read = (relative) => readFileSync(join(ROOT, relative), 'utf8');
+
+function decide(branch, action = 'commit') {
+  const result = spawnSync('bash', [DECIDER, branch, action], { encoding: 'utf8' });
+  return { refused: result.status !== 0, stderr: result.stderr || '' };
+}
+
+test('the hooks exist and are executable, or git silently ignores them', () => {
+  for (const name of ['pre-commit', 'pre-push', 'protected-branch.sh']) {
+    const path = join(HOOKS, name);
+    assert.ok(existsSync(path), `.githooks/${name} is missing`);
+    assert.ok(statSync(path).mode & 0o111, `.githooks/${name} is not executable`);
+  }
+});
+
+// The rule is "never on main, no matter how small". A guard that only covered some branches, or
+// that let master through on an older clone, would be the same policy with a hole in it.
+test('commits are refused on the protected branches and allowed everywhere else', () => {
+  assert.equal(decide('main').refused, true);
+  assert.equal(decide('master').refused, true);
+  for (const branch of ['feat/x', 'fix/y', 'chore/z', 'docs/w', 'mainline', 'feature/main']) {
+    assert.equal(decide(branch).refused, false, `${branch} should be allowed`);
+  }
+});
+
+test('pushes to a protected branch are refused too', () => {
+  assert.equal(decide('main', 'push').refused, true);
+});
+
+// `git push origin HEAD:main` from a feature branch is a direct write to main. A hook that read the
+// LOCAL branch name would wave it through -- and that is the exact shape that put two commits on
+// main by hand on 2026-09-06.
+test('the pre-push hook checks the destination ref, not the local branch name', () => {
+  const hook = read('.githooks/pre-push');
+  assert.match(hook, /remote_ref/);
+  assert.match(hook, /refs\/heads\/\*/);
+  const result = spawnSync('bash', [join(HOOKS, 'pre-push')], {
+    input: 'refs/heads/feat/x abc123 refs/heads/main def456\n',
+    encoding: 'utf8',
+  });
+  assert.notEqual(result.status, 0, 'pushing a feature branch to main must be refused');
+});
+
+test('a push to a feature branch passes the hook', () => {
+  const result = spawnSync('bash', [join(HOOKS, 'pre-push')], {
+    input: 'refs/heads/feat/x abc123 refs/heads/feat/x def456\n',
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+// A detached HEAD is where rebases, bisects and worktree surgery run. Refusing there would break
+// ordinary git operations while protecting nothing.
+test('a detached HEAD is not treated as a protected branch', () => {
+  assert.equal(decide('').refused, false);
+});
+
+// A refusal that does not say what to do instead gets bypassed rather than obeyed.
+test('the refusal names the way forward, not just the rule', () => {
+  const { stderr } = decide('main');
+  assert.match(stderr, /git switch -c/);
+  assert.match(stderr, /gh pr create/);
+  assert.match(stderr, /--delete-branch/, 'the cleanup step must be part of the instructions');
+  assert.match(stderr, /AGENTS\.md/);
+});
+
+// .git/hooks is not versioned, so hooks are inert until core.hooksPath points into the tree. If
+// that wiring is dropped, every fresh clone and cloud VM silently loses the guard.
+test('the hooks are activated by an installer that session-refresh runs', () => {
+  assert.ok(existsSync(join(ROOT, 'scripts/setup/install-git-hooks.sh')));
+  assert.match(read('scripts/setup/install-git-hooks.sh'), /core\.hooksPath/);
+  assert.match(read('scripts/setup/session-refresh.sh'), /install-git-hooks\.sh/);
+});
+
+// Three harnesses drive this repo. A policy only one of them can see is not the policy.
+test('every harness carries the rule, and AGENTS.md is the one that states it', () => {
+  const agents = read('AGENTS.md');
+  assert.match(agents, /## Branching — every change goes through a branch and a PR/);
+  assert.match(agents, /--delete-branch/, 'AGENTS.md must carry the branch cleanup step');
+
+  // The other two point at it rather than restating it: CLAUDE.md's own rule is that a rule copied
+  // into both files will drift and one copy will be wrong.
+  const claude = read('CLAUDE.md');
+  assert.match(claude, /AGENTS\.md → Branching/);
+  assert.match(claude, /the branching and PR policy/);
+
+  const cursor = read('.cursor/rules/branch-policy.mdc');
+  assert.match(cursor, /alwaysApply: true/, 'the branch rule must bind on every Cursor turn');
+  assert.match(cursor, /AGENTS\.md/);
+});
+
+// The previous claim about this ruleset sat wrong in AGENTS.md for two weeks. Pin the shape of the
+// correction so a future edit cannot quietly restore "there is no pull_request rule".
+test('AGENTS.md records that main requires a PR, with the date it was verified', () => {
+  const agents = read('AGENTS.md');
+  assert.match(agents, /pull_request/);
+  assert.match(agents, /required_approving_review_count.{0,4}0/);
+  assert.match(agents, /2026-09-06/);
+  assert.doesNotMatch(agents, /carries `deletion` and `non_fast_forward` only/);
+});
+
+test('the hooks are honest that a bypass exists', () => {
+  assert.match(read('.githooks/protected-branch.sh'), /--no-verify/);
+  assert.match(read('AGENTS.md'), /guards, not walls/i);
+});
+
+// Asserted statically rather than by running it: git worktrees SHARE .git/config, so invoking the
+// installer from a test would rewrite core.hooksPath for the whole checkout as a side effect.
+test('the installer is idempotent and re-points a stale hooksPath', () => {
+  const script = read('scripts/setup/install-git-hooks.sh');
+  assert.match(script, /already pointed at \.githooks/);
+  assert.match(script, /exit 0/);
+  assert.match(script, /repointing to \.githooks/);
+});


### PR DESCRIPTION
Two commits reached `main` by direct push on 2026-09-06, each reporting `Bypassed rule violations`. Nothing local objected, because nothing local was watching. This makes the rule explicit for every agent and gives it teeth.

## The rule

No commit on `main`, ever — no exception for size, urgency, or which agent is driving. Claude, Codex, Cursor and the maintainer are bound identically. Size was never what made a direct commit safe; it only made it feel safe.

```bash
git switch -c <type>/<short-description>
git push -u origin HEAD
gh pr create --fill
gh pr merge --squash --delete-branch    # merges, deletes the branch here AND on origin
```

## Enforcement

| File | What it does |
|---|---|
| `.githooks/pre-commit` | refuses a commit while `main`/`master` is checked out |
| `.githooks/pre-push` | refuses a push whose **destination** is `main` — including `git push origin HEAD:main` from a feature branch, the exact shape that put those two commits on main |
| `.githooks/protected-branch.sh` | the shared decision, so both hooks agree and a test can call it directly |

`.git/hooks` is not versioned, so hooks installed there protect one clone and silently protect nothing on the next — including every cloud agent VM, which is where an unattended agent would commit to main with nothing to stop it. `core.hooksPath` is set by `scripts/setup/install-git-hooks.sh`, run from `session-refresh.sh` every session.

## Documentation

`AGENTS.md` **owns** the policy; `CLAUDE.md` and a new `alwaysApply` Cursor rule point at it rather than restating it — a rule copied into both files drifts and one copy ends up wrong.

## A stale claim corrected

`AGENTS.md` asserted the Protect Main ruleset carried "`deletion` and `non_fast_forward` only — no `pull_request` rule", verified 2026-08-21. It now carries `pull_request` with `required_approving_review_count: 0` — a PR is required, an approval is not, which is why the direct pushes reported a bypass. Re-verified 2026-09-06 against `gh api repos/KomplexMojo/agent-kernel/rulesets/14943811`. A test pins the correction so the old wording cannot quietly return.

## Honest limits

These are **guards, not walls**. `--no-verify` bypasses the hooks, and the ruleset carries a repository-role (admin) bypass. Both facts are stated in the refusal message and in `AGENTS.md`. The point is to stop the accident and make a deliberate override visible — a bypass is something you report, not something you use quietly to get unblocked.

**To close the remaining hole**, remove the `bypass_actors` entry from the ruleset. That is a repo-governance change I have not made.

## Verification

- **Full suite: 3793 passed / 4037** (242 skipped), **typecheck 0 errors**
- 12 new guards in `tests/architecture/branch-policy.test.js`, all passing
- Live proof in a throwaway repo: commit on `main` refused with no commit created; the same commit on `feat/allowed` succeeded; `--no-verify` bypassed, as documented
- This PR is itself the first use of the policy — branch, push, PR, no bypass message on the push

### The 2 suite failures are environmental, not from this diff

`tests/tools/remote-ollama-benchmark.test.js` reported 2 failures. `config/llm-host.env` is untracked by design (it holds real addresses and the repo is public), so a fresh worktree does not have it and exactly those two tests fail there. Proven both ways:

- all 28 tests in that file pass in the main checkout, which has the file
- copying the file into the worktree turns the same 2 tests green there

Nothing in this diff touches that area — it changes `.githooks/`, `AGENTS.md`, `CLAUDE.md`, a Cursor rule, two setup scripts, and one new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

