### PR TITLE
test: triage the 10 tests/runtime/ files flagged by #158

### DIFF
--- a/tests/personas/allocator/allocator-design-spend-ledger.test.js
+++ b/tests/personas/allocator/allocator-design-spend-ledger.test.js
@@ -1,14 +1,17 @@
+// #158 — migrated from tests/runtime/design-spend-ledger.test.js: every assertion here is about
+// buildDesignSpendLedger, an Allocator-owned function; Configurator/Director are injected
+// collaborators, exactly as production wires them, not the subject under test.
 const assert = require("node:assert/strict");
 // CR.9 M3: ledgers price raw actor motivations, and the Allocator refuses without the
 // Configurator's vocabulary. Injected here exactly as production injects it.
-const { configuratorNormalizeMotivations } = require("../helpers/configurator-capabilities.js");
+const { configuratorNormalizeMotivations } = require("../../helpers/configurator-capabilities.js");
 // D8 follow-up: a ledger built from CARDS needs the Director's translation, and the
 // Allocator refuses without it. Injected here exactly as production injects it.
-const { directorResolveSummary } = require("../helpers/director-capabilities.js");
+const { directorResolveSummary } = require("../../helpers/director-capabilities.js");
 
 test("buildDesignSpendLedger computes level, actor base, and actor config categories", async () => {
   const { buildDesignSpendLedger } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
 
@@ -62,7 +65,7 @@ test("buildDesignSpendLedger computes level, actor base, and actor config catego
 
 test("buildDesignSpendLedger flags over-budget totals", async () => {
   const { buildDesignSpendLedger } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
 
@@ -81,7 +84,7 @@ test("buildDesignSpendLedger flags over-budget totals", async () => {
 
 test("buildDesignSpendLedger prices actor configuration from price list items", async () => {
   const { buildDesignSpendLedger } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
 
@@ -140,7 +143,7 @@ test("buildDesignSpendLedger prices actor configuration from price list items", 
 
 test("buildDesignSpendLedger treats tokenHint as per-unit and multiplies by count", async () => {
   const { buildDesignSpendLedger } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
 
@@ -202,13 +205,13 @@ test("buildDesignSpendLedger treats tokenHint as per-unit and multiplies by coun
 
 test("buildDesignSpendLedger uses shared room-card layout budget when cardSet is provided", async () => {
   const { buildDesignSpendLedger } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
   // CR.9 M2: the Allocator prices room geometry, it does not derive it — the
   // Configurator's derivation is injected, as production wires it.
   const { createConfiguratorPersona } = await import(
-    "../../packages/runtime/src/personas/configurator/persona.js"
+    "../../../packages/runtime/src/personas/configurator/persona.js"
   );
   const deriveRoomLayout = createConfiguratorPersona({ clock: () => "2026-08-04T00:00:00.000Z" }).deriveRoomLayout;
   const resolveSummary = await directorResolveSummary();
@@ -246,13 +249,13 @@ test("buildDesignSpendLedger uses shared room-card layout budget when cardSet is
 
 test("buildDesignSpendLedger charges rooms layout cost only — no affinity cost", async () => {
   const { buildDesignSpendLedger } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
   // CR.9 M2: the Allocator prices room geometry, it does not derive it — the
   // Configurator's derivation is injected, as production wires it.
   const { createConfiguratorPersona } = await import(
-    "../../packages/runtime/src/personas/configurator/persona.js"
+    "../../../packages/runtime/src/personas/configurator/persona.js"
   );
   const deriveRoomLayout = createConfiguratorPersona({ clock: () => "2026-08-04T00:00:00.000Z" }).deriveRoomLayout;
 
@@ -308,11 +311,11 @@ test("buildDesignSpendLedger charges rooms layout cost only — no affinity cost
 
 test("buildDesignSpendLedger REFUSES to price a card set without the Director's translation", async () => {
   const { buildDesignSpendLedger, AllocatorSummaryResolutionError } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
   const { createConfiguratorPersona } = await import(
-    "../../packages/runtime/src/personas/configurator/persona.js"
+    "../../../packages/runtime/src/personas/configurator/persona.js"
   );
   const deriveRoomLayout = createConfiguratorPersona({ clock: () => "2026-08-04T00:00:00.000Z" }).deriveRoomLayout;
 
@@ -335,7 +338,7 @@ test("buildDesignSpendLedger REFUSES to price a card set without the Director's 
 
 test("buildDesignSpendLedger refuses the `cards` spelling of a card set too", async () => {
   const { buildDesignSpendLedger, AllocatorSummaryResolutionError } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
 
@@ -358,7 +361,7 @@ test("buildDesignSpendLedger refuses the `cards` spelling of a card set too", as
 
 test("buildDesignSpendLedger prices a card-free summary with NO resolveSummary", async () => {
   const { buildDesignSpendLedger } = await import(
-    "../../packages/runtime/src/personas/allocator/spend-proposal.js"
+    "../../../packages/runtime/src/personas/allocator/spend-proposal.js"
   );
   const normalizeMotivations = await configuratorNormalizeMotivations();
 

--- a/tests/personas/moderator/moderator-plan-tick-close.test.js
+++ b/tests/personas/moderator/moderator-plan-tick-close.test.js
@@ -1,0 +1,58 @@
+// #158 — split out of tests/runtime/affinity-field-per-tick.test.js: these two tests call
+// createModeratorPersona().advance() directly and assert on the Moderator's own plan_tick_close
+// decision, with no runtime or core-ts involved — pure Moderator persona behavior (AM.3b). The
+// third test from that file (the field actually following its source actor across real runtime
+// ticks) stays in tests/runtime/ as the integration counterpart; it shares no helper with these.
+
+const assert = require("node:assert/strict");
+
+test("the Moderator decides to close the tick, and says so as data", async () => {
+  const { createModeratorPersona } = await import(
+    "../../../packages/runtime/src/personas/moderator/persona.js"
+  );
+  const { TickPhases } = await import(
+    "../../../packages/runtime/src/personas/_shared/tick-state-machine.mts"
+  );
+  const moderator = createModeratorPersona({ clock: () => "fixed" });
+
+  const plan = moderator.advance({
+    phase: TickPhases.SUMMARIZE,
+    event: "plan_tick_close",
+    payload: {},
+    tick: 1,
+  })?.tickClose;
+
+  assert.ok(plan, "the Moderator must answer plan_tick_close");
+  assert.equal(plan.advanceTick, true);
+  assert.equal(
+    plan.recomputeAffinityField,
+    true,
+    "advancing and recomputing describe the same instant, so they travel together",
+  );
+});
+
+test("a paused Moderator closes nothing — neither the tick nor the field", async () => {
+  const { createModeratorPersona } = await import(
+    "../../../packages/runtime/src/personas/moderator/persona.js"
+  );
+  const { TickPhases } = await import(
+    "../../../packages/runtime/src/personas/_shared/tick-state-machine.mts"
+  );
+  const moderator = createModeratorPersona({ clock: () => "fixed" });
+  moderator.advance({ phase: TickPhases.INIT, event: "start", payload: {}, tick: 0 });
+  moderator.advance({ phase: TickPhases.OBSERVE, event: "pause", payload: {}, tick: 1 });
+
+  const plan = moderator.advance({
+    phase: TickPhases.SUMMARIZE,
+    event: "plan_tick_close",
+    payload: {},
+    tick: 1,
+  })?.tickClose;
+
+  assert.equal(plan.advanceTick, false, "a paused tick must not advance");
+  assert.equal(
+    plan.recomputeAffinityField,
+    false,
+    "and must not publish a field for a tick that never happened",
+  );
+});

--- a/tests/runtime/actor-proposal-replay.test.js
+++ b/tests/runtime/actor-proposal-replay.test.js
@@ -1,3 +1,6 @@
+// #158 triage: stays here (not tests/personas/actor/) — it asserts on how the RUNTIME maps actor
+// proposals to core-ts actions and replays them deterministically, not on the Actor persona's own
+// proposal-generation logic in isolation. Runtime-to-core orchestration, not persona-alone behavior.
 const assert = require("node:assert/strict");
 const { readFileSync } = require("node:fs");
 const { resolve } = require("node:path");

--- a/tests/runtime/affinity-field-per-tick.test.js
+++ b/tests/runtime/affinity-field-per-tick.test.js
@@ -1,6 +1,5 @@
 /**
- * AM.7 / AM.3b — the affinity field follows its source, and the MODERATOR closes
- * the tick (closes F7).
+ * AM.7 — the affinity field follows its source (closes F7).
  *
  * `computeAffinityField()` was called exactly once, during setup
  * (runner/core-setup.mjs). Actors then moved for the rest of the run while their
@@ -8,10 +7,12 @@
  * is decoration, and every consumer of it (tile visuals, the aura bridge, the
  * gameplay renderer) was reading a snapshot of tick 0.
  *
- * The recompute is deliberately NOT a second unconditional glue call. Advancing
- * the tick and recomputing the field describe the same instant, so both are one
- * Moderator decision (`plan_tick_close`), which also closes the AM.3b weakness:
- * before it, glue advanced the tick and the Moderator never said to.
+ * #158 — this is the runtime/core-ts integration counterpart to AM.3b (the
+ * MODERATOR's `plan_tick_close` decision to recompute the field, which used to
+ * live in this same file): that half calls the persona directly with no runtime
+ * involved and moved to tests/personas/moderator/moderator-plan-tick-close.test.js.
+ * This test stays here because it drives a real runtime through real ticks and
+ * reads core-ts state directly — orchestration, not persona-alone behavior.
  */
 "use strict";
 
@@ -137,61 +138,6 @@ test("the affinity field changes across ticks as its source actor moves", async 
     early,
     "the field must follow the actor. Identical fingerprints across a run in which the actor "
       + `moved ${earlyPos} -> ${latePos} mean it is still the setup-time snapshot (F7).`,
-  );
-});
-
-// ---------------------------------------------------------------------------
-// The Moderator owns closing the tick
-// ---------------------------------------------------------------------------
-
-test("the Moderator decides to close the tick, and says so as data", async () => {
-  const { createModeratorPersona } = await import(
-    "../../packages/runtime/src/personas/moderator/persona.js"
-  );
-  const { TickPhases } = await import(
-    "../../packages/runtime/src/personas/_shared/tick-state-machine.mts"
-  );
-  const moderator = createModeratorPersona({ clock: () => "fixed" });
-
-  const plan = moderator.advance({
-    phase: TickPhases.SUMMARIZE,
-    event: "plan_tick_close",
-    payload: {},
-    tick: 1,
-  })?.tickClose;
-
-  assert.ok(plan, "the Moderator must answer plan_tick_close");
-  assert.equal(plan.advanceTick, true);
-  assert.equal(
-    plan.recomputeAffinityField,
-    true,
-    "advancing and recomputing describe the same instant, so they travel together",
-  );
-});
-
-test("a paused Moderator closes nothing — neither the tick nor the field", async () => {
-  const { createModeratorPersona } = await import(
-    "../../packages/runtime/src/personas/moderator/persona.js"
-  );
-  const { TickPhases } = await import(
-    "../../packages/runtime/src/personas/_shared/tick-state-machine.mts"
-  );
-  const moderator = createModeratorPersona({ clock: () => "fixed" });
-  moderator.advance({ phase: TickPhases.INIT, event: "start", payload: {}, tick: 0 });
-  moderator.advance({ phase: TickPhases.OBSERVE, event: "pause", payload: {}, tick: 1 });
-
-  const plan = moderator.advance({
-    phase: TickPhases.SUMMARIZE,
-    event: "plan_tick_close",
-    payload: {},
-    tick: 1,
-  })?.tickClose;
-
-  assert.equal(plan.advanceTick, false, "a paused tick must not advance");
-  assert.equal(
-    plan.recomputeAffinityField,
-    false,
-    "and must not publish a field for a tick that never happened",
   );
 });
 

--- a/tests/runtime/runtime-budget-receipt.test.js
+++ b/tests/runtime/runtime-budget-receipt.test.js
@@ -1,3 +1,6 @@
+// #158 triage: stays here (not tests/personas/allocator/) — it asserts on the RUNTIME's capture
+// of direct/core outcomes and its delegation to a live Allocator, not on Allocator pricing logic
+// in isolation. Runtime-to-Allocator orchestration, not persona-alone behavior.
 const assert = require("node:assert/strict");
 
 const FIXED_CLOCK = () => "2026-09-02T00:00:00.000Z";

--- a/tests/runtime/runtime-moderator-affinity-actions.test.js
+++ b/tests/runtime/runtime-moderator-affinity-actions.test.js
@@ -1,3 +1,6 @@
+// #158 triage: stays here (not tests/personas/moderator/) — it wires a full runtime with a real
+// Moderator persona and asserts on what the RUNTIME applies to core, not on the persona's own
+// decision output in isolation. Runtime-to-core orchestration, not persona-alone behavior.
 const assert = require("node:assert/strict");
 
 test("runtime applies moderator affinity environment actions to core", async () => {


### PR DESCRIPTION
## Summary

Completes the deferred human triage #158 asked for: 10 `tests/runtime/*.test.js` files that import persona `controller`/`state-machine`/`persona` modules, each needing a "migrate to `tests/personas/<persona>/` vs. stay as orchestration/e2e" call.

**5 of 10 were already migrated** between the issue's filing (2026-09-04) and now — `random-movement-ticks`, `complex-motivation-z3`, `actor-motivation-combat`, `spatial-field-aware-actor-decision`, `director-artifact-seeding` all live under `tests/personas/actor/` or `tests/personas/director/` already, with correct `<persona>-*` naming. No action needed.

**Of the remaining 5:**

| File | Disposition | Why |
|---|---|---|
| `design-spend-ledger.test.js` | Migrated → `tests/personas/allocator/allocator-design-spend-ledger.test.js` | Every assertion is about `buildDesignSpendLedger`, an Allocator-owned function; Configurator/Director are injected collaborators exactly as production wires them, not the subject under test. |
| `affinity-field-per-tick.test.js` | **Split** | One test drives a real runtime through real ticks and reads core-ts state directly (orchestration) — stays. The other two call `createModeratorPersona().advance()` directly with zero runtime involvement (pure Moderator behavior) — moved to `tests/personas/moderator/moderator-plan-tick-close.test.js`. They shared no helper functions, so the split was mechanical. |
| `runtime-moderator-affinity-actions.test.js` | Stays, header added | Asserts on what the *runtime* applies to core when wired to a real Moderator — not the persona's own decision in isolation. |
| `runtime-budget-receipt.test.js` | Stays, header added | Asserts on the *runtime's* capture/delegation to a live Allocator — not Allocator pricing logic alone. |
| `actor-proposal-replay.test.js` | Stays, header added | Asserts on how the *runtime* maps actor proposals to core actions — not the Actor persona's proposal generation alone. |

The three "stays" each get a one-line header recording the triage decision and why, per the issue's own suggested disposition — so this is a recorded decision now, not an implicit one a future reader has to re-derive.

## Why split rather than migrate-or-leave

`affinity-field-per-tick.test.js`'s own docstring frames all three of its original tests as one AM.7/AM.3b story, but two of the three call the Moderator persona directly with no runtime object anywhere in scope, while the third needs a full runtime + core-ts to make its assertion at all. Filing it under a single disposition would either misclassify the persona-only tests as orchestration or misclassify the runtime test as Moderator-alone behavior. Verified they share zero helper functions before splitting, so this was a clean cut, not exploratory surgery.

## Test plan

- [x] All 7 touched/created files: `pnpm run test:vitest -- <files>` — 22/22 tests passing
- [x] `tests/architecture/persona-test-layout.test.js` (the layout guard) — 6/6 passing, confirms the new `tests/personas/allocator/` and `tests/personas/moderator/` files satisfy the `<persona>-*` naming rule
- [x] Grepped for stale references to the removed `tests/runtime/design-spend-ledger.test.js` path — none found

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)