### PR TITLE
fix: affinity-summary.json meta determinism (#150) + document dead smt2 surface (#166)

### DIFF
--- a/packages/runtime/src/commands/kernel.js
+++ b/packages/runtime/src/commands/kernel.js
@@ -1211,7 +1211,10 @@ export function createCommandKernel(host = {}) {
       affinitySummary = {
         schema: SCHEMAS.affinitySummary,
         schemaVersion: 1,
-        meta: createMeta({ producedBy: "cli-run", runId }),
+        // #150 — same wall-clock non-determinism #149 fixed for action-log/run-summary/world-state;
+        // confirmed here via a two-run diff (see the fix commit) since no test previously exercised
+        // this artifact at all, wantsAffinitySummary being a rarer flag combination.
+        meta: deterministicRunArtifactMeta("affinitysummary", "cli-run"),
         presetsRef: toRef(affinityPresets),
         loadoutsRef: toRef(affinityLoadouts),
         simConfigRef: toRef(simConfig),

--- a/packages/runtime/src/contracts/artifacts.ts
+++ b/packages/runtime/src/contracts/artifacts.ts
@@ -1698,7 +1698,14 @@ export interface SolverRequestV1 {
 
   /**
    * Problem description to solve. Keep deterministic and fully captured here.
-   * `language: "smt2"` expects a serialized SMT-LIB string.
+   *
+   * `language: "smt2"` is declared intent, not a working route: nothing in this repo produces
+   * a `data` string in SMT-LIB syntax, and nothing consumes `language` to decide how to parse
+   * `data` (see #166). The two live problem stacks (`ConstraintProblemV1` for Allocator/
+   * Configurator, `runtime-decision-v1` for Actor) both go through `language: "custom"` with a
+   * structured `data` object. Using `"smt2"` today would require: an adapter that serializes
+   * `data` to SMT-LIB text, and a solver port implementation that shells out to (or embeds) an
+   * SMT-LIB-speaking solver and parses its output back into `SolverResultV1` -- neither exists.
    */
   problem: {
     language: "smt2" | "custom";

--- a/tests/adapters-cli/ak-affinity-summary.test.js
+++ b/tests/adapters-cli/ak-affinity-summary.test.js
@@ -91,3 +91,30 @@ test("cli run rejects affinity summary without presets or loadouts", (t) => {
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Affinity summary requires/);
 });
+
+// #150 — affinity-summary.json used to stamp meta.id/createdAt via createMeta()'s host wall-clock
+// (Date.now()/Math.random()) instead of the run's seeded clock, the same bug #149 fixed for
+// action-log/run-summary/world-state. Two runs of byte-identical input must produce a
+// byte-identical meta stamp; asserting on the run's own seeded id/timestamp (not a hardcoded
+// literal) keeps this from silently passing if the clock seed itself ever changes.
+test("cli run stamps affinity-summary.json meta from the seeded clock, not the wall clock", (t) => {
+  const runOnce = () => {
+    const workDir = mkdtempSync(join(os.tmpdir(), "agent-kernel-cli-affinity-determinism-"));
+    const outDir = join(workDir, "out");
+    runCli([
+      "run",
+      "--sim-config", SIM_CONFIG,
+      "--initial-state", INITIAL_STATE,
+      "--ticks", "0",
+      "--out-dir", outDir,
+      "--affinity-presets", PRESETS,
+      "--affinity-loadouts", LOADOUTS,
+      "--affinity-summary",
+    ]);
+    return JSON.parse(readFileSync(join(outDir, "affinity-summary.json"), "utf8")).meta;
+  };
+
+  const first = runOnce();
+  const second = runOnce();
+  assert.deepEqual(second, first);
+});


### PR DESCRIPTION
## Summary

Two more self-contained fixes from the open-issue backlog triage, same isolated-worktree approach as [#187](https://github.com/KomplexMojo/agent-kernel/pull/187).

### #150 — affinity-summary.json/deferred-coordination.json wall-clock meta (partial)

Confirmed and fixed the `affinity-summary.json` half. Same bug class #149 fixed for `action-log.json`/`run-summary.json`/`world-state.json`: `meta.id`/`meta.createdAt` stamped from the host wall-clock (`createMeta()`) instead of the run's seeded clock, so two runs of byte-identical input produced byte-identical simulation output but different meta.

Reused the existing `affinity-presets-artifact-v1-basic.json` + `actor-loadouts-artifact-v1-basic.json` fixtures to actually exercise `wantsAffinitySummary` (needs both `--affinity-presets` and `--affinity-loadouts`) via a real `ak run`:

- **Pre-fix**: two runs → `meta.id`/`meta.createdAt` differ
- **Post-fix**: two runs → byte-identical

Routed through the existing `deterministicRunArtifactMeta()` helper and added a regression test.

`deferred-coordination.json`'s identical pattern is **left unconfirmed and unfixed** — it's only written when a run produces a deferred effect, and the only real producer (`ActionKind.RequestExternalFact`) is Allocator-internal with no fixture/scenario in the suite that reaches it through real core-ts. Rather than guess, this follows #149's own precedent of not bundling unconfirmed sites — see the [status comment on #150](https://github.com/KomplexMojo/agent-kernel/issues/150#issuecomment-5621037278).

Also found and filed a **third** site with the identical pattern while investigating this one (`world-state-checkpoints/*.json`'s meta) as [#189](https://github.com/KomplexMojo/agent-kernel/issues/189), rather than bundling it in unverified.

### #166 — dead SMT-LIB surface

`SolverRequestV1.problem.language: "smt2"` has zero producers and zero consumers anywhere in the repo (confirmed by grep) — only `"custom"` is ever actually used, by both live problem stacks (Allocator/Configurator's `ConstraintProblemV1`, Actor's `runtime-decision-v1`). The issue offered two options, "either is fine": remove (needs a `schemaVersion` bump per the charter's never-remove-fields-in-place rule) or document as explicitly unimplemented. Took the documentation route — lower risk, no consumer/fixture changes, and the type stays available to actually implement later.

## Test plan

- [x] `pnpm run test:vitest -- tests/adapters-cli/ak-affinity-summary.test.js` — 3/3 passing (new determinism test included)
- [x] 18 kernel.js-touching test files (131 tests) re-run for regressions — all passing
- [x] `pnpm run typecheck` — zero errors after the `artifacts.ts` doc change

Fixes #150 (partially — see comment for what's still open), Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)